### PR TITLE
Automatic .import updates made by opening projects in the godot editor

### DIFF
--- a/2d/hdr/icon.png.import
+++ b/2d/hdr/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="63a944507088a2392d7d6870fc91dc51"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="79b94abe93da2df9d5e610a249860b02"
+
 [params]
 
 compress/mode=0

--- a/2d/hdr/ocean_beach.png.import
+++ b/2d/hdr/ocean_beach.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/ocean_beach.png-b571ab5468cc775a520aaa47efbed607.stex"
 
+[deps]
+
+source_file="res://ocean_beach.png"
+source_md5="fdfc24e858f07a1ac31c82fd8f357c3a"
+
+dest_files=[ "res://.import/ocean_beach.png-b571ab5468cc775a520aaa47efbed607.stex" ]
+dest_md5="3ae80bb89ba8c0cd67fa2402bb80f230"
+
 [params]
 
 compress/mode=0

--- a/2d/hdr/ocean_cave.png.import
+++ b/2d/hdr/ocean_cave.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/ocean_cave.png-2a86f381e3092b4cb698b627d778e19b.stex"
 
+[deps]
+
+source_file="res://ocean_cave.png"
+source_md5="acabe48e11037e9929f2d5aade9419a4"
+
+dest_files=[ "res://.import/ocean_cave.png-2a86f381e3092b4cb698b627d778e19b.stex" ]
+dest_md5="0f5fe12eb87a48058850e3c6c5c9a347"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-01.png.import
+++ b/2d/hexagonal_map/WWT-01.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-01.png-d71b23a59ce633973e2216144d4c3cc7.stex"
 
+[deps]
+
+source_file="res://WWT-01.png"
+source_md5="0b890247b30e45539a651d35963dfeaa"
+
+dest_files=[ "res://.import/WWT-01.png-d71b23a59ce633973e2216144d4c3cc7.stex" ]
+dest_md5="86ea33916c9166b19d7ec3ce0cbd9ffb"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-02.png.import
+++ b/2d/hexagonal_map/WWT-02.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-02.png-8c7a76bab1a896763ab37f5a7bf77904.stex"
 
+[deps]
+
+source_file="res://WWT-02.png"
+source_md5="37986e5d93e3232705d23f4f08a5ac88"
+
+dest_files=[ "res://.import/WWT-02.png-8c7a76bab1a896763ab37f5a7bf77904.stex" ]
+dest_md5="66b775a71e2f15ab81afc9dd299bb186"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-03.png.import
+++ b/2d/hexagonal_map/WWT-03.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-03.png-f804f0fa409c5c9ad521581b65c67f26.stex"
 
+[deps]
+
+source_file="res://WWT-03.png"
+source_md5="efa48169ca94f0790be7f97ff91a4c33"
+
+dest_files=[ "res://.import/WWT-03.png-f804f0fa409c5c9ad521581b65c67f26.stex" ]
+dest_md5="16a16663d435a8fc31167f029335712b"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-04.png.import
+++ b/2d/hexagonal_map/WWT-04.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-04.png-a50f93109e34b533b1855a7ef46475b2.stex"
 
+[deps]
+
+source_file="res://WWT-04.png"
+source_md5="e1d2e0446506c40a8c197974b432d71f"
+
+dest_files=[ "res://.import/WWT-04.png-a50f93109e34b533b1855a7ef46475b2.stex" ]
+dest_md5="cfd03f3cbb6eb0397ab14301ad9a0bf6"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-05.png.import
+++ b/2d/hexagonal_map/WWT-05.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-05.png-deee12124c9c3ab8368902f7733ff079.stex"
 
+[deps]
+
+source_file="res://WWT-05.png"
+source_md5="66163c8b5cbcdd81c58c745c7d381b09"
+
+dest_files=[ "res://.import/WWT-05.png-deee12124c9c3ab8368902f7733ff079.stex" ]
+dest_md5="d638f976c9bf00280c024c4eff364436"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-06.png.import
+++ b/2d/hexagonal_map/WWT-06.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-06.png-a16b61cdadeeed4ab2c9f5eec8b79c7c.stex"
 
+[deps]
+
+source_file="res://WWT-06.png"
+source_md5="a67336cfc318936f10627e52a9c40faa"
+
+dest_files=[ "res://.import/WWT-06.png-a16b61cdadeeed4ab2c9f5eec8b79c7c.stex" ]
+dest_md5="dcb8070807de1eb2da602cb41681036b"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-07.png.import
+++ b/2d/hexagonal_map/WWT-07.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-07.png-7cc4023daef4567752735bf79f2ccd12.stex"
 
+[deps]
+
+source_file="res://WWT-07.png"
+source_md5="6484917359dde7cebfeb07c1e6cc9c31"
+
+dest_files=[ "res://.import/WWT-07.png-7cc4023daef4567752735bf79f2ccd12.stex" ]
+dest_md5="fa94f39666e467e41aa662d2415809e2"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-08.png.import
+++ b/2d/hexagonal_map/WWT-08.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-08.png-7eaf3eb568b0293e3b28374e0bcfdf76.stex"
 
+[deps]
+
+source_file="res://WWT-08.png"
+source_md5="78d6616e154e0ae38665a9b7773a983a"
+
+dest_files=[ "res://.import/WWT-08.png-7eaf3eb568b0293e3b28374e0bcfdf76.stex" ]
+dest_md5="f72c01caa10db469d93dba5b2545d6d0"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-09.png.import
+++ b/2d/hexagonal_map/WWT-09.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-09.png-05c1bd2bd71982b595886c84d0655094.stex"
 
+[deps]
+
+source_file="res://WWT-09.png"
+source_md5="b69b814834db2bd25e7965754113c2e7"
+
+dest_files=[ "res://.import/WWT-09.png-05c1bd2bd71982b595886c84d0655094.stex" ]
+dest_md5="df7d41109fe474beb8ade30534463e6e"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-10.png.import
+++ b/2d/hexagonal_map/WWT-10.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-10.png-21f5bebc271347b73cd120c7671bcc04.stex"
 
+[deps]
+
+source_file="res://WWT-10.png"
+source_md5="7142231c548c56c101ea10a71e1916f2"
+
+dest_files=[ "res://.import/WWT-10.png-21f5bebc271347b73cd120c7671bcc04.stex" ]
+dest_md5="635e83eb9dae86298d0a9b796d9a3e12"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-11.png.import
+++ b/2d/hexagonal_map/WWT-11.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-11.png-c278f158b8ebe9b98a71fa01d357ea55.stex"
 
+[deps]
+
+source_file="res://WWT-11.png"
+source_md5="053fbf42bc9cebc1f3080de013242479"
+
+dest_files=[ "res://.import/WWT-11.png-c278f158b8ebe9b98a71fa01d357ea55.stex" ]
+dest_md5="6953053ff83a3f7bf380158958c270f2"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-12.png.import
+++ b/2d/hexagonal_map/WWT-12.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-12.png-f99f6470cbf7469390137cc1b1eac0b1.stex"
 
+[deps]
+
+source_file="res://WWT-12.png"
+source_md5="92fea3bd12983ee94d2ae6b76323fae6"
+
+dest_files=[ "res://.import/WWT-12.png-f99f6470cbf7469390137cc1b1eac0b1.stex" ]
+dest_md5="df7d0edfc4e6bdb9a770741421ad2463"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-13.png.import
+++ b/2d/hexagonal_map/WWT-13.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-13.png-b831a7b68dbcdd483e454623cca7af6a.stex"
 
+[deps]
+
+source_file="res://WWT-13.png"
+source_md5="1bdfe15639bf81bdb17702a65f221602"
+
+dest_files=[ "res://.import/WWT-13.png-b831a7b68dbcdd483e454623cca7af6a.stex" ]
+dest_md5="1073c6b45ae80c07e84c7dabac233bbd"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-14.png.import
+++ b/2d/hexagonal_map/WWT-14.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-14.png-473aa39bbfdbf2d9ac37478ba67ab5a8.stex"
 
+[deps]
+
+source_file="res://WWT-14.png"
+source_md5="0908e9c76ad828f0be20b97ba14f0120"
+
+dest_files=[ "res://.import/WWT-14.png-473aa39bbfdbf2d9ac37478ba67ab5a8.stex" ]
+dest_md5="9fbfb2ce92fa1f447b94a4cc000f6d22"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-15.png.import
+++ b/2d/hexagonal_map/WWT-15.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-15.png-f958cd09bdaf7066eb31dea2b35a59fe.stex"
 
+[deps]
+
+source_file="res://WWT-15.png"
+source_md5="42f95b729214f019cd546eb5003b4791"
+
+dest_files=[ "res://.import/WWT-15.png-f958cd09bdaf7066eb31dea2b35a59fe.stex" ]
+dest_md5="1db7da48083097925eb77bfbb089ca16"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-16.png.import
+++ b/2d/hexagonal_map/WWT-16.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-16.png-1027e2a388bf820efb40bb630699acf6.stex"
 
+[deps]
+
+source_file="res://WWT-16.png"
+source_md5="572d9319266e28fbbbcce87eff3c8484"
+
+dest_files=[ "res://.import/WWT-16.png-1027e2a388bf820efb40bb630699acf6.stex" ]
+dest_md5="82b3aed42579c489f6e13095edd6f504"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-17.png.import
+++ b/2d/hexagonal_map/WWT-17.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-17.png-06a724fd2ea7c875038b30870c815f35.stex"
 
+[deps]
+
+source_file="res://WWT-17.png"
+source_md5="1d732fced181b9d10debe504d905dc56"
+
+dest_files=[ "res://.import/WWT-17.png-06a724fd2ea7c875038b30870c815f35.stex" ]
+dest_md5="6ad6b9d8fda151bbcfcab7bc82e1e582"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-18.png.import
+++ b/2d/hexagonal_map/WWT-18.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-18.png-a7a95e5daf469fc05529f5c4d9ffd83f.stex"
 
+[deps]
+
+source_file="res://WWT-18.png"
+source_md5="76847ff65ddbb052a87dde7f668214d0"
+
+dest_files=[ "res://.import/WWT-18.png-a7a95e5daf469fc05529f5c4d9ffd83f.stex" ]
+dest_md5="5a42212a6d89526590641bee2ee5084d"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-19.png.import
+++ b/2d/hexagonal_map/WWT-19.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-19.png-e53561a49d2426c56b7463fcfe7187ad.stex"
 
+[deps]
+
+source_file="res://WWT-19.png"
+source_md5="1e6e2fb4e3a9adb7dbae0c87dc10ec66"
+
+dest_files=[ "res://.import/WWT-19.png-e53561a49d2426c56b7463fcfe7187ad.stex" ]
+dest_md5="6b671b91344897f0ea9a81eb865f8c60"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-20.png.import
+++ b/2d/hexagonal_map/WWT-20.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-20.png-fa22d2cbc86525aa67ed5be2eb766f38.stex"
 
+[deps]
+
+source_file="res://WWT-20.png"
+source_md5="771239ff30038281b10447417c6e5d20"
+
+dest_files=[ "res://.import/WWT-20.png-fa22d2cbc86525aa67ed5be2eb766f38.stex" ]
+dest_md5="98b125f1e3624d89929f464c979f7cfa"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-21.png.import
+++ b/2d/hexagonal_map/WWT-21.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-21.png-0650363bb3b67f7ad8ea91f2ed66a86c.stex"
 
+[deps]
+
+source_file="res://WWT-21.png"
+source_md5="e2515b122a8faea5eeaa441066570c6d"
+
+dest_files=[ "res://.import/WWT-21.png-0650363bb3b67f7ad8ea91f2ed66a86c.stex" ]
+dest_md5="ae92c355792d24c95b5f3670a12c1460"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-22.png.import
+++ b/2d/hexagonal_map/WWT-22.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-22.png-15702d71f9ada16455bd5ec251efa392.stex"
 
+[deps]
+
+source_file="res://WWT-22.png"
+source_md5="5c97ce3df5e87838d61c3f9ff2b17895"
+
+dest_files=[ "res://.import/WWT-22.png-15702d71f9ada16455bd5ec251efa392.stex" ]
+dest_md5="43fe967d3517c66ac967e22831a7a7ad"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-23.png.import
+++ b/2d/hexagonal_map/WWT-23.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-23.png-b96b4e3e762993c848a02a5920369963.stex"
 
+[deps]
+
+source_file="res://WWT-23.png"
+source_md5="725c9d66f212f5986ba7a85828679855"
+
+dest_files=[ "res://.import/WWT-23.png-b96b4e3e762993c848a02a5920369963.stex" ]
+dest_md5="f65b783fc812fa0f8cfbf0b40ca99d82"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-24.png.import
+++ b/2d/hexagonal_map/WWT-24.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-24.png-51252af7231f3c2108e03f43e485e5c9.stex"
 
+[deps]
+
+source_file="res://WWT-24.png"
+source_md5="8511d87652c93d9abce9a5746b0db7fc"
+
+dest_files=[ "res://.import/WWT-24.png-51252af7231f3c2108e03f43e485e5c9.stex" ]
+dest_md5="a20e2346f467b62b082b98ac20dff43e"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-25.png.import
+++ b/2d/hexagonal_map/WWT-25.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-25.png-db9bd847f53180c4b408ac5fe5509089.stex"
 
+[deps]
+
+source_file="res://WWT-25.png"
+source_md5="969e409c3b56df51a6aa6c45e928b06a"
+
+dest_files=[ "res://.import/WWT-25.png-db9bd847f53180c4b408ac5fe5509089.stex" ]
+dest_md5="bda837cf908f9d6163703e6e9c8a404d"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/WWT-26.png.import
+++ b/2d/hexagonal_map/WWT-26.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/WWT-26.png-58e5c6364a04c3baa8d4707bfd79d68c.stex"
 
+[deps]
+
+source_file="res://WWT-26.png"
+source_md5="ea59f6d91c02940f40ce5c1eb8bde46d"
+
+dest_files=[ "res://.import/WWT-26.png-58e5c6364a04c3baa8d4707bfd79d68c.stex" ]
+dest_md5="37f535f42b62844c466fa063407afccd"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/icon.png.import
+++ b/2d/hexagonal_map/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="ec69771a81b10d0c169f902a116af1f9"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="03aff85d639cd66ad9d71cf71112555d"
+
 [params]
 
 compress/mode=0

--- a/2d/hexagonal_map/troll.png.import
+++ b/2d/hexagonal_map/troll.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/troll.png-78efc50bfccaa17f54d40cfea3eef5f5.stex"
 
+[deps]
+
+source_file="res://troll.png"
+source_md5="76a37c47b1f09115f714d6635ab50fb4"
+
+dest_files=[ "res://.import/troll.png-78efc50bfccaa17f54d40cfea3eef5f5.stex" ]
+dest_md5="aded3a6d7973cb880144e84f0b3ec505"
+
 [params]
 
 compress/mode=0

--- a/2d/isometric/icon.png.import
+++ b/2d/isometric/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="c79c9ad7eaca57f9b61f2e8b06d7a2ea"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="557cc789bada50b97252b4b076d9396d"
+
 [params]
 
 compress/mode=0

--- a/2d/isometric/isotiles.png.import
+++ b/2d/isometric/isotiles.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/isotiles.png-502434fe0d6c3fd8ce67cea5a960c208.stex"
 
+[deps]
+
+source_file="res://isotiles.png"
+source_md5="497da3b55d87ebab4df56dba2a0804ed"
+
+dest_files=[ "res://.import/isotiles.png-502434fe0d6c3fd8ce67cea5a960c208.stex" ]
+dest_md5="e81f39117efaa23b86988b64a3523f31"
+
 [params]
 
 compress/mode=0

--- a/2d/isometric/troll.png.import
+++ b/2d/isometric/troll.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/troll.png-78efc50bfccaa17f54d40cfea3eef5f5.stex"
 
+[deps]
+
+source_file="res://troll.png"
+source_md5="76a37c47b1f09115f714d6635ab50fb4"
+
+dest_files=[ "res://.import/troll.png-78efc50bfccaa17f54d40cfea3eef5f5.stex" ]
+dest_md5="aded3a6d7973cb880144e84f0b3ec505"
+
 [params]
 
 compress/mode=0

--- a/2d/kinematic_character/circle.png.import
+++ b/2d/kinematic_character/circle.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/circle.png-10953cad44a8947fbdd4128a631e9e52.stex"
 
+[deps]
+
+source_file="res://circle.png"
+source_md5="c01cd5674a625756c3df259f76d5295a"
+
+dest_files=[ "res://.import/circle.png-10953cad44a8947fbdd4128a631e9e52.stex" ]
+dest_md5="e4ec5acd02941f2f2150d836824a5d51"
+
 [params]
 
 compress/mode=0

--- a/2d/kinematic_character/icon.png.import
+++ b/2d/kinematic_character/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="a2c4d258e30d0a978df50141f46c78fc"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="144813cb6d9a20bff16078a45fa2d990"
+
 [params]
 
 compress/mode=0

--- a/2d/kinematic_character/long_obstacle.png.import
+++ b/2d/kinematic_character/long_obstacle.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/long_obstacle.png-1b33440a15b4db156b2a9ec7e9a2a80e.stex"
 
+[deps]
+
+source_file="res://long_obstacle.png"
+source_md5="3c79b1a7d3ef80a28347634c36f0b2e1"
+
+dest_files=[ "res://.import/long_obstacle.png-1b33440a15b4db156b2a9ec7e9a2a80e.stex" ]
+dest_md5="4956558400a4bac181bc00346aaaacdf"
+
 [params]
 
 compress/mode=0

--- a/2d/kinematic_character/obstacle.png.import
+++ b/2d/kinematic_character/obstacle.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/obstacle.png-dfb3e99d3af573251007cdf5e1c252b9.stex"
 
+[deps]
+
+source_file="res://obstacle.png"
+source_md5="5963aa5f0000565f5472e152003bfaf3"
+
+dest_files=[ "res://.import/obstacle.png-dfb3e99d3af573251007cdf5e1c252b9.stex" ]
+dest_md5="e4a785f1d55f2585bce48ea5d56b3124"
+
 [params]
 
 compress/mode=0

--- a/2d/kinematic_character/player.png.import
+++ b/2d/kinematic_character/player.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/player.png-2dd0af52de4b213777cd8c9df94c0978.stex"
 
+[deps]
+
+source_file="res://player.png"
+source_md5="540f7f0d3b239b1d8c349f4be4d2d253"
+
+dest_files=[ "res://.import/player.png-2dd0af52de4b213777cd8c9df94c0978.stex" ]
+dest_md5="4112e6a5c36d38d07edebbfbd416c9fa"
+
 [params]
 
 compress/mode=0

--- a/2d/kinematic_character/princess.png.import
+++ b/2d/kinematic_character/princess.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/princess.png-9b4caf2cfe324ae3734249d5b559d39d.stex"
 
+[deps]
+
+source_file="res://princess.png"
+source_md5="0cc2f9e0359e84dd37950556613a1778"
+
+dest_files=[ "res://.import/princess.png-9b4caf2cfe324ae3734249d5b559d39d.stex" ]
+dest_md5="856066b52354a42ff12d3b5608755e56"
+
 [params]
 
 compress/mode=0

--- a/2d/kinematic_collision/icon.png.import
+++ b/2d/kinematic_collision/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="49c0855bb2f599fd216190fb14eac778"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="ef5bb91cdcf00e1ad730573fc7704640"
+
 [params]
 
 compress/mode=0

--- a/2d/kinematic_collision/obstacle.png.import
+++ b/2d/kinematic_collision/obstacle.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/obstacle.png-dfb3e99d3af573251007cdf5e1c252b9.stex"
 
+[deps]
+
+source_file="res://obstacle.png"
+source_md5="593e6d05e3859ff3e39eddb0bcad093b"
+
+dest_files=[ "res://.import/obstacle.png-dfb3e99d3af573251007cdf5e1c252b9.stex" ]
+dest_md5="ad71f3bc8585c641906a5ff5124ac2e6"
+
 [params]
 
 compress/mode=0

--- a/2d/kinematic_collision/player.png.import
+++ b/2d/kinematic_collision/player.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/player.png-2dd0af52de4b213777cd8c9df94c0978.stex"
 
+[deps]
+
+source_file="res://player.png"
+source_md5="540f7f0d3b239b1d8c349f4be4d2d253"
+
+dest_files=[ "res://.import/player.png-2dd0af52de4b213777cd8c9df94c0978.stex" ]
+dest_md5="4112e6a5c36d38d07edebbfbd416c9fa"
+
 [params]
 
 compress/mode=0

--- a/2d/light2d_as_mask/burano.png.import
+++ b/2d/light2d_as_mask/burano.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/burano.png-893cff79ccbe972d7b1ad3e1845f81bf.stex"
 
+[deps]
+
+source_file="res://burano.png"
+source_md5="56e0dd7f3166567cd3732be2b3d969d7"
+
+dest_files=[ "res://.import/burano.png-893cff79ccbe972d7b1ad3e1845f81bf.stex" ]
+dest_md5="c41d7eefd81a4a9b247056ecc6cecb53"
+
 [params]
 
 compress/mode=0

--- a/2d/light2d_as_mask/icon.png.import
+++ b/2d/light2d_as_mask/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="0f5dab3f02c95e5a3b2df77bff0389d5"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="8060b8a927328cda642bc470301ec76d"
+
 [params]
 
 compress/mode=0

--- a/2d/light2d_as_mask/splat.png.import
+++ b/2d/light2d_as_mask/splat.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/splat.png-a41a35966004eec2e8a20d517d1ec4bb.stex"
 
+[deps]
+
+source_file="res://splat.png"
+source_md5="2ac066f1b78091c74d758bb6afafff98"
+
+dest_files=[ "res://.import/splat.png-a41a35966004eec2e8a20d517d1ec4bb.stex" ]
+dest_md5="b136a1944158048a2afca2127eb1393f"
+
 [params]
 
 compress/mode=0

--- a/2d/lights_and_shadows/bg.png.import
+++ b/2d/lights_and_shadows/bg.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/bg.png-24bff804693ee063127ad100e04c5185.stex"
 
+[deps]
+
+source_file="res://bg.png"
+source_md5="767fe4b38b7f307c268da6beb72ca732"
+
+dest_files=[ "res://.import/bg.png-24bff804693ee063127ad100e04c5185.stex" ]
+dest_md5="c5f047c8b98d363519d5da3be2119651"
+
 [params]
 
 compress/mode=0

--- a/2d/lights_and_shadows/caster.png.import
+++ b/2d/lights_and_shadows/caster.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/caster.png-67727cb056b9e0209664a84f1653a25a.stex"
 
+[deps]
+
+source_file="res://caster.png"
+source_md5="461a6647dafae1304d7a21178246bb9d"
+
+dest_files=[ "res://.import/caster.png-67727cb056b9e0209664a84f1653a25a.stex" ]
+dest_md5="102ac34dffa3ad96f81d7c422c9ff96d"
+
 [params]
 
 compress/mode=0

--- a/2d/lights_and_shadows/icon.png.import
+++ b/2d/lights_and_shadows/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="b522cb048c2d4713c630a1fd00254467"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="fca2fbe38bffc4d500dcbb63e1985d25"
+
 [params]
 
 compress/mode=0

--- a/2d/lights_and_shadows/light.png.import
+++ b/2d/lights_and_shadows/light.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/light.png-06e94102f0cce323cff7daad56cf3030.stex"
 
+[deps]
+
+source_file="res://light.png"
+source_md5="d36597a1d2ddc06b8d0d22650a176149"
+
+dest_files=[ "res://.import/light.png-06e94102f0cce323cff7daad56cf3030.stex" ]
+dest_md5="4358f9620206dfaf70c1c9c703c7cbc0"
+
 [params]
 
 compress/mode=0

--- a/2d/lights_and_shadows/spot.png.import
+++ b/2d/lights_and_shadows/spot.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/spot.png-36b4dfbff4efeea17ec3137d266ffc4a.stex"
 
+[deps]
+
+source_file="res://spot.png"
+source_md5="8d1a5fb652c178423018bac9e0f5acf0"
+
+dest_files=[ "res://.import/spot.png-36b4dfbff4efeea17ec3137d266ffc4a.stex" ]
+dest_md5="39755819eccb4f1e0c301b93be79590a"
+
 [params]
 
 compress/mode=0

--- a/2d/navigation/agent.png.import
+++ b/2d/navigation/agent.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/agent.png-22bdd448030a3457042db97db7630b4c.stex"
 
+[deps]
+
+source_file="res://agent.png"
+source_md5="c7937b15f89b021d3c888c677b1e1677"
+
+dest_files=[ "res://.import/agent.png-22bdd448030a3457042db97db7630b4c.stex" ]
+dest_md5="fd0675f788288554927ef3a6c9686573"
+
 [params]
 
 compress/mode=0

--- a/2d/navigation/icon.png.import
+++ b/2d/navigation/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="19e03eec58b7d3b8a24db28867a39190"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="5110b1b86f59a6a195f89ab36ee328a6"
+
 [params]
 
 compress/mode=0

--- a/2d/navigation/path.png.import
+++ b/2d/navigation/path.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/path.png-03249d8c3f5af613913d0eb997e480a3.stex"
 
+[deps]
+
+source_file="res://path.png"
+source_md5="e72fbffb80ea739cf373a488a6d0ab27"
+
+dest_files=[ "res://.import/path.png-03249d8c3f5af613913d0eb997e480a3.stex" ]
+dest_md5="9b012237e342f634293969fed09b3966"
+
 [params]
 
 compress/mode=0

--- a/2d/particles/fire_particle.png.import
+++ b/2d/particles/fire_particle.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/fire_particle.png-282b12927cd5b1f6d9c0bfb485d448ae.stex"
 
+[deps]
+
+source_file="res://fire_particle.png"
+source_md5="b0ff2970ad1b00d2ce4ed6f02e01d7c5"
+
+dest_files=[ "res://.import/fire_particle.png-282b12927cd5b1f6d9c0bfb485d448ae.stex" ]
+dest_md5="eea50c6eceabd139f99b8f771003811d"
+
 [params]
 
 compress/mode=0

--- a/2d/particles/icon.png.import
+++ b/2d/particles/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="79bb491eb2c0a0753f965ac0b3106349"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="cbc9a406040e47df12d4494a9431028f"
+
 [params]
 
 compress/mode=0

--- a/2d/particles/mask.png.import
+++ b/2d/particles/mask.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/mask.png-b945516e6475612c1c4c3b4f8dd0bdc6.stex"
 
+[deps]
+
+source_file="res://mask.png"
+source_md5="3214952ea3431758b892aabdbde38b08"
+
+dest_files=[ "res://.import/mask.png-b945516e6475612c1c4c3b4f8dd0bdc6.stex" ]
+dest_md5="6823b6e7db665ffc74987b968f7eaf3b"
+
 [params]
 
 compress/mode=0

--- a/2d/particles/smoke_particle.png.import
+++ b/2d/particles/smoke_particle.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/smoke_particle.png-2af9cbaa4a935c239d404ea2402bff45.stex"
 
+[deps]
+
+source_file="res://smoke_particle.png"
+source_md5="1b1db1ed68bccbfb6cc968edd82d3590"
+
+dest_files=[ "res://.import/smoke_particle.png-2af9cbaa4a935c239d404ea2402bff45.stex" ]
+dest_md5="b15a735d1026591cfe0adf0961cd978d"
+
 [params]
 
 compress/mode=0

--- a/2d/particles/spark_particle2.png.import
+++ b/2d/particles/spark_particle2.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/spark_particle2.png-c01711346d42a0d9675f292248ead315.stex"
 
+[deps]
+
+source_file="res://spark_particle2.png"
+source_md5="907b52c0c7e2668357863bd01721e813"
+
+dest_files=[ "res://.import/spark_particle2.png-c01711346d42a0d9675f292248ead315.stex" ]
+dest_md5="a13abc4e2d2feac9c7fe76af899b5ff4"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/bullet.png.import
+++ b/2d/physics_platformer/bullet.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/bullet.png-ff1424653e10246c11e3724e402c519e.stex"
 
+[deps]
+
+source_file="res://bullet.png"
+source_md5="9fe43d82e09598fc96be75bcf60df249"
+
+dest_files=[ "res://.import/bullet.png-ff1424653e10246c11e3724e402c519e.stex" ]
+dest_md5="04684b9a0276f89c616678cf4489b76d"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/coin.png.import
+++ b/2d/physics_platformer/coin.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/coin.png-7e710de472b75b3653c3283ef5153eb4.stex"
 
+[deps]
+
+source_file="res://coin.png"
+source_md5="e222f7ea0cf168c4da9b5beff4035f2c"
+
+dest_files=[ "res://.import/coin.png-7e710de472b75b3653c3283ef5153eb4.stex" ]
+dest_md5="6ddc3149e946e3fc81f8d94eccdc03aa"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/enemy.png.import
+++ b/2d/physics_platformer/enemy.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/enemy.png-f7d9f81714867a24a08e299bb600e611.stex"
 
+[deps]
+
+source_file="res://enemy.png"
+source_md5="42bb3a8005fffb91c993fbb55e798d1d"
+
+dest_files=[ "res://.import/enemy.png-f7d9f81714867a24a08e299bb600e611.stex" ]
+dest_md5="4c8d1da721e96b61e14085c6dad3a986"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/icon.png.import
+++ b/2d/physics_platformer/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="059cf00427ccbf40878c582845360337"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="b775640cb5a1f03d40f18d355dddd188"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/moving_platform.png.import
+++ b/2d/physics_platformer/moving_platform.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/moving_platform.png-1ef2f9fd1684df90d6ad38a267c1201b.stex"
 
+[deps]
+
+source_file="res://moving_platform.png"
+source_md5="3a3eb41985ca94372fe4a9c81b067504"
+
+dest_files=[ "res://.import/moving_platform.png-1ef2f9fd1684df90d6ad38a267c1201b.stex" ]
+dest_md5="2d28d040ea69e01af7f8d176520661b0"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/music.ogg.import
+++ b/2d/physics_platformer/music.ogg.import
@@ -4,6 +4,14 @@ importer="ogg_vorbis"
 type="AudioStreamOGGVorbis"
 path="res://.import/music.ogg-3bd46d3a4b41702b152014078d12a390.oggstr"
 
+[deps]
+
+source_file="res://music.ogg"
+source_md5="ac01d521c92ce9d01cf09826bd3addbf"
+
+dest_files=[ "res://.import/music.ogg-3bd46d3a4b41702b152014078d12a390.oggstr" ]
+dest_md5="8f49ec9ebb932a81e74cb040e2a26d5f"
+
 [params]
 
 loop=true

--- a/2d/physics_platformer/one_way_platform.png.import
+++ b/2d/physics_platformer/one_way_platform.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/one_way_platform.png-af40161497fd0e8bfbc5d400c8bd650a.stex"
 
+[deps]
+
+source_file="res://one_way_platform.png"
+source_md5="6232db3f22a3599440102f32eb01edca"
+
+dest_files=[ "res://.import/one_way_platform.png-af40161497fd0e8bfbc5d400c8bd650a.stex" ]
+dest_md5="4a0e87dfa4f589f6fead720035abedca"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/osb_fire.png.import
+++ b/2d/physics_platformer/osb_fire.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_fire.png-e657a73546eb75918e9d9a3fea15cf70.stex"
 
+[deps]
+
+source_file="res://osb_fire.png"
+source_md5="99a276197ee76a83312af783f33f0ab3"
+
+dest_files=[ "res://.import/osb_fire.png-e657a73546eb75918e9d9a3fea15cf70.stex" ]
+dest_md5="977d51633748d45e85e4c7a214ade70e"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/osb_jump.png.import
+++ b/2d/physics_platformer/osb_jump.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_jump.png-dbbef3b47abbb562ce6c81a9701121c6.stex"
 
+[deps]
+
+source_file="res://osb_jump.png"
+source_md5="ac3e3adf52903de07cff73354f63896c"
+
+dest_files=[ "res://.import/osb_jump.png-dbbef3b47abbb562ce6c81a9701121c6.stex" ]
+dest_md5="1c8fb76688922e0a92945275b73dcf91"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/osb_left.png.import
+++ b/2d/physics_platformer/osb_left.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_left.png-fc7230aeb0eec74933ed08f89b893288.stex"
 
+[deps]
+
+source_file="res://osb_left.png"
+source_md5="ce066828ec6ef27c9ce3809341574058"
+
+dest_files=[ "res://.import/osb_left.png-fc7230aeb0eec74933ed08f89b893288.stex" ]
+dest_md5="197f26385b7f1c41c11b5d8356744c09"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/osb_right.png.import
+++ b/2d/physics_platformer/osb_right.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_right.png-5cf5add2dbc1c8dde17173ac56f3a004.stex"
 
+[deps]
+
+source_file="res://osb_right.png"
+source_md5="860560d5e66ccd837973fbbde7eb958f"
+
+dest_files=[ "res://.import/osb_right.png-5cf5add2dbc1c8dde17173ac56f3a004.stex" ]
+dest_md5="79b739823ce27077acfa70f6330fedd6"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/plank.png.import
+++ b/2d/physics_platformer/plank.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/plank.png-1bbc55bc0ea546386ad520f861cb9ff9.stex"
 
+[deps]
+
+source_file="res://plank.png"
+source_md5="28f8eb328fb1fde3d65c243e1ae25725"
+
+dest_files=[ "res://.import/plank.png-1bbc55bc0ea546386ad520f861cb9ff9.stex" ]
+dest_md5="4fe094c2877ef1b9c6ede602be7118ec"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/plankpin.png.import
+++ b/2d/physics_platformer/plankpin.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/plankpin.png-5a03e8bdc3cbf81fc9d7a4c7873b7dc0.stex"
 
+[deps]
+
+source_file="res://plankpin.png"
+source_md5="ac4e469b71f5d466f8212f0d6c8ca7aa"
+
+dest_files=[ "res://.import/plankpin.png-5a03e8bdc3cbf81fc9d7a4c7873b7dc0.stex" ]
+dest_md5="99fa804f6514a65d1f533d80da8e54bf"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/robot_demo.png.import
+++ b/2d/physics_platformer/robot_demo.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/robot_demo.png-8502817e0037b3f31eaca3dae49dcfc5.stex"
 
+[deps]
+
+source_file="res://robot_demo.png"
+source_md5="2a19cb85548217b26700914bd42617b4"
+
+dest_files=[ "res://.import/robot_demo.png-8502817e0037b3f31eaca3dae49dcfc5.stex" ]
+dest_md5="a8591e098e3f1315468e7318da46cbb7"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/scroll_bg_cloud_1.png.import
+++ b/2d/physics_platformer/scroll_bg_cloud_1.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_cloud_1.png-bad76c04aedb60c1b863fc1c1c6387ee.stex"
 
+[deps]
+
+source_file="res://scroll_bg_cloud_1.png"
+source_md5="469ececd0862fb9ee972f4c9afa833e5"
+
+dest_files=[ "res://.import/scroll_bg_cloud_1.png-bad76c04aedb60c1b863fc1c1c6387ee.stex" ]
+dest_md5="2bafbc3854a3abad3d1464c5793f5815"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/scroll_bg_cloud_2.png.import
+++ b/2d/physics_platformer/scroll_bg_cloud_2.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_cloud_2.png-cb251e8e91cb5450d56a9d0584943db0.stex"
 
+[deps]
+
+source_file="res://scroll_bg_cloud_2.png"
+source_md5="5acccab15a17f158a267e2cbf2c8d037"
+
+dest_files=[ "res://.import/scroll_bg_cloud_2.png-cb251e8e91cb5450d56a9d0584943db0.stex" ]
+dest_md5="a8e0aaff2215a5fc5c4e98ac28cc7158"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/scroll_bg_cloud_3.png.import
+++ b/2d/physics_platformer/scroll_bg_cloud_3.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_cloud_3.png-6bbd67870db2f55a0c1b4685aa91e57c.stex"
 
+[deps]
+
+source_file="res://scroll_bg_cloud_3.png"
+source_md5="b5e117acfbd6979087b6ac12f030bfcb"
+
+dest_files=[ "res://.import/scroll_bg_cloud_3.png-6bbd67870db2f55a0c1b4685aa91e57c.stex" ]
+dest_md5="156719b40a3d6eeb72c9992c371e9e06"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/scroll_bg_fg_1.png.import
+++ b/2d/physics_platformer/scroll_bg_fg_1.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_fg_1.png-af0d9d2847aea6e03f54efcc2d9b6f06.stex"
 
+[deps]
+
+source_file="res://scroll_bg_fg_1.png"
+source_md5="7b7b3b723bb49a3c3794fb11d24d7600"
+
+dest_files=[ "res://.import/scroll_bg_fg_1.png-af0d9d2847aea6e03f54efcc2d9b6f06.stex" ]
+dest_md5="870592f1c5cb451e3b9b101d1f0f3cf2"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/scroll_bg_fg_2.png.import
+++ b/2d/physics_platformer/scroll_bg_fg_2.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_fg_2.png-2419a5b3b81617ba71d0ad50d23bf6f1.stex"
 
+[deps]
+
+source_file="res://scroll_bg_fg_2.png"
+source_md5="4e0e7290a3706ac8b25a9cdcdcd86a22"
+
+dest_files=[ "res://.import/scroll_bg_fg_2.png-2419a5b3b81617ba71d0ad50d23bf6f1.stex" ]
+dest_md5="c8ac2a13834166a1e6089723cff0b7e6"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/scroll_bg_sky.png.import
+++ b/2d/physics_platformer/scroll_bg_sky.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_sky.png-df3e8b7d076f566a7bd83c6d4f9b57cf.stex"
 
+[deps]
+
+source_file="res://scroll_bg_sky.png"
+source_md5="8bd7da5f8f7bde4409890946fa92d678"
+
+dest_files=[ "res://.import/scroll_bg_sky.png-df3e8b7d076f566a7bd83c6d4f9b57cf.stex" ]
+dest_md5="78e807a4df94f72516cc399479809e5a"
+
 [params]
 
 compress/mode=0

--- a/2d/physics_platformer/sound_coin.wav.import
+++ b/2d/physics_platformer/sound_coin.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_coin.wav-b4defacd1a1eab95585c7b5095506878.sample"
 
+[deps]
+
+source_file="res://sound_coin.wav"
+source_md5="c9b8b4e85a53ce0e7add721a872d0479"
+
+dest_files=[ "res://.import/sound_coin.wav-b4defacd1a1eab95585c7b5095506878.sample" ]
+dest_md5="e5a76bfdb2a7b57010209e1a78e45030"
+
 [params]
 
 force/8_bit=false

--- a/2d/physics_platformer/sound_explode.wav.import
+++ b/2d/physics_platformer/sound_explode.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_explode.wav-23e94be75a4346bffb517c7e07035977.sample"
 
+[deps]
+
+source_file="res://sound_explode.wav"
+source_md5="c49bffd6268c2fb061a578c559fbd988"
+
+dest_files=[ "res://.import/sound_explode.wav-23e94be75a4346bffb517c7e07035977.sample" ]
+dest_md5="51dec829415973af026f4966d5e5d65a"
+
 [params]
 
 force/8_bit=false

--- a/2d/physics_platformer/sound_hit.wav.import
+++ b/2d/physics_platformer/sound_hit.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_hit.wav-d8455980ada2d4a9a73508948d7317cc.sample"
 
+[deps]
+
+source_file="res://sound_hit.wav"
+source_md5="ce60125d5b1639a3b88d652aea6ca0c3"
+
+dest_files=[ "res://.import/sound_hit.wav-d8455980ada2d4a9a73508948d7317cc.sample" ]
+dest_md5="e433fcac326cc1a2c8dc44d629790a7d"
+
 [params]
 
 force/8_bit=false

--- a/2d/physics_platformer/sound_jump.wav.import
+++ b/2d/physics_platformer/sound_jump.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_jump.wav-4966d1f327e26a176b56ab335c03b5e1.sample"
 
+[deps]
+
+source_file="res://sound_jump.wav"
+source_md5="f15f2f75683475fb46217cb108a91d44"
+
+dest_files=[ "res://.import/sound_jump.wav-4966d1f327e26a176b56ab335c03b5e1.sample" ]
+dest_md5="d93302188764fedd122195b34b711ceb"
+
 [params]
 
 force/8_bit=false

--- a/2d/physics_platformer/sound_shoot.wav.import
+++ b/2d/physics_platformer/sound_shoot.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_shoot.wav-f0f26619cba21d411b53ad23b8788116.sample"
 
+[deps]
+
+source_file="res://sound_shoot.wav"
+source_md5="5c1909840119124623da414167fad697"
+
+dest_files=[ "res://.import/sound_shoot.wav-f0f26619cba21d411b53ad23b8788116.sample" ]
+dest_md5="8c33ecb945ea94e05e6be5ee5a7b0c6b"
+
 [params]
 
 force/8_bit=false

--- a/2d/physics_platformer/tiles_demo.png.import
+++ b/2d/physics_platformer/tiles_demo.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/tiles_demo.png-7ca5c7c5c02ab8abe0d585a6a8f086bd.stex"
 
+[deps]
+
+source_file="res://tiles_demo.png"
+source_md5="34392fef9536a0df0c258a8cba521bf3"
+
+dest_files=[ "res://.import/tiles_demo.png-7ca5c7c5c02ab8abe0d585a6a8f086bd.stex" ]
+dest_md5="50bcf4fa0ff63c13469a9f9bba31f1a4"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/bullet.png.import
+++ b/2d/platformer/bullet.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/bullet.png-ff1424653e10246c11e3724e402c519e.stex"
 
+[deps]
+
+source_file="res://bullet.png"
+source_md5="9fe43d82e09598fc96be75bcf60df249"
+
+dest_files=[ "res://.import/bullet.png-ff1424653e10246c11e3724e402c519e.stex" ]
+dest_md5="441db1f0cf2701a43ee3ec6fcf10fc41"
+
 [params]
 
 compress/mode=3

--- a/2d/platformer/coin.png.import
+++ b/2d/platformer/coin.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/coin.png-7e710de472b75b3653c3283ef5153eb4.stex"
 
+[deps]
+
+source_file="res://coin.png"
+source_md5="e222f7ea0cf168c4da9b5beff4035f2c"
+
+dest_files=[ "res://.import/coin.png-7e710de472b75b3653c3283ef5153eb4.stex" ]
+dest_md5="c029cc68ec2da7c23bf6bc76055a8399"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/enemy.png.import
+++ b/2d/platformer/enemy.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/enemy.png-f7d9f81714867a24a08e299bb600e611.stex"
 
+[deps]
+
+source_file="res://enemy.png"
+source_md5="42bb3a8005fffb91c993fbb55e798d1d"
+
+dest_files=[ "res://.import/enemy.png-f7d9f81714867a24a08e299bb600e611.stex" ]
+dest_md5="b5dd9d2c4c2d679d2fd9cc6bd60db4a2"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/icon.png.import
+++ b/2d/platformer/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="059cf00427ccbf40878c582845360337"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="41a62e78fba2a38eac650b96d4963e54"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/moving_platform.png.import
+++ b/2d/platformer/moving_platform.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/moving_platform.png-1ef2f9fd1684df90d6ad38a267c1201b.stex"
 
+[deps]
+
+source_file="res://moving_platform.png"
+source_md5="5b9fb03128b6249a94e3af4976d65033"
+
+dest_files=[ "res://.import/moving_platform.png-1ef2f9fd1684df90d6ad38a267c1201b.stex" ]
+dest_md5="1b8e7060e89b4f682cc0e5df69b74574"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/music.ogg.import
+++ b/2d/platformer/music.ogg.import
@@ -4,6 +4,14 @@ importer="ogg_vorbis"
 type="AudioStreamOGGVorbis"
 path="res://.import/music.ogg-3bd46d3a4b41702b152014078d12a390.oggstr"
 
+[deps]
+
+source_file="res://music.ogg"
+source_md5="ac01d521c92ce9d01cf09826bd3addbf"
+
+dest_files=[ "res://.import/music.ogg-3bd46d3a4b41702b152014078d12a390.oggstr" ]
+dest_md5="8f49ec9ebb932a81e74cb040e2a26d5f"
+
 [params]
 
 loop=true

--- a/2d/platformer/one_way_platform.png.import
+++ b/2d/platformer/one_way_platform.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/one_way_platform.png-af40161497fd0e8bfbc5d400c8bd650a.stex"
 
+[deps]
+
+source_file="res://one_way_platform.png"
+source_md5="94d5d85de357d84b918ac588b8bd6a8d"
+
+dest_files=[ "res://.import/one_way_platform.png-af40161497fd0e8bfbc5d400c8bd650a.stex" ]
+dest_md5="fc01b5aa5c5312405b6180a76d05200c"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/osb_fire.png.import
+++ b/2d/platformer/osb_fire.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_fire.png-e657a73546eb75918e9d9a3fea15cf70.stex"
 
+[deps]
+
+source_file="res://osb_fire.png"
+source_md5="99a276197ee76a83312af783f33f0ab3"
+
+dest_files=[ "res://.import/osb_fire.png-e657a73546eb75918e9d9a3fea15cf70.stex" ]
+dest_md5="6a322e882c9dc02ebfaa6f88e228f6fe"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/osb_jump.png.import
+++ b/2d/platformer/osb_jump.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_jump.png-dbbef3b47abbb562ce6c81a9701121c6.stex"
 
+[deps]
+
+source_file="res://osb_jump.png"
+source_md5="ac3e3adf52903de07cff73354f63896c"
+
+dest_files=[ "res://.import/osb_jump.png-dbbef3b47abbb562ce6c81a9701121c6.stex" ]
+dest_md5="dadb0fd2527ced2e0592b8d84687d463"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/osb_left.png.import
+++ b/2d/platformer/osb_left.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_left.png-fc7230aeb0eec74933ed08f89b893288.stex"
 
+[deps]
+
+source_file="res://osb_left.png"
+source_md5="ce066828ec6ef27c9ce3809341574058"
+
+dest_files=[ "res://.import/osb_left.png-fc7230aeb0eec74933ed08f89b893288.stex" ]
+dest_md5="f1204f132a121270977d3db6b3833c2e"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/osb_right.png.import
+++ b/2d/platformer/osb_right.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_right.png-5cf5add2dbc1c8dde17173ac56f3a004.stex"
 
+[deps]
+
+source_file="res://osb_right.png"
+source_md5="860560d5e66ccd837973fbbde7eb958f"
+
+dest_files=[ "res://.import/osb_right.png-5cf5add2dbc1c8dde17173ac56f3a004.stex" ]
+dest_md5="53dbe913ca4af3c548217038b3b6b7de"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/robot_demo.png.import
+++ b/2d/platformer/robot_demo.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/robot_demo.png-8502817e0037b3f31eaca3dae49dcfc5.stex"
 
+[deps]
+
+source_file="res://robot_demo.png"
+source_md5="2a19cb85548217b26700914bd42617b4"
+
+dest_files=[ "res://.import/robot_demo.png-8502817e0037b3f31eaca3dae49dcfc5.stex" ]
+dest_md5="070eb843a3e7fbd77ae02e22a0190c54"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/scroll_bg_cloud_1.png.import
+++ b/2d/platformer/scroll_bg_cloud_1.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_cloud_1.png-bad76c04aedb60c1b863fc1c1c6387ee.stex"
 
+[deps]
+
+source_file="res://scroll_bg_cloud_1.png"
+source_md5="469ececd0862fb9ee972f4c9afa833e5"
+
+dest_files=[ "res://.import/scroll_bg_cloud_1.png-bad76c04aedb60c1b863fc1c1c6387ee.stex" ]
+dest_md5="37255df31e22594ad1c9dc765be60b4e"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/scroll_bg_cloud_2.png.import
+++ b/2d/platformer/scroll_bg_cloud_2.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_cloud_2.png-cb251e8e91cb5450d56a9d0584943db0.stex"
 
+[deps]
+
+source_file="res://scroll_bg_cloud_2.png"
+source_md5="5acccab15a17f158a267e2cbf2c8d037"
+
+dest_files=[ "res://.import/scroll_bg_cloud_2.png-cb251e8e91cb5450d56a9d0584943db0.stex" ]
+dest_md5="99986e2aacf77e0243ac594877e65af2"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/scroll_bg_cloud_3.png.import
+++ b/2d/platformer/scroll_bg_cloud_3.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_cloud_3.png-6bbd67870db2f55a0c1b4685aa91e57c.stex"
 
+[deps]
+
+source_file="res://scroll_bg_cloud_3.png"
+source_md5="b5e117acfbd6979087b6ac12f030bfcb"
+
+dest_files=[ "res://.import/scroll_bg_cloud_3.png-6bbd67870db2f55a0c1b4685aa91e57c.stex" ]
+dest_md5="3f2a1b5817369909200dd83ff99265e9"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/scroll_bg_fg_1.png.import
+++ b/2d/platformer/scroll_bg_fg_1.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_fg_1.png-af0d9d2847aea6e03f54efcc2d9b6f06.stex"
 
+[deps]
+
+source_file="res://scroll_bg_fg_1.png"
+source_md5="27792a0e523d6009f00b02b495ed577a"
+
+dest_files=[ "res://.import/scroll_bg_fg_1.png-af0d9d2847aea6e03f54efcc2d9b6f06.stex" ]
+dest_md5="02ce953a24b02bfc10ee9491a276041a"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/scroll_bg_fg_2.png.import
+++ b/2d/platformer/scroll_bg_fg_2.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_fg_2.png-2419a5b3b81617ba71d0ad50d23bf6f1.stex"
 
+[deps]
+
+source_file="res://scroll_bg_fg_2.png"
+source_md5="0a4fca6ccb08f3673b208b2730138413"
+
+dest_files=[ "res://.import/scroll_bg_fg_2.png-2419a5b3b81617ba71d0ad50d23bf6f1.stex" ]
+dest_md5="c90197251b52fbb36f4bde85bfa9a424"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/scroll_bg_sky.png.import
+++ b/2d/platformer/scroll_bg_sky.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/scroll_bg_sky.png-df3e8b7d076f566a7bd83c6d4f9b57cf.stex"
 
+[deps]
+
+source_file="res://scroll_bg_sky.png"
+source_md5="98017e52a97035ac8cece7bf2e9c7022"
+
+dest_files=[ "res://.import/scroll_bg_sky.png-df3e8b7d076f566a7bd83c6d4f9b57cf.stex" ]
+dest_md5="fe52a91404b775bdab02d228e5b0d75c"
+
 [params]
 
 compress/mode=0

--- a/2d/platformer/sound_coin.wav.import
+++ b/2d/platformer/sound_coin.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_coin.wav-b4defacd1a1eab95585c7b5095506878.sample"
 
+[deps]
+
+source_file="res://sound_coin.wav"
+source_md5="c9b8b4e85a53ce0e7add721a872d0479"
+
+dest_files=[ "res://.import/sound_coin.wav-b4defacd1a1eab95585c7b5095506878.sample" ]
+dest_md5="bc48ea50ea226e68d159c771a7b6c318"
+
 [params]
 
 force/8_bit=false

--- a/2d/platformer/sound_explode.wav.import
+++ b/2d/platformer/sound_explode.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_explode.wav-23e94be75a4346bffb517c7e07035977.sample"
 
+[deps]
+
+source_file="res://sound_explode.wav"
+source_md5="c49bffd6268c2fb061a578c559fbd988"
+
+dest_files=[ "res://.import/sound_explode.wav-23e94be75a4346bffb517c7e07035977.sample" ]
+dest_md5="f1c1ea6486e70e5f621672683eea6d33"
+
 [params]
 
 force/8_bit=false

--- a/2d/platformer/sound_hit.wav.import
+++ b/2d/platformer/sound_hit.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_hit.wav-d8455980ada2d4a9a73508948d7317cc.sample"
 
+[deps]
+
+source_file="res://sound_hit.wav"
+source_md5="ce60125d5b1639a3b88d652aea6ca0c3"
+
+dest_files=[ "res://.import/sound_hit.wav-d8455980ada2d4a9a73508948d7317cc.sample" ]
+dest_md5="9314e087578e39441eed950ef19f066a"
+
 [params]
 
 force/8_bit=false

--- a/2d/platformer/sound_jump.wav.import
+++ b/2d/platformer/sound_jump.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_jump.wav-4966d1f327e26a176b56ab335c03b5e1.sample"
 
+[deps]
+
+source_file="res://sound_jump.wav"
+source_md5="f15f2f75683475fb46217cb108a91d44"
+
+dest_files=[ "res://.import/sound_jump.wav-4966d1f327e26a176b56ab335c03b5e1.sample" ]
+dest_md5="d93302188764fedd122195b34b711ceb"
+
 [params]
 
 force/8_bit=false

--- a/2d/platformer/sound_shoot.wav.import
+++ b/2d/platformer/sound_shoot.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_shoot.wav-f0f26619cba21d411b53ad23b8788116.sample"
 
+[deps]
+
+source_file="res://sound_shoot.wav"
+source_md5="5c1909840119124623da414167fad697"
+
+dest_files=[ "res://.import/sound_shoot.wav-f0f26619cba21d411b53ad23b8788116.sample" ]
+dest_md5="8c33ecb945ea94e05e6be5ee5a7b0c6b"
+
 [params]
 
 force/8_bit=false

--- a/2d/platformer/tiles_demo.png.import
+++ b/2d/platformer/tiles_demo.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/tiles_demo.png-7ca5c7c5c02ab8abe0d585a6a8f086bd.stex"
 
+[deps]
+
+source_file="res://tiles_demo.png"
+source_md5="6ec267217d26ae9bec28a948ef2a2aec"
+
+dest_files=[ "res://.import/tiles_demo.png-7ca5c7c5c02ab8abe0d585a6a8f086bd.stex" ]
+dest_md5="bad5b7f4a678554dadd7a95695a76507"
+
 [params]
 
 compress/mode=0

--- a/2d/pong/ball.png.import
+++ b/2d/pong/ball.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex"
 
+[deps]
+
+source_file="res://ball.png"
+source_md5="4219e9084f5485c8d1812297700f317d"
+
+dest_files=[ "res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex" ]
+dest_md5="c23684a1fd10063a69ecc18f7ccca4c3"
+
 [params]
 
 compress/mode=0

--- a/2d/pong/icon.png.import
+++ b/2d/pong/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="9be177e863d37787c0836d64924b3503"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="6339016da0f704252e68ba6dd6477388"
+
 [params]
 
 compress/mode=0

--- a/2d/pong/left_pallete.png.import
+++ b/2d/pong/left_pallete.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/left_pallete.png-bc33611074a0f886142e37c77bd2545a.stex"
 
+[deps]
+
+source_file="res://left_pallete.png"
+source_md5="df76627349499ad47ebf48a7ca947cca"
+
+dest_files=[ "res://.import/left_pallete.png-bc33611074a0f886142e37c77bd2545a.stex" ]
+dest_md5="f286e993cb5a7b7513004045afcc4313"
+
 [params]
 
 compress/mode=0

--- a/2d/pong/right_pallete.png.import
+++ b/2d/pong/right_pallete.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/right_pallete.png-fc6e4a6a7c8197834656482b94708e47.stex"
 
+[deps]
+
+source_file="res://right_pallete.png"
+source_md5="d46f647d3f045dbee4d786089c309868"
+
+dest_files=[ "res://.import/right_pallete.png-fc6e4a6a7c8197834656482b94708e47.stex" ]
+dest_md5="5f8755f214bc8d4caf7c467291452637"
+
 [params]
 
 compress/mode=0

--- a/2d/pong/separator.png.import
+++ b/2d/pong/separator.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/separator.png-f981c8489b9148e2e1dc63398273da74.stex"
 
+[deps]
+
+source_file="res://separator.png"
+source_md5="b6234b89455156532bbe1256249fcfd4"
+
+dest_files=[ "res://.import/separator.png-f981c8489b9148e2e1dc63398273da74.stex" ]
+dest_md5="6e27251839594842494c6cd51e3b86cb"
+
 [params]
 
 compress/mode=0

--- a/2d/screen_space_shaders/art/burano.jpg.import
+++ b/2d/screen_space_shaders/art/burano.jpg.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/burano.jpg-bbae3c5a81f8b6300cd944219dbbbc05.stex"
 
+[deps]
+
+source_file="res://art/burano.jpg"
+source_md5="a7a43f4048c157e4180fadc2fb85500a"
+
+dest_files=[ "res://.import/burano.jpg-bbae3c5a81f8b6300cd944219dbbbc05.stex" ]
+dest_md5="7eac829bfd32310547f1ec1f64a2b6e1"
+
 [params]
 
 compress/mode=0

--- a/2d/screen_space_shaders/art/filmgrain.png.import
+++ b/2d/screen_space_shaders/art/filmgrain.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/filmgrain.png-8b1c9d8b22a2ffa8f94b1e004d5eddc9.s3tc.stex"
 path.etc2="res://.import/filmgrain.png-8b1c9d8b22a2ffa8f94b1e004d5eddc9.etc2.stex"
 
+[deps]
+
+source_file="res://art/filmgrain.png"
+source_md5="6e935b013571b36377b4f225746be5df"
+
+dest_files=[ "res://.import/filmgrain.png-8b1c9d8b22a2ffa8f94b1e004d5eddc9.s3tc.stex", "res://.import/filmgrain.png-8b1c9d8b22a2ffa8f94b1e004d5eddc9.etc2.stex" ]
+dest_md5="c0ae0627c5a3e2f284d0d36ceac850a9"
+
 [params]
 
 compress/mode=2

--- a/2d/screen_space_shaders/art/forest.jpg.import
+++ b/2d/screen_space_shaders/art/forest.jpg.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/forest.jpg-f2ce28f12b0871a15d1e9ebfcd24b47f.stex"
 
+[deps]
+
+source_file="res://art/forest.jpg"
+source_md5="a19424db1a6064ebc09c600ab2b0a0e8"
+
+dest_files=[ "res://.import/forest.jpg-f2ce28f12b0871a15d1e9ebfcd24b47f.stex" ]
+dest_md5="406ea3b480446997fd81be4e4b1e4589"
+
 [params]
 
 compress/mode=0

--- a/2d/screen_space_shaders/art/mountains.jpg.import
+++ b/2d/screen_space_shaders/art/mountains.jpg.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/mountains.jpg-fd51eb0e2a35878963804e860ef9d187.stex"
 
+[deps]
+
+source_file="res://art/mountains.jpg"
+source_md5="d2d89058d725456ef75987637c06a7c0"
+
+dest_files=[ "res://.import/mountains.jpg-fd51eb0e2a35878963804e860ef9d187.stex" ]
+dest_md5="0b74851a8390532635e9dcd70cf58e8c"
+
 [params]
 
 compress/mode=0

--- a/2d/screen_space_shaders/art/platformer.jpg.import
+++ b/2d/screen_space_shaders/art/platformer.jpg.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/platformer.jpg-ce18350247a11c58497c7e0d8e3be273.stex"
 
+[deps]
+
+source_file="res://art/platformer.jpg"
+source_md5="8ff2fb3bb2fe75e79d0812c4cc7f4380"
+
+dest_files=[ "res://.import/platformer.jpg-ce18350247a11c58497c7e0d8e3be273.stex" ]
+dest_md5="ed068c0fed8f318e84ce5371746bf6b3"
+
 [params]
 
 compress/mode=0

--- a/2d/screen_space_shaders/art/vignette.png.import
+++ b/2d/screen_space_shaders/art/vignette.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/vignette.png-993dbe0a69e475ef62cba692d80d947d.s3tc.stex"
 path.etc2="res://.import/vignette.png-993dbe0a69e475ef62cba692d80d947d.etc2.stex"
 
+[deps]
+
+source_file="res://art/vignette.png"
+source_md5="d430febbb0b34beb0fdf23da8fe91676"
+
+dest_files=[ "res://.import/vignette.png-993dbe0a69e475ef62cba692d80d947d.s3tc.stex", "res://.import/vignette.png-993dbe0a69e475ef62cba692d80d947d.etc2.stex" ]
+dest_md5="e545eac98bc8a28106968b5f7529dc8c"
+
 [params]
 
 compress/mode=2

--- a/2d/screen_space_shaders/art/white.png.import
+++ b/2d/screen_space_shaders/art/white.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/white.png-9cdc9524282ba2bce69b45edcd6ac827.stex"
 
+[deps]
+
+source_file="res://art/white.png"
+source_md5="b68844373120b3795a9b80a7922d0c76"
+
+dest_files=[ "res://.import/white.png-9cdc9524282ba2bce69b45edcd6ac827.stex" ]
+dest_md5="f17f3e225bc88873851ebd43ba696987"
+
 [params]
 
 compress/mode=0

--- a/2d/screen_space_shaders/icon.png.import
+++ b/2d/screen_space_shaders/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="7a9f231537559872f9c95e294e0024d8"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="ac2a005446207123eae90720f81b5c46"
+
 [params]
 
 compress/mode=0

--- a/3d/kinematic_character/kinebody3d.png.import
+++ b/3d/kinematic_character/kinebody3d.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/kinebody3d.png-13e5946de0ae5f65e359d6d81ccb14f1.stex"
 
+[deps]
+
+source_file="res://kinebody3d.png"
+source_md5="5eca5c1838fc1255a4ad6a0adf3f9948"
+
+dest_files=[ "res://.import/kinebody3d.png-13e5946de0ae5f65e359d6d81ccb14f1.stex" ]
+dest_md5="d510ae31bff93a498822d7d61bfd5b45"
+
 [params]
 
 compress/mode=0

--- a/3d/kinematic_character/purple_wood.png.import
+++ b/3d/kinematic_character/purple_wood.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/purple_wood.png-ae65a206e7a59edf759728c3bad04e56.s3tc.stex"
 path.etc2="res://.import/purple_wood.png-ae65a206e7a59edf759728c3bad04e56.etc2.stex"
 
+[deps]
+
+source_file="res://purple_wood.png"
+source_md5="eaf661fce293648f914ea742cf66b535"
+
+dest_files=[ "res://.import/purple_wood.png-ae65a206e7a59edf759728c3bad04e56.s3tc.stex", "res://.import/purple_wood.png-ae65a206e7a59edf759728c3bad04e56.etc2.stex" ]
+dest_md5="ae0c38d6b330596dbb9257e9bed1d6a7"
+
 [params]
 
 compress/mode=2

--- a/3d/kinematic_character/white_wood.png.import
+++ b/3d/kinematic_character/white_wood.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/white_wood.png-6895acd60ce97b4315494d2be377c357.s3tc.stex"
 path.etc2="res://.import/white_wood.png-6895acd60ce97b4315494d2be377c357.etc2.stex"
 
+[deps]
+
+source_file="res://white_wood.png"
+source_md5="4565f03f9b3e5ea8bbd492559e733a35"
+
+dest_files=[ "res://.import/white_wood.png-6895acd60ce97b4315494d2be377c357.s3tc.stex", "res://.import/white_wood.png-6895acd60ce97b4315494d2be377c357.etc2.stex" ]
+dest_md5="6e02a3d6e2e6c5c82a8a85db38bbb708"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/GodotBall.dae.import
+++ b/3d/material_testers/GodotBall.dae.import
@@ -4,10 +4,19 @@ importer="scene"
 type="PackedScene"
 path="res://.import/GodotBall.dae-7d94ed6d65f13de1df930390992b739e.scn"
 
+[deps]
+
+source_file="res://GodotBall.dae"
+source_md5="59e883011fb80841747f9c062a298e73"
+
+dest_files=[ "res://.import/GodotBall.dae-7d94ed6d65f13de1df930390992b739e.scn" ]
+dest_md5="a12f9bb9a7d8091a3dbbfb06e9cc1106"
+
 [params]
 
 nodes/root_type="Spatial"
 nodes/root_name="Scene Root"
+nodes/root_scale=1.0
 nodes/custom_script=""
 nodes/storage=0
 materials/location=0
@@ -16,11 +25,14 @@ materials/keep_on_reimport=false
 meshes/compress=true
 meshes/ensure_tangents=true
 meshes/storage=false
+meshes/light_baking=0
+meshes/lightmap_texel_size=0.1
 external_files/store_in_subdir=true
 animation/import=true
 animation/fps=15
 animation/filter_script=""
 animation/storage=false
+animation/keep_custom_tracks=false
 animation/optimizer/enabled=true
 animation/optimizer/max_linear_error=0.05
 animation/optimizer/max_angular_error=0.01

--- a/3d/material_testers/aluminium_albedo.png.import
+++ b/3d/material_testers/aluminium_albedo.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/aluminium_albedo.png-8465e536e9f8dfa1137257f84f2b50f4.s3tc.stex"
 path.etc2="res://.import/aluminium_albedo.png-8465e536e9f8dfa1137257f84f2b50f4.etc2.stex"
 
+[deps]
+
+source_file="res://aluminium_albedo.png"
+source_md5="378f2256b1be80610f0371d39d45f460"
+
+dest_files=[ "res://.import/aluminium_albedo.png-8465e536e9f8dfa1137257f84f2b50f4.s3tc.stex", "res://.import/aluminium_albedo.png-8465e536e9f8dfa1137257f84f2b50f4.etc2.stex" ]
+dest_md5="fe471e303a5bf03214d816a92e665e8c"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/aluminium_flow.png.import
+++ b/3d/material_testers/aluminium_flow.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/aluminium_flow.png-a53868607847a6b19b83857fdf27ef17.s3tc.stex"
 path.etc2="res://.import/aluminium_flow.png-a53868607847a6b19b83857fdf27ef17.etc2.stex"
 
+[deps]
+
+source_file="res://aluminium_flow.png"
+source_md5="756bcb7700ae85303955842cf3a4453d"
+
+dest_files=[ "res://.import/aluminium_flow.png-a53868607847a6b19b83857fdf27ef17.s3tc.stex", "res://.import/aluminium_flow.png-a53868607847a6b19b83857fdf27ef17.etc2.stex" ]
+dest_md5="cb9f054f74621732102677ece7c05742"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/aluminium_normal.png.import
+++ b/3d/material_testers/aluminium_normal.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/aluminium_normal.png-8309c0de24d2619ec41813ca11bcfa8e.s3tc.stex"
 path.etc2="res://.import/aluminium_normal.png-8309c0de24d2619ec41813ca11bcfa8e.etc2.stex"
 
+[deps]
+
+source_file="res://aluminium_normal.png"
+source_md5="1146678f290558611b5bb82b03779ddf"
+
+dest_files=[ "res://.import/aluminium_normal.png-8309c0de24d2619ec41813ca11bcfa8e.s3tc.stex", "res://.import/aluminium_normal.png-8309c0de24d2619ec41813ca11bcfa8e.etc2.stex" ]
+dest_md5="c3feb8349929d76350a83dafed13eb6b"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/experiment.hdr.import
+++ b/3d/material_testers/experiment.hdr.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/experiment.hdr-9c87b674db59b87ae6c71d507945718a.stex"
 
+[deps]
+
+source_file="res://experiment.hdr"
+source_md5="8c6f3023a090d344d4f617d41410e4b5"
+
+dest_files=[ "res://.import/experiment.hdr-9c87b674db59b87ae6c71d507945718a.stex" ]
+dest_md5="1e589860cb8e18e20668d37418d60882"
+
 [params]
 
 compress/mode=0

--- a/3d/material_testers/lobby.hdr.import
+++ b/3d/material_testers/lobby.hdr.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/lobby.hdr-19eeb77528a0be82c97b317aa865de05.stex"
 
+[deps]
+
+source_file="res://lobby.hdr"
+source_md5="c79723e7be17c3cf51a2e401f02dc073"
+
+dest_files=[ "res://.import/lobby.hdr-19eeb77528a0be82c97b317aa865de05.stex" ]
+dest_md5="dba7ac181d39808d30d3b51611ea6f78"
+
 [params]
 
 compress/mode=0

--- a/3d/material_testers/marble_albedo.png.import
+++ b/3d/material_testers/marble_albedo.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/marble_albedo.png-330de4517eeff8f0c0a9a19d8035b409.s3tc.stex"
 path.etc2="res://.import/marble_albedo.png-330de4517eeff8f0c0a9a19d8035b409.etc2.stex"
 
+[deps]
+
+source_file="res://marble_albedo.png"
+source_md5="4e85eb345518883c1b1dc44c76f9281b"
+
+dest_files=[ "res://.import/marble_albedo.png-330de4517eeff8f0c0a9a19d8035b409.s3tc.stex", "res://.import/marble_albedo.png-330de4517eeff8f0c0a9a19d8035b409.etc2.stex" ]
+dest_md5="20bc858c4f781f26f0afd548a1bc90a1"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/night.hdr.import
+++ b/3d/material_testers/night.hdr.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/night.hdr-332f5acd8584ef56a1a6547f38a69ed0.stex"
 
+[deps]
+
+source_file="res://night.hdr"
+source_md5="f0ab059238055a2b53e13bf13784d9b1"
+
+dest_files=[ "res://.import/night.hdr-332f5acd8584ef56a1a6547f38a69ed0.stex" ]
+dest_md5="7d3919ef1811d64b3e7e8b9947fa0bf9"
+
 [params]
 
 compress/mode=0

--- a/3d/material_testers/park.hdr.import
+++ b/3d/material_testers/park.hdr.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/park.hdr-5bf7587b9d6b1215ad5e0650ef813289.stex"
 
+[deps]
+
+source_file="res://park.hdr"
+source_md5="bb49bd487d84bf7476b31e644bb551ba"
+
+dest_files=[ "res://.import/park.hdr-5bf7587b9d6b1215ad5e0650ef813289.stex" ]
+dest_md5="0020e457143736a2e8c4f166366e019c"
+
 [params]
 
 compress/mode=0

--- a/3d/material_testers/pbr_bed.dae.import
+++ b/3d/material_testers/pbr_bed.dae.import
@@ -4,10 +4,19 @@ importer="scene"
 type="PackedScene"
 path="res://.import/pbr_bed.dae-a65f6f39b6a66a5680aec6e4308d1465.scn"
 
+[deps]
+
+source_file="res://pbr_bed.dae"
+source_md5="0c9a339a82c621a1da01b86a64b2e3ce"
+
+dest_files=[ "res://.import/pbr_bed.dae-a65f6f39b6a66a5680aec6e4308d1465.scn" ]
+dest_md5="7b79253562fdbd1697e491219ee54dfc"
+
 [params]
 
 nodes/root_type="Spatial"
 nodes/root_name="Scene Root"
+nodes/root_scale=1.0
 nodes/custom_script=""
 nodes/storage=0
 materials/location=0
@@ -16,11 +25,14 @@ materials/keep_on_reimport=false
 meshes/compress=true
 meshes/ensure_tangents=true
 meshes/storage=false
+meshes/light_baking=0
+meshes/lightmap_texel_size=0.1
 external_files/store_in_subdir=true
 animation/import=true
 animation/fps=15
 animation/filter_script=""
 animation/storage=false
+animation/keep_custom_tracks=false
 animation/optimizer/enabled=true
 animation/optimizer/max_linear_error=0.05
 animation/optimizer/max_angular_error=0.01

--- a/3d/material_testers/rock_albedo.jpg.import
+++ b/3d/material_testers/rock_albedo.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/rock_albedo.jpg-22e9a32a083cfcfc2f4fff95187a039c.s3tc.stex"
 path.etc2="res://.import/rock_albedo.jpg-22e9a32a083cfcfc2f4fff95187a039c.etc2.stex"
 
+[deps]
+
+source_file="res://rock_albedo.jpg"
+source_md5="7201ca706e99fd03c063ad83d14585ef"
+
+dest_files=[ "res://.import/rock_albedo.jpg-22e9a32a083cfcfc2f4fff95187a039c.s3tc.stex", "res://.import/rock_albedo.jpg-22e9a32a083cfcfc2f4fff95187a039c.etc2.stex" ]
+dest_md5="8b2ad9b36409512e5c5e82647cf718e1"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/rock_ao.jpg.import
+++ b/3d/material_testers/rock_ao.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/rock_ao.jpg-6d1ea370b7a8387d8adc07e245cfd5aa.s3tc.stex"
 path.etc2="res://.import/rock_ao.jpg-6d1ea370b7a8387d8adc07e245cfd5aa.etc2.stex"
 
+[deps]
+
+source_file="res://rock_ao.jpg"
+source_md5="2476843b97c02d87515f5df97cac30ae"
+
+dest_files=[ "res://.import/rock_ao.jpg-6d1ea370b7a8387d8adc07e245cfd5aa.s3tc.stex", "res://.import/rock_ao.jpg-6d1ea370b7a8387d8adc07e245cfd5aa.etc2.stex" ]
+dest_md5="9a3c821dce6bc658dc2967aa1ce43d25"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/rock_depth.jpg.import
+++ b/3d/material_testers/rock_depth.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/rock_depth.jpg-b10a74f6c8987f92932ee2f3637dce4e.s3tc.stex"
 path.etc2="res://.import/rock_depth.jpg-b10a74f6c8987f92932ee2f3637dce4e.etc2.stex"
 
+[deps]
+
+source_file="res://rock_depth.jpg"
+source_md5="bb828bf59728f5ebb2750a7ac6d21c35"
+
+dest_files=[ "res://.import/rock_depth.jpg-b10a74f6c8987f92932ee2f3637dce4e.s3tc.stex", "res://.import/rock_depth.jpg-b10a74f6c8987f92932ee2f3637dce4e.etc2.stex" ]
+dest_md5="1b9e6d282292a95fdcd4037a9813d480"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/rock_metal.jpg.import
+++ b/3d/material_testers/rock_metal.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/rock_metal.jpg-5af21640ab618fdf5d03595166e2bdc4.s3tc.stex"
 path.etc2="res://.import/rock_metal.jpg-5af21640ab618fdf5d03595166e2bdc4.etc2.stex"
 
+[deps]
+
+source_file="res://rock_metal.jpg"
+source_md5="1fb20f71334fc6c58c80e295036e3f75"
+
+dest_files=[ "res://.import/rock_metal.jpg-5af21640ab618fdf5d03595166e2bdc4.s3tc.stex", "res://.import/rock_metal.jpg-5af21640ab618fdf5d03595166e2bdc4.etc2.stex" ]
+dest_md5="10238b4913a966baf3f86bb7ffa36d9b"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/rock_rough.jpg.import
+++ b/3d/material_testers/rock_rough.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/rock_rough.jpg-4dc5db109393ce22de7ba90bc6555451.s3tc.stex"
 path.etc2="res://.import/rock_rough.jpg-4dc5db109393ce22de7ba90bc6555451.etc2.stex"
 
+[deps]
+
+source_file="res://rock_rough.jpg"
+source_md5="d9f9c43214c2bddf430b04abec201dd2"
+
+dest_files=[ "res://.import/rock_rough.jpg-4dc5db109393ce22de7ba90bc6555451.s3tc.stex", "res://.import/rock_rough.jpg-4dc5db109393ce22de7ba90bc6555451.etc2.stex" ]
+dest_md5="61468d6bc67d4e9f19e2725c64de5743"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/sand_albedo.jpg.import
+++ b/3d/material_testers/sand_albedo.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/sand_albedo.jpg-2e96d28fbd6ccbeedf02aa2d2eaeb3c7.s3tc.stex"
 path.etc2="res://.import/sand_albedo.jpg-2e96d28fbd6ccbeedf02aa2d2eaeb3c7.etc2.stex"
 
+[deps]
+
+source_file="res://sand_albedo.jpg"
+source_md5="409f981563cabc094ec8d7736aa8c1f0"
+
+dest_files=[ "res://.import/sand_albedo.jpg-2e96d28fbd6ccbeedf02aa2d2eaeb3c7.s3tc.stex", "res://.import/sand_albedo.jpg-2e96d28fbd6ccbeedf02aa2d2eaeb3c7.etc2.stex" ]
+dest_md5="bf097cfaeff84480a2603ca46e58ee08"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/sand_metal.jpg.import
+++ b/3d/material_testers/sand_metal.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/sand_metal.jpg-d878e561d91ca01991af7855a718f32f.s3tc.stex"
 path.etc2="res://.import/sand_metal.jpg-d878e561d91ca01991af7855a718f32f.etc2.stex"
 
+[deps]
+
+source_file="res://sand_metal.jpg"
+source_md5="00ce653bb63fe274a5a508438a06e007"
+
+dest_files=[ "res://.import/sand_metal.jpg-d878e561d91ca01991af7855a718f32f.s3tc.stex", "res://.import/sand_metal.jpg-d878e561d91ca01991af7855a718f32f.etc2.stex" ]
+dest_md5="4e4b89cebd9afbe9284b750cc4669268"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/sand_normal.jpg.import
+++ b/3d/material_testers/sand_normal.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/sand_normal.jpg-301374b7038f7e6f751f04aa77042dad.s3tc.stex"
 path.etc2="res://.import/sand_normal.jpg-301374b7038f7e6f751f04aa77042dad.etc2.stex"
 
+[deps]
+
+source_file="res://sand_normal.jpg"
+source_md5="db7ba80780dda5777fa6dc94a7f806a9"
+
+dest_files=[ "res://.import/sand_normal.jpg-301374b7038f7e6f751f04aa77042dad.s3tc.stex", "res://.import/sand_normal.jpg-301374b7038f7e6f751f04aa77042dad.etc2.stex" ]
+dest_md5="95279b4395868fe13566557a8ea7abc4"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/sand_rough.jpg.import
+++ b/3d/material_testers/sand_rough.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/sand_rough.jpg-c65a80e64c890f26dbcd777854758cb8.s3tc.stex"
 path.etc2="res://.import/sand_rough.jpg-c65a80e64c890f26dbcd777854758cb8.etc2.stex"
 
+[deps]
+
+source_file="res://sand_rough.jpg"
+source_md5="d2b1aa116cc59f3fad1e9ee7228f4dba"
+
+dest_files=[ "res://.import/sand_rough.jpg-c65a80e64c890f26dbcd777854758cb8.s3tc.stex", "res://.import/sand_rough.jpg-c65a80e64c890f26dbcd777854758cb8.etc2.stex" ]
+dest_md5="9daaa784f2dd4ed3871ad5c193732b9a"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/sand_shine.jpg.import
+++ b/3d/material_testers/sand_shine.jpg.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/sand_shine.jpg-1052c3ef1aff28138658d353fe42fa08.stex"
 
+[deps]
+
+source_file="res://sand_shine.jpg"
+source_md5="1fa3b19cc14721d1a473c35c8570e6ec"
+
+dest_files=[ "res://.import/sand_shine.jpg-1052c3ef1aff28138658d353fe42fa08.stex" ]
+dest_md5="5fa2f9125c34e94bab7253cf6e02b5ac"
+
 [params]
 
 compress/mode=0

--- a/3d/material_testers/schelde.hdr.import
+++ b/3d/material_testers/schelde.hdr.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/schelde.hdr-70b608d92e301bcc05f9a0a8b999832a.stex"
 
+[deps]
+
+source_file="res://schelde.hdr"
+source_md5="17fb32283c17aa2fd51540914a69b0ce"
+
+dest_files=[ "res://.import/schelde.hdr-70b608d92e301bcc05f9a0a8b999832a.stex" ]
+dest_md5="16edea935d7a7933515139fb4b861227"
+
 [params]
 
 compress/mode=0

--- a/3d/material_testers/texture_bricks.jpg.import
+++ b/3d/material_testers/texture_bricks.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_bricks.jpg-d3b343aa38aee9a6b0951e00d08ac2ac.s3tc.stex"
 path.etc2="res://.import/texture_bricks.jpg-d3b343aa38aee9a6b0951e00d08ac2ac.etc2.stex"
 
+[deps]
+
+source_file="res://texture_bricks.jpg"
+source_md5="a195b516e46de6804c17dedc6c3b58bd"
+
+dest_files=[ "res://.import/texture_bricks.jpg-d3b343aa38aee9a6b0951e00d08ac2ac.s3tc.stex", "res://.import/texture_bricks.jpg-d3b343aa38aee9a6b0951e00d08ac2ac.etc2.stex" ]
+dest_md5="93326519cbcbf8049cace33730ebf0ae"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_bricks_depth.jpg.import
+++ b/3d/material_testers/texture_bricks_depth.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_bricks_depth.jpg-b725221b03775ad5fda51e36c8539693.s3tc.stex"
 path.etc2="res://.import/texture_bricks_depth.jpg-b725221b03775ad5fda51e36c8539693.etc2.stex"
 
+[deps]
+
+source_file="res://texture_bricks_depth.jpg"
+source_md5="8fdc6769db0ce2eaabdd0cff91e8704a"
+
+dest_files=[ "res://.import/texture_bricks_depth.jpg-b725221b03775ad5fda51e36c8539693.s3tc.stex", "res://.import/texture_bricks_depth.jpg-b725221b03775ad5fda51e36c8539693.etc2.stex" ]
+dest_md5="28f7bdcdc3c77d18b91c01de5493f027"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_bricks_metal.jpg.import
+++ b/3d/material_testers/texture_bricks_metal.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_bricks_metal.jpg-432f72dd37b9668c0061f39964123e2e.s3tc.stex"
 path.etc2="res://.import/texture_bricks_metal.jpg-432f72dd37b9668c0061f39964123e2e.etc2.stex"
 
+[deps]
+
+source_file="res://texture_bricks_metal.jpg"
+source_md5="8f6671a8ae8417fe55e507ca8c842e28"
+
+dest_files=[ "res://.import/texture_bricks_metal.jpg-432f72dd37b9668c0061f39964123e2e.s3tc.stex", "res://.import/texture_bricks_metal.jpg-432f72dd37b9668c0061f39964123e2e.etc2.stex" ]
+dest_md5="97293d70abb39f4e7391c5aae94cff1e"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_bricks_normal.jpg.import
+++ b/3d/material_testers/texture_bricks_normal.jpg.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_bricks_normal.jpg-f511d813bdfac68deb908142f6206640.s3tc.stex"
 path.etc2="res://.import/texture_bricks_normal.jpg-f511d813bdfac68deb908142f6206640.etc2.stex"
 
+[deps]
+
+source_file="res://texture_bricks_normal.jpg"
+source_md5="33d1a6393e938da88f4bed7819661f88"
+
+dest_files=[ "res://.import/texture_bricks_normal.jpg-f511d813bdfac68deb908142f6206640.s3tc.stex", "res://.import/texture_bricks_normal.jpg-f511d813bdfac68deb908142f6206640.etc2.stex" ]
+dest_md5="209b6f8062fd7d2876c3e83e698a4992"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_cheese_albedo.png.import
+++ b/3d/material_testers/texture_cheese_albedo.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_cheese_albedo.png-ced5468dd652fe22fb58e4fd3e3a4bbd.s3tc.stex"
 path.etc2="res://.import/texture_cheese_albedo.png-ced5468dd652fe22fb58e4fd3e3a4bbd.etc2.stex"
 
+[deps]
+
+source_file="res://texture_cheese_albedo.png"
+source_md5="d37037eafd519878c137f25c4ec11733"
+
+dest_files=[ "res://.import/texture_cheese_albedo.png-ced5468dd652fe22fb58e4fd3e3a4bbd.s3tc.stex", "res://.import/texture_cheese_albedo.png-ced5468dd652fe22fb58e4fd3e3a4bbd.etc2.stex" ]
+dest_md5="a4c4b2c75ff0e52399e6609b109b3e36"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_cheese_ao.png.import
+++ b/3d/material_testers/texture_cheese_ao.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_cheese_ao.png-79c642c52e0a990ef398c8818cd56ced.s3tc.stex"
 path.etc2="res://.import/texture_cheese_ao.png-79c642c52e0a990ef398c8818cd56ced.etc2.stex"
 
+[deps]
+
+source_file="res://texture_cheese_ao.png"
+source_md5="2d6744c576bf3670033eafcd4dfa4665"
+
+dest_files=[ "res://.import/texture_cheese_ao.png-79c642c52e0a990ef398c8818cd56ced.s3tc.stex", "res://.import/texture_cheese_ao.png-79c642c52e0a990ef398c8818cd56ced.etc2.stex" ]
+dest_md5="363c637c83c2ac741884165b478160ca"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_cheese_depth.png.import
+++ b/3d/material_testers/texture_cheese_depth.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_cheese_depth.png-6461e37dafc766bdb9c6ee35bcfc082e.s3tc.stex"
 path.etc2="res://.import/texture_cheese_depth.png-6461e37dafc766bdb9c6ee35bcfc082e.etc2.stex"
 
+[deps]
+
+source_file="res://texture_cheese_depth.png"
+source_md5="501c7060aad919de1bbd952c99ca24fa"
+
+dest_files=[ "res://.import/texture_cheese_depth.png-6461e37dafc766bdb9c6ee35bcfc082e.s3tc.stex", "res://.import/texture_cheese_depth.png-6461e37dafc766bdb9c6ee35bcfc082e.etc2.stex" ]
+dest_md5="aa519ecdbd47e3d55ebf205c86faf48e"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_cheese_normal.png.import
+++ b/3d/material_testers/texture_cheese_normal.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_cheese_normal.png-0fa23a508b8380b2968078be79949326.s3tc.stex"
 path.etc2="res://.import/texture_cheese_normal.png-0fa23a508b8380b2968078be79949326.etc2.stex"
 
+[deps]
+
+source_file="res://texture_cheese_normal.png"
+source_md5="58f250babb5dce613114ed42cbe4f8c8"
+
+dest_files=[ "res://.import/texture_cheese_normal.png-0fa23a508b8380b2968078be79949326.s3tc.stex", "res://.import/texture_cheese_normal.png-0fa23a508b8380b2968078be79949326.etc2.stex" ]
+dest_md5="1654b91112ed9384704ab50466df7272"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_rock_albedo.png.import
+++ b/3d/material_testers/texture_rock_albedo.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_rock_albedo.png-a68a57186abfc0ec7c0856dd4d19e57a.s3tc.stex"
 path.etc2="res://.import/texture_rock_albedo.png-a68a57186abfc0ec7c0856dd4d19e57a.etc2.stex"
 
+[deps]
+
+source_file="res://texture_rock_albedo.png"
+source_md5="38e87f0e3c15e7e85a1300b4533cc9d5"
+
+dest_files=[ "res://.import/texture_rock_albedo.png-a68a57186abfc0ec7c0856dd4d19e57a.s3tc.stex", "res://.import/texture_rock_albedo.png-a68a57186abfc0ec7c0856dd4d19e57a.etc2.stex" ]
+dest_md5="351c821d4dc206747bfa24dd0b27dc41"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_rock_ao.png.import
+++ b/3d/material_testers/texture_rock_ao.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_rock_ao.png-876ff29d15db920077c3a4eedf0391ba.s3tc.stex"
 path.etc2="res://.import/texture_rock_ao.png-876ff29d15db920077c3a4eedf0391ba.etc2.stex"
 
+[deps]
+
+source_file="res://texture_rock_ao.png"
+source_md5="5c3ae2eccc9410cbf63efbf282bb79fd"
+
+dest_files=[ "res://.import/texture_rock_ao.png-876ff29d15db920077c3a4eedf0391ba.s3tc.stex", "res://.import/texture_rock_ao.png-876ff29d15db920077c3a4eedf0391ba.etc2.stex" ]
+dest_md5="07cfece3d1dcf4894ec365b03950c3ea"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_rock_depth.png.import
+++ b/3d/material_testers/texture_rock_depth.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_rock_depth.png-263bbd49c5f4a80a3ab535786ba3d2d0.s3tc.stex"
 path.etc2="res://.import/texture_rock_depth.png-263bbd49c5f4a80a3ab535786ba3d2d0.etc2.stex"
 
+[deps]
+
+source_file="res://texture_rock_depth.png"
+source_md5="c8b4c8496b66544f8eae01be6b5cf8b7"
+
+dest_files=[ "res://.import/texture_rock_depth.png-263bbd49c5f4a80a3ab535786ba3d2d0.s3tc.stex", "res://.import/texture_rock_depth.png-263bbd49c5f4a80a3ab535786ba3d2d0.etc2.stex" ]
+dest_md5="4450b49f40e5361a8533d0b8ddf296d2"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_rock_metal.png.import
+++ b/3d/material_testers/texture_rock_metal.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_rock_metal.png-0684b921574f18caeb657e95d1acb52f.s3tc.stex"
 path.etc2="res://.import/texture_rock_metal.png-0684b921574f18caeb657e95d1acb52f.etc2.stex"
 
+[deps]
+
+source_file="res://texture_rock_metal.png"
+source_md5="1165731e562335eede3c49c445b27804"
+
+dest_files=[ "res://.import/texture_rock_metal.png-0684b921574f18caeb657e95d1acb52f.s3tc.stex", "res://.import/texture_rock_metal.png-0684b921574f18caeb657e95d1acb52f.etc2.stex" ]
+dest_md5="5e5722844f622f00a96a6f2e56f376bb"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_rock_normal.png.import
+++ b/3d/material_testers/texture_rock_normal.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_rock_normal.png-3a7708ff84016bcf75dae97ed3c1dd99.s3tc.stex"
 path.etc2="res://.import/texture_rock_normal.png-3a7708ff84016bcf75dae97ed3c1dd99.etc2.stex"
 
+[deps]
+
+source_file="res://texture_rock_normal.png"
+source_md5="6ab6d1103fb591f94808b61bc91310e7"
+
+dest_files=[ "res://.import/texture_rock_normal.png-3a7708ff84016bcf75dae97ed3c1dd99.s3tc.stex", "res://.import/texture_rock_normal.png-3a7708ff84016bcf75dae97ed3c1dd99.etc2.stex" ]
+dest_md5="af1666e24e566d18dca069b00a4e4542"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/texture_wood.png.import
+++ b/3d/material_testers/texture_wood.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texture_wood.png-9b04e5a28e94d609932fce33329c7bba.s3tc.stex"
 path.etc2="res://.import/texture_wood.png-9b04e5a28e94d609932fce33329c7bba.etc2.stex"
 
+[deps]
+
+source_file="res://texture_wood.png"
+source_md5="3f98d4183848caa65f7e39c2a468954d"
+
+dest_files=[ "res://.import/texture_wood.png-9b04e5a28e94d609932fce33329c7bba.s3tc.stex", "res://.import/texture_wood.png-9b04e5a28e94d609932fce33329c7bba.etc2.stex" ]
+dest_md5="cd9945d395574e24fb38240c62986f64"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/wool_albedo.png.import
+++ b/3d/material_testers/wool_albedo.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/wool_albedo.png-13b4480f7715040f550618b0867a4240.s3tc.stex"
 path.etc2="res://.import/wool_albedo.png-13b4480f7715040f550618b0867a4240.etc2.stex"
 
+[deps]
+
+source_file="res://wool_albedo.png"
+source_md5="83dfd1bff82e8d1ded0ad19607f923ef"
+
+dest_files=[ "res://.import/wool_albedo.png-13b4480f7715040f550618b0867a4240.s3tc.stex", "res://.import/wool_albedo.png-13b4480f7715040f550618b0867a4240.etc2.stex" ]
+dest_md5="e57a929a2d3d4773ca57b410d6091f20"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/wool_depth.png.import
+++ b/3d/material_testers/wool_depth.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/wool_depth.png-b54a8703f10017b4c0db1af616cbeada.s3tc.stex"
 path.etc2="res://.import/wool_depth.png-b54a8703f10017b4c0db1af616cbeada.etc2.stex"
 
+[deps]
+
+source_file="res://wool_depth.png"
+source_md5="6b0f47dc7468def5180968147420eff9"
+
+dest_files=[ "res://.import/wool_depth.png-b54a8703f10017b4c0db1af616cbeada.s3tc.stex", "res://.import/wool_depth.png-b54a8703f10017b4c0db1af616cbeada.etc2.stex" ]
+dest_md5="16b5ebb3489087086beb121f3621e6f8"
+
 [params]
 
 compress/mode=2

--- a/3d/material_testers/wool_normal.png.import
+++ b/3d/material_testers/wool_normal.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/wool_normal.png-60ff7f57bf1350fad781bc9803fe0cab.stex"
 
+[deps]
+
+source_file="res://wool_normal.png"
+source_md5="63f033eb50f03abdbe52cc25c8118a86"
+
+dest_files=[ "res://.import/wool_normal.png-60ff7f57bf1350fad781bc9803fe0cab.stex" ]
+dest_md5="4866fc1e3e4d51a4bbdc88c0caccdc17"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/cutout.png.import
+++ b/3d/platformer/cutout.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/cutout.png-8aacc6c936bf12e889c8e11f6c4eb91c.stex"
 
+[deps]
+
+source_file="res://cutout.png"
+source_md5="402126cf2fa67147f40ea3903c5faf24"
+
+dest_files=[ "res://.import/cutout.png-8aacc6c936bf12e889c8e11f6c4eb91c.stex" ]
+dest_md5="61fc77ca5029cf1672400d8638ddc7cb"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/icon.png.import
+++ b/3d/platformer/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="fd9813b084986772b022c46b26b70946"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="e00a57b2081c8cced0b55877be375ff5"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/osb_down.png.import
+++ b/3d/platformer/osb_down.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_down.png-4a1ab934f787719766862b499528d054.stex"
 
+[deps]
+
+source_file="res://osb_down.png"
+source_md5="380dffa32ccc4f1a7f26a866a75e8d7f"
+
+dest_files=[ "res://.import/osb_down.png-4a1ab934f787719766862b499528d054.stex" ]
+dest_md5="5eccf0e866157072c9a9aff04c314240"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/osb_fire.png.import
+++ b/3d/platformer/osb_fire.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_fire.png-e657a73546eb75918e9d9a3fea15cf70.stex"
 
+[deps]
+
+source_file="res://osb_fire.png"
+source_md5="99a276197ee76a83312af783f33f0ab3"
+
+dest_files=[ "res://.import/osb_fire.png-e657a73546eb75918e9d9a3fea15cf70.stex" ]
+dest_md5="6482bf57180d11ef68855aa2a08394df"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/osb_jump.png.import
+++ b/3d/platformer/osb_jump.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_jump.png-dbbef3b47abbb562ce6c81a9701121c6.stex"
 
+[deps]
+
+source_file="res://osb_jump.png"
+source_md5="ac3e3adf52903de07cff73354f63896c"
+
+dest_files=[ "res://.import/osb_jump.png-dbbef3b47abbb562ce6c81a9701121c6.stex" ]
+dest_md5="27ebfaebcab0d0dec8bc8653d9086845"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/osb_left.png.import
+++ b/3d/platformer/osb_left.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_left.png-fc7230aeb0eec74933ed08f89b893288.stex"
 
+[deps]
+
+source_file="res://osb_left.png"
+source_md5="ce066828ec6ef27c9ce3809341574058"
+
+dest_files=[ "res://.import/osb_left.png-fc7230aeb0eec74933ed08f89b893288.stex" ]
+dest_md5="38850545bc1772ea9aa01359f76bc52e"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/osb_right.png.import
+++ b/3d/platformer/osb_right.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_right.png-5cf5add2dbc1c8dde17173ac56f3a004.stex"
 
+[deps]
+
+source_file="res://osb_right.png"
+source_md5="860560d5e66ccd837973fbbde7eb958f"
+
+dest_files=[ "res://.import/osb_right.png-5cf5add2dbc1c8dde17173ac56f3a004.stex" ]
+dest_md5="bc21992309c3a5da0b5df5361cdf07fa"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/osb_up.png.import
+++ b/3d/platformer/osb_up.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/osb_up.png-6a05b6a7bf0ede3756308a5cffdd2b9a.stex"
 
+[deps]
+
+source_file="res://osb_up.png"
+source_md5="5a6485a8b3b72ee63b421dc641e3840d"
+
+dest_files=[ "res://.import/osb_up.png-6a05b6a7bf0ede3756308a5cffdd2b9a.stex" ]
+dest_md5="345b4dd67a8fe5b99a3e9438b7e67123"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/panorama.png.import
+++ b/3d/platformer/panorama.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/panorama.png-e05131d3dca9fd5b03101f18fbe08995.stex"
 
+[deps]
+
+source_file="res://panorama.png"
+source_md5="dfc06d296e0ae47b4b8751d80530e36b"
+
+dest_files=[ "res://.import/panorama.png-e05131d3dca9fd5b03101f18fbe08995.stex" ]
+dest_md5="46d01f14477d7b9334e7aac18a713e1c"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/robot_walk.wav.import
+++ b/3d/platformer/robot_walk.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/robot_walk.wav-4313e7d5f563e62e3923080b14a79c15.sample"
 
+[deps]
+
+source_file="res://robot_walk.wav"
+source_md5="96695430153c689bb7d67c72b2668656"
+
+dest_files=[ "res://.import/robot_walk.wav-4313e7d5f563e62e3923080b14a79c15.sample" ]
+dest_md5="02aaa8a5ac8872165cc05a71fe9cf2fa"
+
 [params]
 
 force/8_bit=false

--- a/3d/platformer/shine.png.import
+++ b/3d/platformer/shine.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/shine.png-a8253c1d2dc8acbf187823f695c13207.s3tc.stex"
 path.etc2="res://.import/shine.png-a8253c1d2dc8acbf187823f695c13207.etc2.stex"
 
+[deps]
+
+source_file="res://shine.png"
+source_md5="9fe43d82e09598fc96be75bcf60df249"
+
+dest_files=[ "res://.import/shine.png-a8253c1d2dc8acbf187823f695c13207.s3tc.stex", "res://.import/shine.png-a8253c1d2dc8acbf187823f695c13207.etc2.stex" ]
+dest_md5="bcf678c7760624596bb69eefc7ba94b9"
+
 [params]
 
 compress/mode=2

--- a/3d/platformer/sound_coin.wav.import
+++ b/3d/platformer/sound_coin.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_coin.wav-b4defacd1a1eab95585c7b5095506878.sample"
 
+[deps]
+
+source_file="res://sound_coin.wav"
+source_md5="c9b8b4e85a53ce0e7add721a872d0479"
+
+dest_files=[ "res://.import/sound_coin.wav-b4defacd1a1eab95585c7b5095506878.sample" ]
+dest_md5="a5c99ee24792b7e1b62ffe0c66a8edbe"
+
 [params]
 
 force/8_bit=false

--- a/3d/platformer/sound_explode.wav.import
+++ b/3d/platformer/sound_explode.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_explode.wav-23e94be75a4346bffb517c7e07035977.sample"
 
+[deps]
+
+source_file="res://sound_explode.wav"
+source_md5="c49bffd6268c2fb061a578c559fbd988"
+
+dest_files=[ "res://.import/sound_explode.wav-23e94be75a4346bffb517c7e07035977.sample" ]
+dest_md5="7415ca619baef1372a2b639078e6614f"
+
 [params]
 
 force/8_bit=false

--- a/3d/platformer/sound_hit.wav.import
+++ b/3d/platformer/sound_hit.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_hit.wav-d8455980ada2d4a9a73508948d7317cc.sample"
 
+[deps]
+
+source_file="res://sound_hit.wav"
+source_md5="ce60125d5b1639a3b88d652aea6ca0c3"
+
+dest_files=[ "res://.import/sound_hit.wav-d8455980ada2d4a9a73508948d7317cc.sample" ]
+dest_md5="5c03dd1fa4210af447e9218d29e7add5"
+
 [params]
 
 force/8_bit=false

--- a/3d/platformer/sound_jump.wav.import
+++ b/3d/platformer/sound_jump.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_jump.wav-4966d1f327e26a176b56ab335c03b5e1.sample"
 
+[deps]
+
+source_file="res://sound_jump.wav"
+source_md5="f15f2f75683475fb46217cb108a91d44"
+
+dest_files=[ "res://.import/sound_jump.wav-4966d1f327e26a176b56ab335c03b5e1.sample" ]
+dest_md5="d93302188764fedd122195b34b711ceb"
+
 [params]
 
 force/8_bit=false

--- a/3d/platformer/sound_shoot.wav.import
+++ b/3d/platformer/sound_shoot.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/sound_shoot.wav-f0f26619cba21d411b53ad23b8788116.sample"
 
+[deps]
+
+source_file="res://sound_shoot.wav"
+source_md5="5c1909840119124623da414167fad697"
+
+dest_files=[ "res://.import/sound_shoot.wav-f0f26619cba21d411b53ad23b8788116.sample" ]
+dest_md5="8c33ecb945ea94e05e6be5ee5a7b0c6b"
+
 [params]
 
 force/8_bit=false

--- a/3d/platformer/texture.png.import
+++ b/3d/platformer/texture.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/texture.png-77dc6ecaf884a35cd9dbaf886cacc46d.stex"
 
+[deps]
+
+source_file="res://texture.png"
+source_md5="46505d8c8180cb3fcbdc17f7b684c754"
+
+dest_files=[ "res://.import/texture.png-77dc6ecaf884a35cd9dbaf886cacc46d.stex" ]
+dest_md5="b822a0e9914c432cab879950ec20de54"
+
 [params]
 
 compress/mode=0

--- a/3d/platformer/texturemr.png.import
+++ b/3d/platformer/texturemr.png.import
@@ -5,6 +5,14 @@ type="StreamTexture"
 path.s3tc="res://.import/texturemr.png-0568a8b09834741143da53ce460e36f1.s3tc.stex"
 path.etc2="res://.import/texturemr.png-0568a8b09834741143da53ce460e36f1.etc2.stex"
 
+[deps]
+
+source_file="res://texturemr.png"
+source_md5="44c91f2d59a98b888e2bc235d5ea379d"
+
+dest_files=[ "res://.import/texturemr.png-0568a8b09834741143da53ce460e36f1.s3tc.stex", "res://.import/texturemr.png-0568a8b09834741143da53ce460e36f1.etc2.stex" ]
+dest_md5="2526b51bff771b289cc452ccfb76606c"
+
 [params]
 
 compress/mode=2

--- a/gui/drag_and_drop/icon.png.import
+++ b/gui/drag_and_drop/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="9cb7b2d10396f1f208c56fb5126b023d"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="3a238454b327f15f0e03ddf32f186730"
+
 [params]
 
 compress/mode=0

--- a/gui/input_mapping/icon.png.import
+++ b/gui/input_mapping/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="2e01548c24fa4b937105fc62dee25cb3"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="ceecd61fcffc0b649641832c508976b8"
+
 [params]
 
 compress/mode=0

--- a/gui/rich_text_bbcode/icon.png.import
+++ b/gui/rich_text_bbcode/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="7308b25cf412df075856feeee943d2b4"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="02a47787cb375a9393c36defd733eca5"
+
 [params]
 
 compress/mode=0

--- a/gui/rich_text_bbcode/unicorn_icon.png.import
+++ b/gui/rich_text_bbcode/unicorn_icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/unicorn_icon.png-7e6ed0493ce9bae1105057e782fcd0de.stex"
 
+[deps]
+
+source_file="res://unicorn_icon.png"
+source_md5="22f87e5cf3d8de3aae88c5af51032da0"
+
+dest_files=[ "res://.import/unicorn_icon.png-7e6ed0493ce9bae1105057e782fcd0de.stex" ]
+dest_md5="f10e3990ad10694cb7e392dc727a4ea7"
+
 [params]
 
 compress/mode=0

--- a/gui/translation/flag_japan.png.import
+++ b/gui/translation/flag_japan.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/flag_japan.png-e7284e6af3de26ab9c66cac9c4062038.stex"
 
+[deps]
+
+source_file="res://flag_japan.png"
+source_md5="9c0bec8a1e496f92954558a42a00119d"
+
+dest_files=[ "res://.import/flag_japan.png-e7284e6af3de26ab9c66cac9c4062038.stex" ]
+dest_md5="8d7183dc67f4e8ef7c8318ca56c0327a"
+
 [params]
 
 compress/mode=0

--- a/gui/translation/flag_spain.png.import
+++ b/gui/translation/flag_spain.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/flag_spain.png-fd2012b4e19487cfc4923df0c268553f.stex"
 
+[deps]
+
+source_file="res://flag_spain.png"
+source_md5="ed47f2f75055c516f978a931a1c94bbd"
+
+dest_files=[ "res://.import/flag_spain.png-fd2012b4e19487cfc4923df0c268553f.stex" ]
+dest_md5="4bb283a20c83c753f70bd351d3c83a6a"
+
 [params]
 
 compress/mode=0

--- a/gui/translation/flag_uk.png.import
+++ b/gui/translation/flag_uk.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/flag_uk.png-eb8a2b26ac36f4d0cf0d7345e577ec2c.stex"
 
+[deps]
+
+source_file="res://flag_uk.png"
+source_md5="e08b397a6aafd9113aa9c0600a53263b"
+
+dest_files=[ "res://.import/flag_uk.png-eb8a2b26ac36f4d0cf0d7345e577ec2c.stex" ]
+dest_md5="e4b3148288d20d8c3041d0b3cd8c3562"
+
 [params]
 
 compress/mode=0

--- a/gui/translation/hello_en.wav.import
+++ b/gui/translation/hello_en.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/hello_en.wav-27ed59f2d75c1ba813ab0abd069b6758.sample"
 
+[deps]
+
+source_file="res://hello_en.wav"
+source_md5="8a03a08650119bbd66417681a4f5aa5a"
+
+dest_files=[ "res://.import/hello_en.wav-27ed59f2d75c1ba813ab0abd069b6758.sample" ]
+dest_md5="efd203cb33d77deff8a912c7748cd2a6"
+
 [params]
 
 force/8_bit=false

--- a/gui/translation/hello_es.wav.import
+++ b/gui/translation/hello_es.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/hello_es.wav-64fe245556f8642a1881ae257bd123f2.sample"
 
+[deps]
+
+source_file="res://hello_es.wav"
+source_md5="4a0a73a1532d0c46f69e5336c550a431"
+
+dest_files=[ "res://.import/hello_es.wav-64fe245556f8642a1881ae257bd123f2.sample" ]
+dest_md5="c732de9ea1407b3336b07438569a9f88"
+
 [params]
 
 force/8_bit=false

--- a/gui/translation/hello_jp.wav.import
+++ b/gui/translation/hello_jp.wav.import
@@ -4,6 +4,14 @@ importer="wav"
 type="AudioStreamSample"
 path="res://.import/hello_jp.wav-c31fbd7870b4b969789cb01f208809ac.sample"
 
+[deps]
+
+source_file="res://hello_jp.wav"
+source_md5="60ed6a48deebb7a10da83adea9507693"
+
+dest_files=[ "res://.import/hello_jp.wav-c31fbd7870b4b969789cb01f208809ac.sample" ]
+dest_md5="256e57800b66c2ad4fe9454d6f06a883"
+
 [params]
 
 force/8_bit=false

--- a/gui/translation/icon.png.import
+++ b/gui/translation/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="53a00c1d20a2abda9a48e6c38c1f8558"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="44f27e8bb4c333990f2b6c9a422454af"
+
 [params]
 
 compress/mode=0

--- a/gui/translation/speaker.png.import
+++ b/gui/translation/speaker.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/speaker.png-045bf6684b83b55b088824f14e175d16.stex"
 
+[deps]
+
+source_file="res://speaker.png"
+source_md5="de26c4d8fbe4b16061ef1dcaedbb92fd"
+
+dest_files=[ "res://.import/speaker.png-045bf6684b83b55b088824f14e175d16.stex" ]
+dest_md5="1fe95898c91866243e523bac00082b5e"
+
 [params]
 
 compress/mode=0

--- a/gui/translation/text.csv.import
+++ b/gui/translation/text.csv.import
@@ -3,8 +3,15 @@
 importer="csv_translation"
 type="Translation"
 
-[gen]
+[deps]
+
 files=[ "res://text.en.translation", "res://text.es.translation", "res://text.ja.translation" ]
+
+source_file="res://text.csv"
+source_md5="4c02672dcc571d8d3754983a2d06042e"
+
+dest_files=[ "res://text.en.translation", "res://text.es.translation", "res://text.ja.translation" ]
+dest_md5="f710d4f235972e0a916cc4d6ba28aedc"
 
 [params]
 

--- a/misc/android_iap/icon.png.import
+++ b/misc/android_iap/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="86aa1d9e8afaf5ec9cabb7e89945c7a8"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="de268f1fefb026236e22a224989920b8"
+
 [params]
 
 compress/mode=0

--- a/misc/instancing/bowling_ball.png.import
+++ b/misc/instancing/bowling_ball.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/bowling_ball.png-0fe48f78a8537b41cee7fd03e5ee14fe.stex"
 
+[deps]
+
+source_file="res://bowling_ball.png"
+source_md5="ed6ee0994bbfefa88886b9c0844fd911"
+
+dest_files=[ "res://.import/bowling_ball.png-0fe48f78a8537b41cee7fd03e5ee14fe.stex" ]
+dest_md5="486e2c71579c634163b4521aeb93c256"
+
 [params]
 
 compress/mode=0

--- a/misc/instancing/container.png.import
+++ b/misc/instancing/container.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/container.png-08b8c30d2209234da421d1db5c67b811.stex"
 
+[deps]
+
+source_file="res://container.png"
+source_md5="3bb268159ba0d05e281b2218e48c8ce8"
+
+dest_files=[ "res://.import/container.png-08b8c30d2209234da421d1db5c67b811.stex" ]
+dest_md5="5c570503eb858bbf6a495ff5fac6653e"
+
 [params]
 
 compress/mode=0

--- a/misc/instancing/icon.png.import
+++ b/misc/instancing/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="e70abe25cc26c842c92db68acfe39dbb"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="c3a615657e792c23f1442ea6f3eb334a"
+
 [params]
 
 compress/mode=0

--- a/misc/joypads/diagram.png.import
+++ b/misc/joypads/diagram.png.import
@@ -6,7 +6,11 @@ path="res://.import/diagram.png-1621ff3c0b6dad34000ac99354b64701.stex"
 
 [deps]
 
+source_file="res://diagram.png"
 source_md5="bc20fa2375b14c17e86892fe7210e8bf"
+
+dest_files=[ "res://.import/diagram.png-1621ff3c0b6dad34000ac99354b64701.stex" ]
+dest_md5="b89deabdecbd4bf7df40baed08cb0aaa"
 
 [params]
 

--- a/misc/joypads/icon.png.import
+++ b/misc/joypads/icon.png.import
@@ -6,7 +6,11 @@ path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
 [deps]
 
+source_file="res://icon.png"
 source_md5="046afbd20c33eff2ded7513724d08a93"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="9893e97a56e2f5e72cc18b6345b2e1b7"
 
 [params]
 

--- a/misc/joypads/indicators.png.import
+++ b/misc/joypads/indicators.png.import
@@ -6,7 +6,11 @@ path="res://.import/indicators.png-b2d98522e44d4529354ba542a9970360.stex"
 
 [deps]
 
+source_file="res://indicators.png"
 source_md5="5a31443cd8b7034172883cd5e7da21a9"
+
+dest_files=[ "res://.import/indicators.png-b2d98522e44d4529354ba542a9970360.stex" ]
+dest_md5="5b7e33bf684419426842a3eee2108858"
 
 [params]
 

--- a/misc/pause/icon.png.import
+++ b/misc/pause/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="96d63cb4455baa9e16edea6a3d3d7376"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="ec0188ad554f40c7bf64dff529d58d79"
+
 [params]
 
 compress/mode=0

--- a/misc/regex/icon.png.import
+++ b/misc/regex/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="1a9620f0fb6d6216fe36a69a9f4e89f6"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="b4d083f20fc2ab22305e92d47d512f03"
+
 [params]
 
 compress/mode=0

--- a/misc/threads/mona.png.import
+++ b/misc/threads/mona.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/mona.png-a5ce9963ac8c7ef765aeb0f5428366a9.stex"
 
+[deps]
+
+source_file="res://mona.png"
+source_md5="322f77c3c7a57eec5c262ca7939d8e7d"
+
+dest_files=[ "res://.import/mona.png-a5ce9963ac8c7ef765aeb0f5428366a9.stex" ]
+dest_md5="a7cbd29df4074aa0e6aee6f38442e987"
+
 [params]
 
 compress/mode=0

--- a/misc/tween/godot.png.import
+++ b/misc/tween/godot.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/godot.png-5e0da45ed3d6786d5794553e04f58a8c.stex"
 
+[deps]
+
+source_file="res://godot.png"
+source_md5="377c28f8825ea7512b64b3bff69f4e34"
+
+dest_files=[ "res://.import/godot.png-5e0da45ed3d6786d5794553e04f58a8c.stex" ]
+dest_md5="7d9b5e3ee856458ff45c2bf5351d3d81"
+
 [params]
 
 compress/mode=0

--- a/misc/tween/icon.png.import
+++ b/misc/tween/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="84f7874a3f7c91a93c9ee13c816e4c09"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="7d003c6ff4c5614804c89fb09547b9bd"
+
 [params]
 
 compress/mode=0

--- a/misc/window_management/icon.png.import
+++ b/misc/window_management/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="c28e0db2f5a967b654ad97060476c589"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="fdb1aa47e7dac052e4263c47685a630d"
+
 [params]
 
 compress/mode=0

--- a/networking/multiplayer_bomber/brickfloor.png.import
+++ b/networking/multiplayer_bomber/brickfloor.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/brickfloor.png-bab1cbace80ab627972eea565951db9e.stex"
 
+[deps]
+
+source_file="res://brickfloor.png"
+source_md5="58c8113a4c6cb037376fd4c1530b797a"
+
+dest_files=[ "res://.import/brickfloor.png-bab1cbace80ab627972eea565951db9e.stex" ]
+dest_md5="59f392610dd24df206fe041c44ddcdb0"
+
 [params]
 
 compress/mode=0

--- a/networking/multiplayer_bomber/charwalk.png.import
+++ b/networking/multiplayer_bomber/charwalk.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/charwalk.png-a9f067962a6454cc2f52a6e82832cbc5.stex"
 
+[deps]
+
+source_file="res://charwalk.png"
+source_md5="7dbd87a40f60dd5882f23731d13e9798"
+
+dest_files=[ "res://.import/charwalk.png-a9f067962a6454cc2f52a6e82832cbc5.stex" ]
+dest_md5="fe50c0fcfde8daf5b933d4e84ae31a9c"
+
 [params]
 
 compress/mode=0

--- a/networking/multiplayer_bomber/explosion.png.import
+++ b/networking/multiplayer_bomber/explosion.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/explosion.png-730076d88b39dbfd5c22ad71f1135b01.stex"
 
+[deps]
+
+source_file="res://explosion.png"
+source_md5="9c7f3018d72fd9e82c868eb5c3fbf0d7"
+
+dest_files=[ "res://.import/explosion.png-730076d88b39dbfd5c22ad71f1135b01.stex" ]
+dest_md5="f279883906fff65cae8669c1489e6336"
+
 [params]
 
 compress/mode=0

--- a/networking/multiplayer_bomber/rock_bit.png.import
+++ b/networking/multiplayer_bomber/rock_bit.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/rock_bit.png-cd30ec3dce7edf848ee632b29d4d0c95.stex"
 
+[deps]
+
+source_file="res://rock_bit.png"
+source_md5="72daee59795a6b17ee21df81b712631f"
+
+dest_files=[ "res://.import/rock_bit.png-cd30ec3dce7edf848ee632b29d4d0c95.stex" ]
+dest_md5="81cad6adf308b35e7495206306476fce"
+
 [params]
 
 compress/mode=0

--- a/networking/multiplayer_pong/ball.png.import
+++ b/networking/multiplayer_pong/ball.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex"
 
+[deps]
+
+source_file="res://ball.png"
+source_md5="4219e9084f5485c8d1812297700f317d"
+
+dest_files=[ "res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex" ]
+dest_md5="c23684a1fd10063a69ecc18f7ccca4c3"
+
 [params]
 
 compress/mode=0

--- a/networking/multiplayer_pong/icon.png.import
+++ b/networking/multiplayer_pong/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="9be177e863d37787c0836d64924b3503"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="6339016da0f704252e68ba6dd6477388"
+
 [params]
 
 compress/mode=0

--- a/networking/multiplayer_pong/paddle.png.import
+++ b/networking/multiplayer_pong/paddle.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/paddle.png-0e798fb0912613386507c9904d5cc01a.stex"
 
+[deps]
+
+source_file="res://paddle.png"
+source_md5="946d462749230c01dcc1c69371ed119b"
+
+dest_files=[ "res://.import/paddle.png-0e798fb0912613386507c9904d5cc01a.stex" ]
+dest_md5="ed1295225d73ba25982010781ff03d09"
+
 [params]
 
 compress/mode=0

--- a/networking/multiplayer_pong/separator.png.import
+++ b/networking/multiplayer_pong/separator.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/separator.png-f981c8489b9148e2e1dc63398273da74.stex"
 
+[deps]
+
+source_file="res://separator.png"
+source_md5="b6234b89455156532bbe1256249fcfd4"
+
+dest_files=[ "res://.import/separator.png-f981c8489b9148e2e1dc63398273da74.stex" ]
+dest_md5="6e27251839594842494c6cd51e3b86cb"
+
 [params]
 
 compress/mode=0

--- a/viewport/2d_in_3d/ball.png.import
+++ b/viewport/2d_in_3d/ball.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex"
 
+[deps]
+
+source_file="res://ball.png"
+source_md5="4219e9084f5485c8d1812297700f317d"
+
+dest_files=[ "res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex" ]
+dest_md5="91f57141ffceed4f9c2aadd8d8fd5ca0"
+
 [params]
 
 compress/mode=0

--- a/viewport/2d_in_3d/icon.png.import
+++ b/viewport/2d_in_3d/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="e7ac148f851212c3a05eef07783e1c0f"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="52b37083b9086ccbd84d6c0c418662ad"
+
 [params]
 
 compress/mode=0

--- a/viewport/2d_in_3d/left_pallete.png.import
+++ b/viewport/2d_in_3d/left_pallete.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/left_pallete.png-bc33611074a0f886142e37c77bd2545a.stex"
 
+[deps]
+
+source_file="res://left_pallete.png"
+source_md5="df76627349499ad47ebf48a7ca947cca"
+
+dest_files=[ "res://.import/left_pallete.png-bc33611074a0f886142e37c77bd2545a.stex" ]
+dest_md5="d6c1a2e71044d865ecf599009c3535f9"
+
 [params]
 
 compress/mode=0

--- a/viewport/2d_in_3d/right_pallete.png.import
+++ b/viewport/2d_in_3d/right_pallete.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/right_pallete.png-fc6e4a6a7c8197834656482b94708e47.stex"
 
+[deps]
+
+source_file="res://right_pallete.png"
+source_md5="d46f647d3f045dbee4d786089c309868"
+
+dest_files=[ "res://.import/right_pallete.png-fc6e4a6a7c8197834656482b94708e47.stex" ]
+dest_md5="7117a0b411d33197a041e42b2248a0fb"
+
 [params]
 
 compress/mode=0

--- a/viewport/2d_in_3d/separator.png.import
+++ b/viewport/2d_in_3d/separator.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/separator.png-f981c8489b9148e2e1dc63398273da74.stex"
 
+[deps]
+
+source_file="res://separator.png"
+source_md5="b6234b89455156532bbe1256249fcfd4"
+
+dest_files=[ "res://.import/separator.png-f981c8489b9148e2e1dc63398273da74.stex" ]
+dest_md5="c0b4370815bb5757200fc92c71e46313"
+
 [params]
 
 compress/mode=0

--- a/viewport/3d_in_2d/icon.png.import
+++ b/viewport/3d_in_2d/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="f40bb4b4a5a2bb0fb17a9fe2ffaf7dbc"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="c5c5c8e2efdfcc4a75ef8be0cb5f4a0f"
+
 [params]
 
 compress/mode=0

--- a/viewport/3d_in_2d/robot_demo.png.import
+++ b/viewport/3d_in_2d/robot_demo.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/robot_demo.png-8502817e0037b3f31eaca3dae49dcfc5.stex"
 
+[deps]
+
+source_file="res://robot_demo.png"
+source_md5="2a19cb85548217b26700914bd42617b4"
+
+dest_files=[ "res://.import/robot_demo.png-8502817e0037b3f31eaca3dae49dcfc5.stex" ]
+dest_md5="a8591e098e3f1315468e7318da46cbb7"
+
 [params]
 
 compress/mode=0

--- a/viewport/gui_in_3d/icon.png.import
+++ b/viewport/gui_in_3d/icon.png.import
@@ -6,7 +6,11 @@ path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
 [deps]
 
+source_file="res://icon.png"
 source_md5="434c8eb4c3320b4afd88f7a34b3a12d6"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="a6b3d106eb33d75fd3532a8554f6daaa"
 
 [params]
 

--- a/viewport/screen_capture/icon.png.import
+++ b/viewport/screen_capture/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="71dbfbd9db1b88e8d729c2009427b7f6"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="4330ec3e316be795892551964cdca11c"
+
 [params]
 
 compress/mode=0

--- a/viewport/screen_capture/mountains.png.import
+++ b/viewport/screen_capture/mountains.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/mountains.png-03f302fbd9195711fc86ea8f28ca435e.stex"
 
+[deps]
+
+source_file="res://mountains.png"
+source_md5="cd668b794fb4cfeb602258757b79ef0d"
+
+dest_files=[ "res://.import/mountains.png-03f302fbd9195711fc86ea8f28ca435e.stex" ]
+dest_md5="942af6591a343f789f7450f2d5706f8a"
+
 [params]
 
 compress/mode=0

--- a/visual_script/visual_pong/ball.png.import
+++ b/visual_script/visual_pong/ball.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex"
 
+[deps]
+
+source_file="res://ball.png"
+source_md5="4219e9084f5485c8d1812297700f317d"
+
+dest_files=[ "res://.import/ball.png-9a4ca347acb7532f6ae347744a6b04f7.stex" ]
+dest_md5="c23684a1fd10063a69ecc18f7ccca4c3"
+
 [params]
 
 compress/mode=0

--- a/visual_script/visual_pong/icon.png.import
+++ b/visual_script/visual_pong/icon.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 
+[deps]
+
+source_file="res://icon.png"
+source_md5="9be177e863d37787c0836d64924b3503"
+
+dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="6339016da0f704252e68ba6dd6477388"
+
 [params]
 
 compress/mode=0

--- a/visual_script/visual_pong/left_pallete.png.import
+++ b/visual_script/visual_pong/left_pallete.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/left_pallete.png-bc33611074a0f886142e37c77bd2545a.stex"
 
+[deps]
+
+source_file="res://left_pallete.png"
+source_md5="df76627349499ad47ebf48a7ca947cca"
+
+dest_files=[ "res://.import/left_pallete.png-bc33611074a0f886142e37c77bd2545a.stex" ]
+dest_md5="f286e993cb5a7b7513004045afcc4313"
+
 [params]
 
 compress/mode=0

--- a/visual_script/visual_pong/right_pallete.png.import
+++ b/visual_script/visual_pong/right_pallete.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/right_pallete.png-fc6e4a6a7c8197834656482b94708e47.stex"
 
+[deps]
+
+source_file="res://right_pallete.png"
+source_md5="d46f647d3f045dbee4d786089c309868"
+
+dest_files=[ "res://.import/right_pallete.png-fc6e4a6a7c8197834656482b94708e47.stex" ]
+dest_md5="5f8755f214bc8d4caf7c467291452637"
+
 [params]
 
 compress/mode=0

--- a/visual_script/visual_pong/separator.png.import
+++ b/visual_script/visual_pong/separator.png.import
@@ -4,6 +4,14 @@ importer="texture"
 type="StreamTexture"
 path="res://.import/separator.png-f981c8489b9148e2e1dc63398273da74.stex"
 
+[deps]
+
+source_file="res://separator.png"
+source_md5="b6234b89455156532bbe1256249fcfd4"
+
+dest_files=[ "res://.import/separator.png-f981c8489b9148e2e1dc63398273da74.stex" ]
+dest_md5="6e27251839594842494c6cd51e3b86cb"
+
 [params]
 
 compress/mode=0


### PR DESCRIPTION
Related to issue #179 this pull request is the result of opening each project in the editor, the only changes are what godot automatically saves.

These changes to the *.import files allow the demo projects to be opened using the godot runtime and prevent reimporting every time they are opened in the editor.

There were also changes saved to gui/translation/text.xx.translation but as I am unable to verify the changes and they don't prevent the runtime starting, so I didn't include those changes here.