### PR TITLE
checking array length beforehand

### DIFF
--- a/2d/navigation_astar/character.gd
+++ b/2d/navigation_astar/character.gd
@@ -18,7 +18,7 @@ func _ready():
 func _change_state(new_state):
 	if new_state == FOLLOW:
 		path = get_parent().get_node('TileMap').get_path(position, target_position)
-		if not path:
+		if not path or len(path) == 1:
 			_change_state(IDLE)
 			return
 		# The index 0 is the starting cell


### PR DESCRIPTION
This fixes a minor bug when the astar target_position is the same as the staring point. In that case the path-array has the length of one. The bug is already fixed in @NathanLovato's repository but hasn't been pushed yet.