### PR TITLE
Fix observer yaw and pitch

### DIFF
--- a/misc/window_management/observer/observer.gd
+++ b/misc/window_management/observer/observer.gd
@@ -36,10 +36,10 @@ func _fixed_process(delta):
 
 	move(dir * 10 * delta)
 	var d = delta * 0.1
-
-	var yaw = get_transform().rotated(Vector3(0, 1, 0), d * r_pos.x)
-	set_transform(yaw)
-
+	
+	#set yaw
+	rotate(Vector3(0, 1, 0), d*r_pos.x)
+	#set pitch
 	var pitch = $Camera.get_transform().rotated(Vector3(1, 0, 0), d * r_pos.y)
 	$Camera.set_transform(pitch)
 
@@ -48,7 +48,7 @@ func _fixed_process(delta):
 
 func _input(event):
 	if (event is InputEventMouseMotion):
-		r_pos = event.relative
+		r_pos = -event.relative
 
 	if (event.is_action("ui_cancel") and event.is_pressed() and !event.is_echo()):
 		if (state == STATE_GRAB):

--- a/misc/window_management/window_management.tscn
+++ b/misc/window_management/window_management.tscn
@@ -15,6 +15,7 @@ subdivide_depth = 0
 [node name="Observer" parent="." instance=ExtResource( 1 )]
 
 transform = Transform( 0.910685, 0, -0.4131, 0, 1, 0, 0.4131, 0, 0.910685, -4.81287, -0.152566, 9.90641 )
+collision/safe_margin = 0.001
 
 [node name="MeshInstance" type="MeshInstance" parent="."]
 


### PR DESCRIPTION
There were two issues with the observer script:

- Pitch and yaw were reversed (fixed by setting `r_pos` to `-event.relative`
- Yaw fixed by using the `rotate` method rather than setting transform directly. Setting the transform directly made the kinematic character rotate relative to the origin of the scene (I think). Would be nice get a clear reason why this wasn't working.