### PR TITLE
fixed font rotation animation in sdf demo

### DIFF
--- a/2d/sdf_font/sdf.tscn
+++ b/2d/sdf_font/sdf.tscn
@@ -8,15 +8,15 @@ length = 15.0
 loop = true
 step = 0.1
 tracks/0/type = "value"
-tracks/0/path = NodePath(".:rotation_deg")
+tracks/0/path = NodePath(".:rotation_degrees")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/keys = {
-"times": PoolRealArray( 0, 15 ),
+"times": PoolRealArray( 0, 10 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ 0.0, -360.0 ]
+"values": [ 0.0, 360.0 ]
 }
 
 [sub_resource type="Animation" id=2]


### PR DESCRIPTION
The signed distance field font didn't rotate during the demo and produced the following errors instead.

![2017-12-02-101721_1366x768_scrot](https://user-images.githubusercontent.com/3285214/33511411-f5e3c4c2-d74c-11e7-990c-99a3a1d65035.png)

The font now should now properly rotate. Tested on Godot 3.0 Beta 1.