### PR TITLE
Add files via upload

### DIFF
--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (10) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (10) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (10) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (10) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (10) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (10) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (11) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (11) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (11) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (11) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (11) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (11) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (12) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (12) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (12) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (12) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (13) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (13) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (13) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (13) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (14) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (14) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (14) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (14) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (15) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (15) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (15) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (15) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (16) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (16) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (16) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (16) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (17) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (17) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (17) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (17) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (18) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (18) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (18) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (18) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (19) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (19) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (19) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (19) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (2) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (2) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (2) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (2) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (20) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (20) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (20) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (20) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (21) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (21) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (21) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (21) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (22) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (22) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (22) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (22) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (23) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (23) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (23) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (23) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (24) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (24) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (24) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (24) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (25) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (25) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (25) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (25) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (26) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (26) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (26) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (26) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (27) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (27) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (27) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (27) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (28) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (28) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (28) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (28) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (29) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (29) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (29) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (29) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (3) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (3) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (30) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (30) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (30) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (30) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (31) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (31) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (31) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (31) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (32) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (32) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (32) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (32) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (33) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (33) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (33) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (33) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (34) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (34) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (34) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (34) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (35) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (35) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (35) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (35) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (36) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (36) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (36) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (36) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (37) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (37) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (37) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (37) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (38) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (38) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (38) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (38) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (39) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (39) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (39) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (39) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (4) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (4) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (4) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (4) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (4) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (4) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (40) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (40) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (40) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (40) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (41) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (41) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (41) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (41) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (42) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (42) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (43) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (43) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (44) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (44) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (45) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (45) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (46) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (46) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (47) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (47) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (48) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (48) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (49) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (49) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (5) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (5) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (5) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (5) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (5) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (5) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (50) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (50) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (51) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (51) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (52) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (52) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (53) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (53) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (54) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (54) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (6) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (6) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (6) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (6) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (6) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (6) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (7) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (7) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (7) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (7) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (7) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (7) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (8) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (8) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (8) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (8) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (8) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (8) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (9) - Copy - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (9) - Copy - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (9) - Copy - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (9) - Copy - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 

--- a/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (9) - Copy.txt
+++ b/2d/New folder/Think twice before giving feedback to this community! - Copy - Copy (9) - Copy.txt
@@ -1,0 +1,20 @@
+(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)
+
+![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)
+
+Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).
+
+They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!
+
+Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  
+
+Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
+> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.
+
+He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.
+
+
+
+He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.
+
+Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 


### PR DESCRIPTION
(Since everyone keeps closing this, I am going to continue to post it until one thread remains visible for discussion, no need to censor)

![](https://i.gyazo.com/364f1b11bc57924374d0a8c81df1eeab.png)

Lead developer sent this message after a user was giving his honest feedback via this [reddit thread](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqk9nel/).

They also said (I kid you not) -- giving feedback is "**bullying**",  a "**professional whiner**", and "**ranting**". Reduz's passive aggressive tone and insulting behavior is rampant there.  I already terminated my patreon account because of this, and not saying you should either (FLOSS projects) are great, however, for the lead developer to act like this towards people giving feedback.. is not okay!

Let me re-iterate, not saying that you should stop giving feedback, but I just want this message to be seen across github and reach as far as possible. Because this kind of communication and how the lead developer treats a regular Godot developer is not right at all. I've never seen this behavior from a FLOSS project lead developer.  It's a shame, because the guy giving feedback is just a random person anyway, and the way the project managers and lead developers took it so personally like it was an attack (when it wasn't), means the lead developers/contributors are possibly not viewing your issues with the right mindset.  

Also, after reading the last paragraph from [this post by akien](https://www.reddit.com/r/gamedev/comments/7gmtxl/godot_30_beta_1_is_there_right_in_time_for_ludum/dqlqj2v/)
> From here on, we will avoid responding to xxx's threads on the various Godot communities, and focus instead on the huge amount of constructive feedback and bug reports that we get from other users. This will likely overlap with some of the issues mentioned above, which will thus be fixed eventually, but we won't accept being bullied into working on them now when we have different priorities. Users are free to disagree with our priorities, but in the end the contributors are the ones making the call.

He's saying they will now favor/prioritize issues based on the user reporting it, and not the issue itself. (Extreme prejudice), which will not be good for the project because the issue should be irrelevant to the user reporting it. Just because if a user who has a snotty attitude that is reporting a huge client crash error, doesn't mean that client crash error should not be taken lightly.



He's also stating that anyone giving hard feedback is now "bullying" them. Which is not true whatsoever.

Just wanting to post this to get the word out there, hopefully some things change. @reduz @akien-mga  This is just unbelievable :( 