### PR TITLE
Fix compiler errors after pos to position renames

### DIFF
--- a/2d/physics_platformer/player.gd
+++ b/2d/physics_platformer/player.gd
@@ -213,7 +213,7 @@ func _integrate_forces(s):
 	
 	# Apply floor velocity
 	if (found_floor):
-		floor_h_velocity = s.get_contact_collider_velocity_at_pos(floor_index).x
+		floor_h_velocity = s.get_contact_collider_velocity_at_position(floor_index).x
 		lv.x += floor_h_velocity
 	
 	# Finally, apply gravity and set back the linear velocity

--- a/3d/kinematic_character/follow_camera.gd
+++ b/3d/kinematic_character/follow_camera.gd
@@ -35,7 +35,7 @@ func _fixed_process(dt):
 	
 	pos = target + delta
 	
-	look_at_from_pos(pos, target, up)
+	look_at_from_position(pos, target, up)
 	
 	# Turn a little up or down
 	var t = transform

--- a/3d/platformer/follow_camera.gd
+++ b/3d/platformer/follow_camera.gd
@@ -58,7 +58,7 @@ func _fixed_process(dt):
 
 	pos = target + delta
 	
-	look_at_from_pos(pos, target, up)
+	look_at_from_position(pos, target, up)
 	
 	# Turn a little up or down
 	var t = get_transform()


### PR DESCRIPTION
A recent commit to the main Godot engine repo renamed all instances of `pos` with `position` within the Godot API. This PR fixes some compile errors in demo projects that were using the old API names.