### PR TITLE
Fix finite state demo warning

### DIFF
--- a/2d/finite_state_machine/debug/states_stack_displayer.gd
+++ b/2d/finite_state_machine/debug/states_stack_displayer.gd
@@ -1,4 +1,3 @@
-tool
 extends Panel
 
 onready var fsm_node = get_node("../Player/StateMachine")

--- a/2d/finite_state_machine/project.godot
+++ b/2d/finite_state_machine/project.godot
@@ -14,10 +14,6 @@ config/name="Hierarchical Finite State Machine example"
 run/main_scene="res://Demo.tscn"
 config/icon="res://icon.png"
 
-[autoload]
-
-GlobalConstants="*res://debug/autoload/global_constants.gd"
-
 [display]
 
 window/size/width=1280


### PR DESCRIPTION
Not effect runtime, just remove some warning spam in editor output.

- Remove autoload non existence script
- Not running state stack display in editor 