### PR TITLE
Update 3d in 2d demo for Godot 3.0

### DIFF
--- a/viewport/3d_in_2d/player.gd
+++ b/viewport/3d_in_2d/player.gd
@@ -11,4 +11,4 @@ func _ready():
 
 
 func _process(delta):
-	model.rotation_deg.y += delta * SPEED
+	model.rotation_degrees.y += delta * SPEED


### PR DESCRIPTION
The "3d in 2d" demo wasn't compatible with the current godot version on master.
The player.gd script just seems to use a member of Spatial that got refactored.