### PR TITLE
Rubegoldberg/engine.cfg: Changed the deprecated 'default_density' to 'default_linear_damp'

### DIFF
--- a/2d/rubegoldberg/engine.cfg
+++ b/2d/rubegoldberg/engine.cfg
@@ -7,4 +7,4 @@ icon="res://icon.png"
 [physics_2d]
 
 default_gravity=500
-default_density=0.01
+default_linear_damp=0.01


### PR DESCRIPTION
![g21_-_rubegoldberg_-_fix_a_warning](https://user-images.githubusercontent.com/20697655/30018564-99dad6a8-9187-11e7-8d2a-5d231011bd0e.png)
