### PR TITLE
Remove non-static physics objects to match tutorial beginning.

### DIFF
--- a/misc/instancing/container.tscn
+++ b/misc/instancing/container.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://container.png" type="Texture" id=1]
-[ext_resource path="res://ball.tscn" type="PackedScene" id=2]
 
 [node name="container" type="Node"]
 
@@ -25,45 +24,5 @@ centered = false
 
 build_mode = 0
 polygon = PoolVector2Array( 8.68994, 22.1976, 50.4445, 556.656, 292.621, 501.54, 335.36, 550.855, 510.039, 563.135, 542.137, 526.368, 567.463, 515.822, 612.463, 506.822, 667.291, 495.079, 747.553, 553.575, 793.806, 6.70509, 802.465, 601.097, 4.43558, 596.186 )
-
-[node name="ball 1" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 223.823, 161.773 )
-
-[node name="ball 2" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 388.078, 213.215 )
-
-[node name="ball 3" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 439.52, 104.013 )
-
-[node name="ball 4" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 235.555, 336.858 )
-
-[node name="ball 5" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 509.555, 362.858 )
-
-[node name="ball 6" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 635.555, 147.858 )
-
-[node name="ball 7" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 631.872, 325.88 )
-
-[node name="ball 8" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 529.97, 205.561 )
-
-[node name="ball 9" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 101.489, 167.502 )
-
-[node name="ball 10" parent="." instance=ExtResource( 2 )]
-
-position = Vector2( 143.756, 295.139 )
 
 


### PR DESCRIPTION
In the [tutorial documentation](http://docs.godotengine.org/en/latest/learning/step_by_step/instancing.html), the container scene does not have any spheres in it.