### PR TITLE
Reorganize the README and make the version compatibility notice clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ Each folder containing an `engine.cfg` file is a demo project meant to
 be used with [Godot Engine](https://godotengine.org), the open source
 2D and 3D game engine.
 
-Those demos are distributed under the terms of the MIT license, as
-described in the [LICENSE.md](LICENSE.md) file.
+## Important note
 
-**Note:**
-Master branch is compatible with the latest Godot version (currently 3.0). Use the appropriate branch for your Godot version, for example branch [2.1](https://github.com/godotengine/godot-demo-projects/tree/2.1) for Godot 2.1.x.
+- The `master` branch is compatible with the latest Godot version (currently 3.0).
+- Use the appropriate branch for your Godot version, such as the
+  [`2.1`](https://github.com/godotengine/godot-demo-projects/tree/2.1) branch
+  for Godot 2.1.x.
 
-### Useful links
+## Useful links
 
  - [Main website](https://godotengine.org)
  - [Source code](https://github.com/godotengine/godot)
  - [Documentation](http://docs.godotengine.org)
  - [Community hub](https://godotengine.org/community)
+
+## License
+
+Those demos are distributed under the terms of the MIT license, as
+described in the [LICENSE.md](LICENSE.md) file.


### PR DESCRIPTION
This backports changes from https://github.com/godotengine/godot-demo-projects/pull/231 into the `2.1` branch.