### PR TITLE
Remove an unused variable declaration in Kinematic Character 3D

### DIFF
--- a/3d/kinematic_character/cubio.gd
+++ b/3d/kinematic_character/cubio.gd
@@ -14,7 +14,7 @@ const MAX_SLOPE_ANGLE = 30
 func _physics_process(delta):
 	var dir = Vector3() # Where does the player intend to walk to
 	var cam_xform = $target/camera.get_global_transform()
-	
+
 	if Input.is_action_pressed("move_forward"):
 		dir += -cam_xform.basis[2]
 	if Input.is_action_pressed("move_backwards"):
@@ -23,33 +23,31 @@ func _physics_process(delta):
 		dir += -cam_xform.basis[0]
 	if Input.is_action_pressed("move_right"):
 		dir += cam_xform.basis[0]
-	
+
 	dir.y = 0
 	dir = dir.normalized()
-	
+
 	vel.y += delta * g
-	
+
 	var hvel = vel
 	hvel.y = 0
-	
+
 	var target = dir * MAX_SPEED
 	var accel
 	if dir.dot(hvel) > 0:
 		accel = ACCEL
 	else:
 		accel = DEACCEL
-	
+
 	hvel = hvel.linear_interpolate(target, accel * delta)
-	
+
 	vel.x = hvel.x
 	vel.z = hvel.z
-	
+
 	vel = move_and_slide(vel, Vector3(0,1,0))
-	
+
 	if is_on_floor() and Input.is_action_pressed("jump"):
 		vel.y = JUMP_SPEED
-	
-	var crid = get_node("../elevator1").get_rid()
 
 
 func _on_tcube_body_enter(body):

--- a/3d/kinematic_character/follow_camera.gd
+++ b/3d/kinematic_character/follow_camera.gd
@@ -16,27 +16,27 @@ func _physics_process(dt):
 	var target = get_parent().global_transform.origin
 	var pos = global_transform.origin
 	var up = Vector3(0, 1, 0)
-	
+
 	var delta = pos - target
-	
+
 	# Regular delta follow
-	
+
 	# Check ranges
 	if delta.length() < min_distance:
 		delta = delta.normalized() * min_distance
 	elif delta.length() > max_distance:
 		delta = delta.normalized() * max_distance
-	
+
 	# Check upper and lower height
 	if delta.y > max_height:
 		delta.y = max_height
 	if delta.y < min_height:
 		delta.y = min_height
-	
+
 	pos = target + delta
-	
+
 	look_at_from_position(pos, target, up)
-	
+
 	# Turn a little up or down
 	var t = transform
 	t.basis = Basis(t.basis[0], deg2rad(angle_v_adjust)) * t.basis


### PR DESCRIPTION
This also strips trailing whitespace in the demo's code – let me know if I should leave them as-is.

This fixes #253.