### PR TITLE
GDScript style fixes and other minor corrections

### DIFF
--- a/2d/hdr/beach_cave.gd
+++ b/2d/hdr/beach_cave.gd
@@ -6,12 +6,12 @@ const CAVE_LIMIT = 1000
 
 
 func _input(event):
-	if (event is InputEventMouseMotion and event.button_mask&1):
+	if event is InputEventMouseMotion and event.button_mask&1:
 		var rel_x = event.relative.x
-		var cavepos = get_node("cave").position
+		var cavepos = $cave.position
 		cavepos.x += rel_x
-		if (cavepos.x < -CAVE_LIMIT):
+		if cavepos.x < -CAVE_LIMIT:
 			cavepos.x = -CAVE_LIMIT
-		elif (cavepos.x > 0):
+		elif cavepos.x > 0:
 			cavepos.x = 0
-		get_node("cave").position=cavepos
+		$cave.position = cavepos

--- a/2d/hexagonal_map/troll.gd
+++ b/2d/hexagonal_map/troll.gd
@@ -1,11 +1,7 @@
-
 extends KinematicBody2D
 
-# This is a simple collision demo showing how
-# the kinematic controller works.
-# move() will allow to move the node, and will
-# always move it to a non-colliding spot, 
-# as long as it starts from a non-colliding spot too.
+# This is a demo showing how KinematicBody2D
+# move_and_slide works.
 
 # Member variables
 const MOTION_SPEED = 160 # Pixels/second
@@ -14,16 +10,15 @@ const MOTION_SPEED = 160 # Pixels/second
 func _physics_process(delta):
 	var motion = Vector2()
 	
-	if (Input.is_action_pressed("move_up")):
+	if Input.is_action_pressed("move_up"):
 		motion += Vector2(0, -1)
-	if (Input.is_action_pressed("move_bottom")):
+	if Input.is_action_pressed("move_bottom"):
 		motion += Vector2(0, 1)
-	if (Input.is_action_pressed("move_left")):
+	if Input.is_action_pressed("move_left"):
 		motion += Vector2(-1, 0)
-	if (Input.is_action_pressed("move_right")):
+	if Input.is_action_pressed("move_right"):
 		motion += Vector2(1, 0)
 	
-	motion = motion.normalized()*MOTION_SPEED
+	motion = motion.normalized() * MOTION_SPEED
 
 	move_and_slide(motion)
-	

--- a/2d/isometric/troll.gd
+++ b/2d/isometric/troll.gd
@@ -1,29 +1,24 @@
-
 extends KinematicBody2D
 
-# This is a simple collision demo showing how
-# the kinematic controller works.
-# move() will allow to move the node, and will
-# always move it to a non-colliding spot, 
-# as long as it starts from a non-colliding spot too.
+# This is a demo showing how KinematicBody2D
+# move_and_slide works.
 
 # Member variables
-const MOTION_SPEED = 160 # Pixels/seconds
+const MOTION_SPEED = 160 # Pixels/second
 
 
 func _physics_process(delta):
 	var motion = Vector2()
 	
-	if (Input.is_action_pressed("move_up")):
+	if Input.is_action_pressed("move_up"):
 		motion += Vector2(0, -1)
-	if (Input.is_action_pressed("move_bottom")):
+	if Input.is_action_pressed("move_bottom"):
 		motion += Vector2(0, 1)
-	if (Input.is_action_pressed("move_left")):
+	if Input.is_action_pressed("move_left"):
 		motion += Vector2(-1, 0)
-	if (Input.is_action_pressed("move_right")):
+	if Input.is_action_pressed("move_right"):
 		motion += Vector2(1, 0)
 	
-	motion = motion.normalized()*MOTION_SPEED
-		# Make character slide nicely through the world
-	move_and_slide( motion )
+	motion = motion.normalized() * MOTION_SPEED
 
+	move_and_slide(motion)

--- a/2d/kinematic_character/colworld.gd
+++ b/2d/kinematic_character/colworld.gd
@@ -1,8 +1,7 @@
-
 extends Node2D
 
 
 func _on_princess_body_enter(body):
 	# The name of this editor-generated callback is unfortunate
-	if (body.get_name() == "player"):
-		get_node("youwin").show()
+	if body.get_name() == "player":
+		$youwin.show()

--- a/2d/kinematic_character/player.gd
+++ b/2d/kinematic_character/player.gd
@@ -1,14 +1,9 @@
-
 extends KinematicBody2D
 
-# This is a simple collision demo showing how
-# the kinematic controller works.
-# move() will allow to move the node, and will
-# always move it to a non-colliding spot,
-# as long as it starts from a non-colliding spot too.
+# This demo shows how to build a kinematic controller.
 
 # Member variables
-const GRAVITY = 500.0 # Pixels/second
+const GRAVITY = 500.0 # pixels/second/second
 
 # Angle in degrees towards either side that the player can consider "floor"
 const FLOOR_ANGLE_TOLERANCE = 40
@@ -19,8 +14,8 @@ const STOP_FORCE = 1300
 const JUMP_SPEED = 200
 const JUMP_MAX_AIRBORNE_TIME = 0.2
 
-const SLIDE_STOP_VELOCITY = 1.0 # One pixel per second
-const SLIDE_STOP_MIN_TRAVEL = 1.0 # One pixel
+const SLIDE_STOP_VELOCITY = 1.0 # one pixel/second
+const SLIDE_STOP_MIN_TRAVEL = 1.0 # one pixel
 
 var velocity = Vector2()
 var on_air_time = 100
@@ -39,38 +34,38 @@ func _physics_process(delta):
 	
 	var stop = true
 	
-	if (walk_left):
-		if (velocity.x <= WALK_MIN_SPEED and velocity.x > -WALK_MAX_SPEED):
+	if walk_left:
+		if velocity.x <= WALK_MIN_SPEED and velocity.x > -WALK_MAX_SPEED:
 			force.x -= WALK_FORCE
 			stop = false
-	elif (walk_right):
-		if (velocity.x >= -WALK_MIN_SPEED and velocity.x < WALK_MAX_SPEED):
+	elif walk_right:
+		if velocity.x >= -WALK_MIN_SPEED and velocity.x < WALK_MAX_SPEED:
 			force.x += WALK_FORCE
 			stop = false
 	
-	if (stop):
+	if stop:
 		var vsign = sign(velocity.x)
 		var vlen = abs(velocity.x)
 		
-		vlen -= STOP_FORCE*delta
-		if (vlen < 0):
+		vlen -= STOP_FORCE * delta
+		if vlen < 0:
 			vlen = 0
 		
-		velocity.x = vlen*vsign
+		velocity.x = vlen * vsign
 	
 	# Integrate forces to velocity
-	velocity += force*delta	
+	velocity += force * delta	
 	# Integrate velocity into motion and move
-	velocity = move_and_slide(velocity,Vector2(0,-1))
+	velocity = move_and_slide(velocity, Vector2(0, -1))
 	
-	if (is_on_floor()):
-		on_air_time=0
+	if is_on_floor():
+		on_air_time = 0
 		
-	if (jumping and velocity.y > 0):
+	if jumping and velocity.y > 0:
 		# If falling, no longer jumping
 		jumping = false
 	
-	if (on_air_time < JUMP_MAX_AIRBORNE_TIME and jump and not prev_jump_pressed and not jumping):
+	if on_air_time < JUMP_MAX_AIRBORNE_TIME and jump and not prev_jump_pressed and not jumping:
 		# Jump must also be allowed to happen if the character left the floor a little bit ago.
 		# Makes controls more snappy.
 		velocity.y = -JUMP_SPEED

--- a/2d/kinematic_collision/player.gd
+++ b/2d/kinematic_collision/player.gd
@@ -1,11 +1,7 @@
-
 extends KinematicBody2D
 
-# This is a simple collision demo showing how
-# the kinematic controller works.
-# move() will allow to move the node, and will
-# always move it to a non-colliding spot, 
-# as long as it starts from a non-colliding spot too.
+# This is a demo showing how KinematicBody2D
+# move_and_slide works.
 
 # Member variables
 const MOTION_SPEED = 160 # Pixels/second
@@ -14,14 +10,15 @@ const MOTION_SPEED = 160 # Pixels/second
 func _physics_process(delta):
 	var motion = Vector2()
 	
-	if (Input.is_action_pressed("move_up")):
+	if Input.is_action_pressed("move_up"):
 		motion += Vector2(0, -1)
-	if (Input.is_action_pressed("move_bottom")):
+	if Input.is_action_pressed("move_bottom"):
 		motion += Vector2(0, 1)
-	if (Input.is_action_pressed("move_left")):
+	if Input.is_action_pressed("move_left"):
 		motion += Vector2(-1, 0)
-	if (Input.is_action_pressed("move_right")):
+	if Input.is_action_pressed("move_right"):
 		motion += Vector2(1, 0)
 	
-	motion = motion.normalized()*MOTION_SPEED
+	motion = motion.normalized() * MOTION_SPEED
+
 	move_and_slide(motion)

--- a/2d/navigation/navigation.gd
+++ b/2d/navigation/navigation.gd
@@ -1,4 +1,3 @@
-
 extends Navigation2D
 
 # Member variables
@@ -10,13 +9,13 @@ var path = []
 
 
 func _process(delta):
-	if (path.size() > 1):
-		var to_walk = delta*SPEED
-		while(to_walk > 0 and path.size() >= 2):
+	if path.size() > 1:
+		var to_walk = delta * SPEED
+		while to_walk > 0 and path.size() >= 2:
 			var pfrom = path[path.size() - 1]
 			var pto = path[path.size() - 2]
 			var d = pfrom.distance_to(pto)
-			if (d <= to_walk):
+			if d <= to_walk:
 				path.remove(path.size() - 1)
 				to_walk -= d
 			else:
@@ -24,9 +23,9 @@ func _process(delta):
 				to_walk = 0
 		
 		var atpos = path[path.size() - 1]
-		get_node("agent").position=atpos
+		$agent.position = atpos
 		
-		if (path.size() < 2):
+		if path.size() < 2:
 			path = []
 			set_process(false)
 	else:
@@ -35,16 +34,15 @@ func _process(delta):
 
 func _update_path():
 	var p = get_simple_path(begin, end, true)
-	path = Array(p) # Vector2array too complex to use, convert to regular array
+	path = Array(p) # PoolVector2Array too complex to use, convert to regular array
 	path.invert()
 	
 	set_process(true)
 
 
 func _input(event):
-	if (event is InputEventMouseButton and event.pressed and event.button_index == 1):
-		begin = get_node("agent").position
+	if event is InputEventMouseButton and event.pressed and event.button_index == 1:
+		begin = $agent.position
 		# Mouse to local navigation coordinates
 		end = event.position - position
 		_update_path()
-

--- a/2d/physics_platformer/bullet.gd
+++ b/2d/physics_platformer/bullet.gd
@@ -1,4 +1,3 @@
-
 extends RigidBody2D
 
 # Member variables
@@ -6,11 +5,11 @@ var disabled = false
 
 
 func disable():
-	if (disabled):
+	if disabled:
 		return
-	get_node("anim").play("shutdown")
+	$anim.play("shutdown")
 	disabled = true
 
 
 func _ready():
-	get_node("Timer").start()
+	$Timer.start()

--- a/2d/physics_platformer/coin.gd
+++ b/2d/physics_platformer/coin.gd
@@ -1,4 +1,3 @@
-
 extends Area2D
 
 # Member variables
@@ -6,8 +5,8 @@ var taken = false
 
 
 func _on_body_enter( body ):
-	if (not taken and body is preload("res://player.gd")):
-		get_node("anim").play("taken")
+	if not taken and body is preload("res://player.gd"):
+		$anim.play("taken")
 		taken = true
 
 

--- a/2d/physics_platformer/enemy.gd
+++ b/2d/physics_platformer/enemy.gd
@@ -1,4 +1,3 @@
-
 extends RigidBody2D
 
 # Member variables
@@ -10,8 +9,8 @@ var state = STATE_WALKING
 var direction = -1
 var anim = ""
 
-onready var rc_left = get_node("raycast_left")
-onready var rc_right = get_node("raycast_right")
+onready var rc_left = $raycast_left
+onready var rc_right = $raycast_right
 
 var WALK_SPEED = 50
 
@@ -24,22 +23,22 @@ func _die():
 
 func _pre_explode():
 	#make sure nothing collides against this
-	get_node("shape1").queue_free()
-	get_node("shape2").queue_free()
-	get_node("shape3").queue_free()
+	$shape1.queue_free()
+	$shape2.queue_free()
+	$shape3.queue_free()
 	
 	# Stay there
-	set_mode(MODE_STATIC)
-	get_node("sound_explode").play()
+	mode = MODE_STATIC
+	$sound_explode.play()
 
 
 func _integrate_forces(s):
 	var lv = s.get_linear_velocity()
 	var new_anim = anim
 
-	if (state == STATE_DYING):
+	if state == STATE_DYING:
 		new_anim = "explode"
-	elif (state == STATE_WALKING):
+	elif state == STATE_WALKING:
 		new_anim = "walk"
 		
 		var wall_side = 0.0
@@ -48,38 +47,36 @@ func _integrate_forces(s):
 			var cc = s.get_contact_collider_object(i)
 			var dp = s.get_contact_local_normal(i)
 			
-			if (cc):
-				if (cc is bullet_class and not cc.disabled):
-					set_mode(MODE_RIGID)
+			if cc:
+				if cc is bullet_class and not cc.disabled:
+					mode = MODE_RIGID
 					state = STATE_DYING
-					#lv = s.get_contact_local_normal(i)*400
-					s.set_angular_velocity(sign(dp.x)*33.0)
+					#lv = s.get_contact_local_normal(i) * 400
+					s.set_angular_velocity(sign(dp.x) * 33.0)
 					set_friction(1)
 					cc.disable()
-					get_node("sound_hit").play()
+					$sound_hit.play()
 					break
 			
-			if (dp.x > 0.9):
+			if dp.x > 0.9:
 				wall_side = 1.0
-			elif (dp.x < -0.9):
+			elif dp.x < -0.9:
 				wall_side = -1.0
 		
-		if (wall_side != 0 and wall_side != direction):
+		if wall_side != 0 and wall_side != direction:
 			direction = -direction
-			get_node("sprite").scale.x=-direction
-		if (direction < 0 and not rc_left.is_colliding() and rc_right.is_colliding()):
+			$sprite.scale.x = -direction
+		if direction < 0 and not rc_left.is_colliding() and rc_right.is_colliding():
 			direction = -direction
-			get_node("sprite").scale.x=-direction
-		elif (direction > 0 and not rc_right.is_colliding() and rc_left.is_colliding()):
+			$sprite.scale.x = -direction
+		elif direction > 0 and not rc_right.is_colliding() and rc_left.is_colliding():
 			direction = -direction
-			get_node("sprite").scale.x=-direction
+			$sprite.scale.x = -direction
 		
-		lv.x = direction*WALK_SPEED
+		lv.x = direction * WALK_SPEED
 	
-	if(anim != new_anim):
+	if anim != new_anim:
 		anim = new_anim
-		get_node("anim").play(anim)
+		$anim.play(anim)
 	
 	s.set_linear_velocity(lv)
-
-

--- a/2d/physics_platformer/moving_platform.gd
+++ b/2d/physics_platformer/moving_platform.gd
@@ -1,4 +1,3 @@
-
 extends Node2D
 
 # Member variables
@@ -8,13 +7,9 @@ var accum = 0.0
 
 
 func _physics_process(delta):
-	accum += delta*(1.0/cycle)*PI*2.0
-	accum = fmod(accum, PI*2.0)
+	accum += delta * (1.0 / cycle) * PI * 2.0
+	accum = fmod(accum, PI * 2.0)
 	var d = sin(accum)
 	var xf = Transform2D()
-	xf[2]= motion*d 
-	get_node("platform").transform=xf
-
-
-func _ready():
-	set_physics_process(true)
+	xf[2]= motion * d 
+	$platform.transform = xf

--- a/2d/physics_platformer/player.gd
+++ b/2d/physics_platformer/player.gd
@@ -1,4 +1,3 @@
-
 extends RigidBody2D
 
 # Character Demo, written by Juan Linietsky.
@@ -71,7 +70,7 @@ func _integrate_forces(s):
 		var e = enemy.instance()
 		var p = position
 		p.y = p.y - 100
-		e.position=p
+		e.position = p
 		get_parent().add_child(e)
 	
 	# Deapply prev floor velocity
@@ -84,35 +83,35 @@ func _integrate_forces(s):
 	
 	for x in range(s.get_contact_count()):
 		var ci = s.get_contact_local_normal(x)
-		if (ci.dot(Vector2(0, -1)) > 0.6):
+		if ci.dot(Vector2(0, -1)) > 0.6:
 			found_floor = true
 			floor_index = x
 	
-	# A good idea when impementing characters of all kinds,
-	# compensates for physics imprecission, as well as human reaction delay.
-	if (shoot and not shooting):
+	# A good idea when implementing characters of all kinds,
+	# compensates for physics imprecision, as well as human reaction delay.
+	if shoot and not shooting:
 		shoot_time = 0
 		var bi = bullet.instance()
 		var ss
-		if (siding_left):
+		if siding_left:
 			ss = -1.0
 		else:
 			ss = 1.0
-		var pos = position + get_node("bullet_shoot").position*Vector2(ss, 1.0)
+		var pos = position + $bullet_shoot.position * Vector2(ss, 1.0)
 		
-		bi.position=pos
+		bi.position = pos
 		get_parent().add_child(bi)
 		
-		bi.linear_velocity=Vector2(800.0*ss, -80)
+		bi.linear_velocity = Vector2(800.0 * ss, -80)
 		
-		get_node("sprite/smoke").restart()
-		get_node("sound_shoot").play()
+		$sprite/smoke.restart()
+		$sound_shoot.play()
 		
 		add_collision_exception_with(bi) # Make bullet and this not collide
 	else:
 		shoot_time += step
 	
-	if (found_floor):
+	if found_floor:
 		airborne_time = 0.0
 	else:
 		airborne_time += step # Time it spent in the air
@@ -120,104 +119,102 @@ func _integrate_forces(s):
 	var on_floor = airborne_time < MAX_FLOOR_AIRBORNE_TIME
 
 	# Process jump
-	if (jumping):
-		if (lv.y > 0):
+	if jumping:
+		if lv.y > 0:
 			# Set off the jumping flag if going down
 			jumping = false
-		elif (not jump):
+		elif not jump:
 			stopping_jump = true
 		
-		if (stopping_jump):
-			lv.y += STOP_JUMP_FORCE*step
+		if stopping_jump:
+			lv.y += STOP_JUMP_FORCE * step
 	
-	if (on_floor):
+	if on_floor:
 		# Process logic when character is on floor
-		if (move_left and not move_right):
-			if (lv.x > -WALK_MAX_VELOCITY):
-				lv.x -= WALK_ACCEL*step
-		elif (move_right and not move_left):
-			if (lv.x < WALK_MAX_VELOCITY):
-				lv.x += WALK_ACCEL*step
+		if move_left and not move_right:
+			if lv.x > -WALK_MAX_VELOCITY:
+				lv.x -= WALK_ACCEL * step
+		elif move_right and not move_left:
+			if lv.x < WALK_MAX_VELOCITY:
+				lv.x += WALK_ACCEL * step
 		else:
 			var xv = abs(lv.x)
-			xv -= WALK_DEACCEL*step
-			if (xv < 0):
+			xv -= WALK_DEACCEL * step
+			if xv < 0:
 				xv = 0
-			lv.x = sign(lv.x)*xv
+			lv.x = sign(lv.x) * xv
 		
 		# Check jump
-		if (not jumping and jump):
+		if not jumping and jump:
 			lv.y = -JUMP_VELOCITY
 			jumping = true
 			stopping_jump = false
-			get_node("sound_jump").play()
+			$sound_jump.play()
 		
 		# Check siding
-		if (lv.x < 0 and move_left):
+		if lv.x < 0 and move_left:
 			new_siding_left = true
-		elif (lv.x > 0 and move_right):
+		elif lv.x > 0 and move_right:
 			new_siding_left = false
-		if (jumping):
+		if jumping:
 			new_anim = "jumping"
-		elif (abs(lv.x) < 0.1):
-			if (shoot_time < MAX_SHOOT_POSE_TIME):
+		elif abs(lv.x) < 0.1:
+			if shoot_time < MAX_SHOOT_POSE_TIME:
 				new_anim = "idle_weapon"
 			else:
 				new_anim = "idle"
 		else:
-			if (shoot_time < MAX_SHOOT_POSE_TIME):
+			if shoot_time < MAX_SHOOT_POSE_TIME:
 				new_anim = "run_weapon"
 			else:
 				new_anim = "run"
 	else:
 		# Process logic when the character is in the air
-		if (move_left and not move_right):
-			if (lv.x > -WALK_MAX_VELOCITY):
-				lv.x -= AIR_ACCEL*step
-		elif (move_right and not move_left):
-			if (lv.x < WALK_MAX_VELOCITY):
-				lv.x += AIR_ACCEL*step
+		if move_left and not move_right:
+			if lv.x > -WALK_MAX_VELOCITY:
+				lv.x -= AIR_ACCEL * step
+		elif move_right and not move_left:
+			if lv.x < WALK_MAX_VELOCITY:
+				lv.x += AIR_ACCEL * step
 		else:
 			var xv = abs(lv.x)
-			xv -= AIR_DEACCEL*step
-			if (xv < 0):
+			xv -= AIR_DEACCEL * step
+			if xv < 0:
 				xv = 0
-			lv.x = sign(lv.x)*xv
+			lv.x = sign(lv.x) * xv
 		
-		if (lv.y < 0):
-			if (shoot_time < MAX_SHOOT_POSE_TIME):
+		if lv.y < 0:
+			if shoot_time < MAX_SHOOT_POSE_TIME:
 				new_anim = "jumping_weapon"
 			else:
 				new_anim = "jumping"
 		else:
-			if (shoot_time < MAX_SHOOT_POSE_TIME):
+			if shoot_time < MAX_SHOOT_POSE_TIME:
 				new_anim = "falling_weapon"
 			else:
 				new_anim = "falling"
 	
 	# Update siding
-	if (new_siding_left != siding_left):
-		if (new_siding_left):
-			get_node("sprite").scale.x=-1
+	if new_siding_left != siding_left:
+		if new_siding_left:
+			$sprite.scale.x = -1
 		else:
-			get_node("sprite").scale.x=1
+			$sprite.scale.x = 1
 		
 		siding_left = new_siding_left
 	
 	# Change animation
-	if (new_anim != anim):
+	if new_anim != anim:
 		anim = new_anim
-		get_node("anim").play(anim)
+		$anim.play(anim)
 	
 	shooting = shoot
 	
 	# Apply floor velocity
-	if (found_floor):
+	if found_floor:
 		floor_h_velocity = s.get_contact_collider_velocity_at_position(floor_index).x
 		lv.x += floor_h_velocity
 	
 	# Finally, apply gravity and set back the linear velocity
-	lv += s.get_total_gravity()*step
+	lv += s.get_total_gravity() * step
 	s.set_linear_velocity(lv)
-
-

--- a/2d/platformer/bullet.gd
+++ b/2d/platformer/bullet.gd
@@ -1,9 +1,8 @@
-
 extends RigidBody2D
 
 func _on_bullet_body_enter( body ):
-	if (body.has_method("hit_by_bullet")):
+	if body.has_method("hit_by_bullet"):
 		body.call("hit_by_bullet")
 
 func _on_Timer_timeout():
-	get_node("anim").play("shutdown")
+	$anim.play("shutdown")

--- a/2d/platformer/coin.gd
+++ b/2d/platformer/coin.gd
@@ -1,11 +1,8 @@
-
 extends Area2D
 
 var taken=false
 
 func _on_coin_body_enter( body ):
-
-	if (not taken and body is preload("res://player.gd")):
-		get_node("anim").play("taken")
-		taken=true
-
+	if not taken and body is preload("res://player.gd"):
+		$anim.play("taken")
+		taken = true

--- a/2d/platformer/enemy.gd
+++ b/2d/platformer/enemy.gd
@@ -1,9 +1,8 @@
-
 extends KinematicBody2D
 
 
-const GRAVITY_VEC = Vector2(0,900)
-const FLOOR_NORMAL = Vector2(0,-1)
+const GRAVITY_VEC = Vector2(0, 900)
+const FLOOR_NORMAL = Vector2(0, -1)
 
 const WALK_SPEED = 70
 const STATE_WALKING = 0
@@ -15,45 +14,36 @@ var anim=""
 
 var state = STATE_WALKING
 
-onready var detect_floor_left = get_node("detect_floor_left")
-onready var detect_wall_left = get_node("detect_wall_left")
-onready var detect_floor_right = get_node("detect_floor_right")
-onready var detect_wall_right = get_node("detect_wall_right")
-onready var sprite = get_node("sprite")
+onready var detect_floor_left = $detect_floor_left
+onready var detect_wall_left = $detect_wall_left
+onready var detect_floor_right = $detect_floor_right
+onready var detect_wall_right = $detect_wall_right
+onready var sprite = $sprite
 
 func _physics_process(delta):
+	var new_anim = "idle"
 
-	var new_anim="idle"
-
-	if (state==STATE_WALKING):
-
-		linear_velocity+= GRAVITY_VEC*delta
+	if state==STATE_WALKING:
+		linear_velocity += GRAVITY_VEC * delta
 		linear_velocity.x = direction * WALK_SPEED
-		linear_velocity = move_and_slide( linear_velocity, FLOOR_NORMAL )
+		linear_velocity = move_and_slide(linear_velocity, FLOOR_NORMAL)
 
-		if (not detect_floor_left.is_colliding() or detect_wall_left.is_colliding()):
-			direction=1.0
+		if not detect_floor_left.is_colliding() or detect_wall_left.is_colliding():
+			direction = 1.0
 
-		if (not detect_floor_right.is_colliding() or detect_wall_right.is_colliding()):
-			direction=-1.0
+		if not detect_floor_right.is_colliding() or detect_wall_right.is_colliding():
+			direction = -1.0
 
-		sprite.set_scale( Vector2(direction,1.0) )
-
-		new_anim="walk"
+		sprite.scale = Vector2(direction, 1.0)
+		new_anim = "walk"
 	else:
-		new_anim="explode"
+		new_anim = "explode"
 
 
-	if (anim!=new_anim):
-		anim=new_anim
-		get_node("anim").play(anim)
-
+	if anim != new_anim:
+		anim = new_anim
+		$anim.play(anim)
 
 
 func hit_by_bullet():
-	state=STATE_KILLED
-
-func _ready():
-	set_physics_process(true)
-
-
+	state = STATE_KILLED

--- a/2d/platformer/moving_platform.gd
+++ b/2d/platformer/moving_platform.gd
@@ -1,4 +1,3 @@
-
 extends Node2D
 
 # Member variables
@@ -8,13 +7,9 @@ var accum = 0.0
 
 
 func _physics_process(delta):
-	accum += delta*(1.0/cycle)*PI*2.0
-	accum = fmod(accum, PI*2.0)
+	accum += delta * (1.0 / cycle) * PI * 2.0
+	accum = fmod(accum, PI * 2.0)
 	var d = sin(accum)
 	var xf = Transform2D()
-	xf[2]= motion*d
-	get_node("platform").transform=xf
-
-
-func _ready():
-	set_physics_process(true)
+	xf[2]= motion * d
+	$platform.transform = xf

--- a/2d/platformer/player.gd
+++ b/2d/platformer/player.gd
@@ -1,8 +1,7 @@
-
 extends KinematicBody2D
 
-const GRAVITY_VEC = Vector2(0,900)
-const FLOOR_NORMAL = Vector2(0,-1)
+const GRAVITY_VEC = Vector2(0, 900)
+const FLOOR_NORMAL = Vector2(0, -1)
 const SLOPE_SLIDE_STOP = 25.0
 const MIN_ONAIR_TIME = 0.1
 const WALK_SPEED = 250 # pixels/sec
@@ -19,25 +18,23 @@ var shoot_time=99999 #time since last shot
 var anim=""
 
 #cache the sprite here for fast access (we will set scale to flip it often)
-onready var sprite = get_node("sprite")
+onready var sprite = $sprite
 
 func _physics_process(delta):
-
 	#increment counters
 
-	onair_time+=delta
-	shoot_time+=delta
-
+	onair_time += delta
+	shoot_time += delta
 
 	### MOVEMENT ###
 
 	# Apply Gravity
 	linear_vel += delta * GRAVITY_VEC
 	# Move and Slide
-	linear_vel = move_and_slide( linear_vel, FLOOR_NORMAL, SLOPE_SLIDE_STOP )
+	linear_vel = move_and_slide(linear_vel, FLOOR_NORMAL, SLOPE_SLIDE_STOP)
 	# Detect Floor
-	if (is_on_floor()):
-		onair_time=0
+	if is_on_floor():
+		onair_time = 0
 
 	on_floor = onair_time < MIN_ONAIR_TIME
 
@@ -45,67 +42,58 @@ func _physics_process(delta):
 
 	# Horizontal Movement
 	var target_speed = 0
-	if (Input.is_action_pressed("move_left")):
+	if Input.is_action_pressed("move_left"):
 		target_speed += -1
-	if (Input.is_action_pressed("move_right")):
+	if Input.is_action_pressed("move_right"):
 		target_speed +=  1
 
 	target_speed *= WALK_SPEED
-	linear_vel.x = lerp( linear_vel.x, target_speed, 0.1 )
+	linear_vel.x = lerp(linear_vel.x, target_speed, 0.1)
 
 	# Jumping
-	if (on_floor and Input.is_action_just_pressed("jump")):
-		linear_vel.y=-JUMP_SPEED
-		get_node("sound_jump").play()
+	if on_floor and Input.is_action_just_pressed("jump"):
+		linear_vel.y = -JUMP_SPEED
+		$sound_jump.play()
 
 	# Shooting
-
-	if (Input.is_action_just_pressed("shoot")):
-
+	if Input.is_action_just_pressed("shoot"):
 		var bullet = preload("res://bullet.tscn").instance()
-		bullet.position = get_node("sprite/bullet_shoot").global_position #use node for shoot position
-		bullet.linear_velocity = Vector2( sprite.scale.x * BULLET_VELOCITY,0 )
+		bullet.position = $sprite/bullet_shoot.global_position #use node for shoot position
+		bullet.linear_velocity = Vector2(sprite.scale.x * BULLET_VELOCITY, 0)
 		bullet.add_collision_exception_with(self) # don't want player to collide with bullet
-		get_parent().add_child( bullet ) #don't want bullet to move with me, so add it as child of parent
-		get_node("sound_shoot").play()
-		shoot_time=0
-
+		get_parent().add_child(bullet) #don't want bullet to move with me, so add it as child of parent
+		$sound_shoot.play()
+		shoot_time = 0
 
 	### ANIMATION ###
 
-	var new_anim="idle"
+	var new_anim = "idle"
 
-	if (on_floor):
-		if (linear_vel.x < -SIDING_CHANGE_SPEED):
+	if on_floor:
+		if linear_vel.x < -SIDING_CHANGE_SPEED:
 			sprite.scale.x = -1
-			new_anim="run"
+			new_anim = "run"
 
-		if (linear_vel.x > SIDING_CHANGE_SPEED):
+		if linear_vel.x > SIDING_CHANGE_SPEED:
 			sprite.scale.x = 1
-			new_anim="run"
-
+			new_anim = "run"
 	else:
 		# We want the character to immediately change facing side when the player
 		# tries to change direction, during air control.
 		# This allows for example the player to shoot quickly left then right.
-		if (Input.is_action_pressed("move_left") and not Input.is_action_pressed("move_right")):
+		if Input.is_action_pressed("move_left") and not Input.is_action_pressed("move_right"):
 			sprite.scale.x = -1
-		if (Input.is_action_pressed("move_right") and not Input.is_action_pressed("move_left")):
+		if Input.is_action_pressed("move_right") and not Input.is_action_pressed("move_left"):
 			sprite.scale.x = 1
 
-		if (linear_vel.y < 0 ):
-			new_anim="jumping"
+		if linear_vel.y < 0:
+			new_anim = "jumping"
 		else:
-			new_anim="falling"
+			new_anim = "falling"
 
-	if (shoot_time < SHOOT_TIME_SHOW_WEAPON):
-		new_anim+="_weapon"
+	if shoot_time < SHOOT_TIME_SHOW_WEAPON:
+		new_anim += "_weapon"
 
-	if (new_anim!=anim):
-		anim=new_anim
-		get_node("anim").play(anim)
-
-
-func _ready():
-	set_physics_process(true)
-
+	if new_anim != anim:
+		anim = new_anim
+		$anim.play(anim)

--- a/2d/pong/ball.gd
+++ b/2d/pong/ball.gd
@@ -1,15 +1,15 @@
 extends Area2D
 
 const BALL_SPEED = 100
-var direction = Vector2(-1,0)
+var direction = Vector2(-1, 0)
 var speed = BALL_SPEED
 
-onready var initial_pos = get_position()
+onready var initial_pos = self.position
 
 func reset():
 	position = initial_pos
 	speed = BALL_SPEED
-	direction = Vector2(-1,0)
+	direction = Vector2(-1, 0)
 
 func _process(delta):
 	position += direction * speed * delta

--- a/2d/pong/ceiling_floor.gd
+++ b/2d/pong/ceiling_floor.gd
@@ -3,5 +3,5 @@ extends Area2D
 export var y_direction = 1
 
 func _on_area_entered( area ):
-	if (area.get_name()=="ball"):
+	if area.get_name() == "ball":
 		area.direction.y = y_direction

--- a/2d/pong/paddle.gd
+++ b/2d/pong/paddle.gd
@@ -1,20 +1,19 @@
 extends Area2D
-export var ball_dir=1
+export var ball_dir = 1
 
-const MOVE_SPEED=100
+const MOVE_SPEED = 100
 
 func _process(delta):
-
 	var which = get_name()
 	
 	# move up and down based on input
-	if (Input.is_action_pressed(which+"_move_up") and position.y > 0):
+	if Input.is_action_pressed(which+"_move_up") and position.y > 0:
 		position.y -= MOVE_SPEED * delta
-	if (Input.is_action_pressed(which+"_move_down") and position.y < get_viewport_rect().size.y):
+	if Input.is_action_pressed(which+"_move_down") and position.y < get_viewport_rect().size.y:
 		position.y += MOVE_SPEED * delta
 		
 
 func _on_area_entered( area ):
 	if area.get_name() == "ball":
 		# assign new direction
-		area.direction = Vector2(ball_dir,randf() * 2 - 1).normalized()
+		area.direction = Vector2(ball_dir, randf() * 2 - 1).normalized()

--- a/2d/pong/wall.gd
+++ b/2d/pong/wall.gd
@@ -1,8 +1,7 @@
 extends Area2D
 
 
-
 func _on_wall_area_entered( area ):
-	if (area.get_name() == "ball"):
+	if area.get_name() == "ball":
 		#oops, ball went out of game place, reset
 		area.reset()

--- a/2d/screen_space_shaders/screen_shaders.gd
+++ b/2d/screen_space_shaders/screen_shaders.gd
@@ -1,25 +1,24 @@
-
 extends Control
 
 
 func _ready():
-	for c in get_node("pictures").get_children():
-		get_node("picture").add_item("PIC: " + c.get_name())
+	for c in $pictures.get_children():
+		$picture.add_item("PIC: " + c.get_name())
 	for c in get_node("effects").get_children():
-		get_node("effect").add_item("FX: " + c.get_name())
+		$effect.add_item("FX: " + c.get_name())
 
 
 func _on_picture_item_selected(ID):
-	for c in range(get_node("pictures").get_child_count()):
-		if (ID == c):
-			get_node("pictures").get_child(c).show()
+	for c in range($pictures.get_child_count()):
+		if ID == c:
+			$pictures.get_child(c).show()
 		else:
-			get_node("pictures").get_child(c).hide()
+			$pictures.get_child(c).hide()
 
 
 func _on_effect_item_selected(ID):
-	for c in range(get_node("effects").get_child_count()):
-		if (ID == c):
-			get_node("effects").get_child(c).show()
+	for c in range($effects.get_child_count()):
+		if ID == c:
+			$effects.get_child(c).show()
 		else:
-			get_node("effects").get_child(c).hide()
+			$effects.get_child(c).hide()


### PR DESCRIPTION
Testing my half-working GDScript style checker, I corrected the scripts in the 2d section to follow the GDScript style guide. Most of the changes were removing extra () in if statements and adding spaces around operators. Also corrected `get_node` references to `$` syntax.