### PR TITLE
Fixes HDR for 2D demo

### DIFF
--- a/2d/hdr/beach_cave.tscn
+++ b/2d/hdr/beach_cave.tscn
@@ -6,7 +6,7 @@
 
 [sub_resource type="Environment" id=1]
 
-background_mode = 3
+background_mode = 4
 background_sky_custom_fov = 0.0
 background_color = Color( 0, 0, 0, 1 )
 background_energy = 1.0


### PR DESCRIPTION
The `WorldEnviroment` background mode has to be `Canvas` for it to work in 2D