### PR TITLE
Fix gui in 3d demo with Godot 3.1

### DIFF
--- a/viewport/gui_in_3d/Gui_in_3D.tscn
+++ b/viewport/gui_in_3d/Gui_in_3D.tscn
@@ -2,74 +2,20 @@
 
 [ext_resource path="res://gui_3d.gd" type="Script" id=1]
 
-[sub_resource type="PlaneMesh" id=1]
+[sub_resource type="QuadMesh" id=14]
 
 size = Vector2( 2, 2 )
-subdivide_width = 0
-subdivide_depth = 0
 
-[sub_resource type="ViewportTexture" id=2]
+[sub_resource type="ViewportTexture" id=15]
 
-resource_local_to_scene = true
-flags = 5
 viewport_path = NodePath("Viewport")
 
-[sub_resource type="SpatialMaterial" id=3]
+[sub_resource type="SpatialMaterial" id=16]
 
 resource_local_to_scene = true
-render_priority = 0
-flags_transparent = false
 flags_unshaded = true
-flags_vertex_lighting = false
-flags_no_depth_test = false
-flags_use_point_size = false
-flags_world_triplanar = false
-flags_fixed_size = false
 flags_albedo_tex_force_srgb = true
-vertex_color_use_as_albedo = false
-vertex_color_is_srgb = false
-params_diffuse_mode = 1
-params_specular_mode = 0
-params_blend_mode = 0
-params_cull_mode = 0
-params_depth_draw_mode = 0
-params_line_width = 1.0
-params_point_size = 1.0
-params_billboard_mode = 0
-params_grow = false
-params_use_alpha_scissor = false
-albedo_color = Color( 1, 1, 1, 1 )
-albedo_texture = SubResource( 2 )
-metallic = 0.0
-metallic_specular = 0.5
-metallic_texture_channel = 0
-roughness = 0.0
-roughness_texture_channel = 0
-emission_enabled = true
-emission = Color( 0, 0, 0, 1 )
-emission_energy = 1.0
-emission_operator = 0
-emission_on_uv2 = false
-normal_enabled = false
-rim_enabled = false
-clearcoat_enabled = false
-anisotropy_enabled = false
-ao_enabled = false
-depth_enabled = false
-subsurf_scatter_enabled = false
-transmission_enabled = false
-refraction_enabled = false
-detail_enabled = false
-uv1_scale = Vector3( 1, 1, 1 )
-uv1_offset = Vector3( 0, 0, 0 )
-uv1_triplanar = false
-uv1_triplanar_sharpness = 1.0
-uv2_scale = Vector3( 1, 1, 1 )
-uv2_offset = Vector3( 0, 0, 0 )
-uv2_triplanar = false
-uv2_triplanar_sharpness = 1.0
-proximity_fade_enable = false
-distance_fade_enable = false
+albedo_texture = SubResource( 15 )
 
 [sub_resource type="GDScript" id=4]
 
@@ -88,7 +34,6 @@ script = SubResource( 4 )
 
 length = 6.0
 loop = true
-step = 0.1
 tracks/0/type = "value"
 tracks/0/path = NodePath("Camera:transform")
 tracks/0/interp = 1
@@ -104,9 +49,6 @@ tracks/0/keys = {
 
 [sub_resource type="PlaneMesh" id=7]
 
-size = Vector2( 2, 2 )
-subdivide_width = 0
-subdivide_depth = 0
 
 [sub_resource type="GDScript" id=8]
 
@@ -134,62 +76,11 @@ func e():
 
 [sub_resource type="CubeMesh" id=11]
 
-size = Vector3( 2, 2, 2 )
-subdivide_width = 0
-subdivide_height = 0
-subdivide_depth = 0
 
 [sub_resource type="SpatialMaterial" id=12]
 
-render_priority = 0
-flags_transparent = false
-flags_unshaded = false
-flags_vertex_lighting = false
-flags_no_depth_test = false
-flags_use_point_size = false
-flags_world_triplanar = false
-flags_fixed_size = false
-flags_albedo_tex_force_srgb = false
-vertex_color_use_as_albedo = false
-vertex_color_is_srgb = false
-params_diffuse_mode = 0
-params_specular_mode = 0
-params_blend_mode = 0
-params_cull_mode = 0
-params_depth_draw_mode = 0
-params_line_width = 1.0
-params_point_size = 1.0
-params_billboard_mode = 0
-params_grow = false
-params_use_alpha_scissor = false
 albedo_color = Color( 0.722656, 0.791992, 1, 1 )
-metallic = 0.0
-metallic_specular = 0.5
-metallic_texture_channel = 0
 roughness = 0.0
-roughness_texture_channel = 0
-emission_enabled = false
-normal_enabled = false
-rim_enabled = false
-clearcoat_enabled = false
-anisotropy_enabled = false
-ao_enabled = false
-depth_enabled = false
-subsurf_scatter_enabled = false
-transmission_enabled = false
-refraction_enabled = false
-detail_enabled = false
-uv1_scale = Vector3( 1, 1, 1 )
-uv1_offset = Vector3( 0, 0, 0 )
-uv1_triplanar = false
-uv1_triplanar_sharpness = 1.0
-uv2_scale = Vector3( 1, 1, 1 )
-uv2_offset = Vector3( 0, 0, 0 )
-uv2_triplanar = false
-uv2_triplanar_sharpness = 1.0
-proximity_fade_enable = false
-distance_fade_enable = false
-_sections_unfolded = [ "Albedo" ]
 
 [sub_resource type="GDScript" id=13]
 
@@ -199,371 +90,114 @@ func e():
 	return 0
 "
 
-[node name="Gui_in_3D" type="Spatial" index="0"]
-
+[node name="Gui_in_3D" type="Spatial"]
 script = ExtResource( 1 )
 
-[node name="Viewport" type="Viewport" parent="." index="0"]
-
-editor/display_folded = true
-arvr = false
+[node name="Viewport" type="Viewport" parent="."]
 size = Vector2( 180, 180 )
-own_world = false
-world = null
 transparent_bg = true
-msaa = 0
 hdr = false
-disable_3d = false
 usage = 0
-debug_draw = 0
 render_target_v_flip = true
-render_target_clear_mode = 0
-render_target_update_mode = 2
-audio_listener_enable_2d = false
-audio_listener_enable_3d = false
-physics_object_picking = false
-gui_disable_input = false
-gui_snap_controls_to_pixels = true
-shadow_atlas_size = 0
-shadow_atlas_quad_0 = 2
-shadow_atlas_quad_1 = 2
-shadow_atlas_quad_2 = 3
-shadow_atlas_quad_3 = 4
-_sections_unfolded = [ "Render Target", "Rendering" ]
 
-[node name="GUI" type="Control" parent="Viewport" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="GUI" type="Control" parent="Viewport"]
 margin_right = 40.0
 margin_bottom = 40.0
-rect_pivot_offset = Vector2( 0, 0 )
 mouse_filter = 1
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-_sections_unfolded = [ "Mouse" ]
 
-[node name="Label" type="Label" parent="Viewport/GUI" index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Label" type="Label" parent="Viewport/GUI"]
 margin_left = 44.0
 margin_top = 27.0
 margin_right = 121.0
 margin_bottom = 41.0
-rect_pivot_offset = Vector2( 0, 0 )
-mouse_filter = 2
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 4
 text = "Hello world!"
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
 
-[node name="Button" type="Button" parent="Viewport/GUI" index="1"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="Button" type="Button" parent="Viewport/GUI"]
 margin_left = 18.0
 margin_top = 46.0
 margin_right = 155.0
 margin_bottom = 73.0
-rect_pivot_offset = Vector2( 0, 0 )
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 1
-toggle_mode = false
-enabled_focus_mode = 2
-shortcut = null
-group = null
 text = "A button!"
-flat = false
-align = 1
 
-[node name="HSlider" type="HSlider" parent="Viewport/GUI" index="2"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="HSlider" type="HSlider" parent="Viewport/GUI"]
 margin_left = 14.0
 margin_top = 118.0
 margin_right = 157.0
 margin_bottom = 134.0
-rect_pivot_offset = Vector2( 0, 0 )
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 1
-size_flags_vertical = 0
-min_value = 0.0
-max_value = 100.0
-step = 1.0
-page = 0.0
-value = 0.0
-exp_edit = false
-rounded = false
-editable = true
-tick_count = 0
-ticks_on_borders = false
-focus_mode = 2
 
-[node name="TextEdit" type="LineEdit" parent="Viewport/GUI" index="3"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+[node name="TextEdit" type="LineEdit" parent="Viewport/GUI"]
 margin_left = 18.0
 margin_top = 87.0
 margin_right = 156.0
 margin_bottom = 111.0
-rect_pivot_offset = Vector2( 0, 0 )
-focus_mode = 2
-mouse_filter = 0
-mouse_default_cursor_shape = 1
-size_flags_horizontal = 1
-size_flags_vertical = 1
-focus_mode = 2
-context_menu_enabled = true
-placeholder_alpha = 0.6
-caret_blink = false
-caret_blink_speed = 0.65
-caret_position = 0
 
-[node name="Area" type="Area" parent="." index="1"]
-
+[node name="Area" type="Area" parent="."]
 input_ray_pickable = true
 input_capture_on_drag = true
-space_override = 0
-gravity_point = false
-gravity_distance_scale = 0.0
-gravity_vec = Vector3( 0, -1, 0 )
-gravity = 9.8
-linear_damp = 0.1
-angular_damp = 1.0
-priority = 0.0
-monitoring = true
-monitorable = true
-collision_layer = 1
-collision_mask = 1
-audio_bus_override = false
-audio_bus_name = "Master"
-reverb_bus_enable = false
-reverb_bus_name = "Master"
-reverb_bus_amount = 0.0
-reverb_bus_uniformity = 0.0
-_sections_unfolded = [ "Transform" ]
 
-[node name="Quad" type="MeshInstance" parent="Area" index="0"]
+[node name="Quad" type="MeshInstance" parent="Area"]
+mesh = SubResource( 14 )
+material/0 = SubResource( 16 )
 
-transform = Transform( -1, 8.74228e-08, -4.37114e-08, -4.37114e-08, 1.91069e-15, 1, 8.74228e-08, 1, 1.91069e-15, 0, 0, 0 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
-mesh = SubResource( 1 )
-skeleton = NodePath("..")
-material/0 = SubResource( 3 )
-_sections_unfolded = [ "Geometry", "Transform", "material" ]
-
-[node name="CollisionShape" type="CollisionShape" parent="Area" index="1"]
-
+[node name="CollisionShape" type="CollisionShape" parent="Area"]
 shape = SubResource( 5 )
-disabled = false
 
-[node name="Camera" type="Camera" parent="." index="2"]
-
+[node name="Camera" type="Camera" parent="."]
 transform = Transform( 0.994592, 0, 0.103856, 0, 1, 0, -0.103856, 0, 0.994592, 0.465682, 0, 1.78523 )
-keep_aspect = 1
-cull_mask = 1048575
-environment = null
-h_offset = 0.0
-v_offset = 0.0
-doppler_tracking = 0
-projection = 0
-current = false
 fov = 74.0
-size = 1.0
 near = 0.1
-far = 100.0
-_sections_unfolded = [ "Transform" ]
 
-[node name="OmniLight" type="OmniLight" parent="." index="3"]
-
+[node name="OmniLight" type="OmniLight" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 1.38866, 1.2413, 2.72141 )
-layers = 1
-light_color = Color( 1, 1, 1, 1 )
-light_energy = 1.0
-light_indirect_energy = 1.0
-light_negative = false
-light_specular = 0.5
-light_bake_mode = 1
-light_cull_mask = -1
 shadow_enabled = true
-shadow_color = Color( 0, 0, 0, 1 )
-shadow_bias = 0.15
-shadow_contact = 0.0
-shadow_reverse_cull_face = false
-editor_only = false
 omni_range = 10.0
-omni_attenuation = 1.0
-omni_shadow_mode = 1
-omni_shadow_detail = 1
-_sections_unfolded = [ "Light", "Omni", "Shadow" ]
 
-[node name="Camera_Move" type="AnimationPlayer" parent="." index="4"]
-
-root_node = NodePath("..")
+[node name="Camera_Move" type="AnimationPlayer" parent="."]
 autoplay = "Move_camera"
-playback_process_mode = 1
-playback_default_blend_time = 0.0
-playback_speed = 1.0
 anims/Move_camera = SubResource( 6 )
-blend_times = [  ]
-autoplay = "Move_camera"
 
-[node name="3D_background" type="Spatial" parent="." index="5"]
-
+[node name="3D_background" type="Spatial" parent="."]
 editor/display_folded = true
 
-[node name="Wall" type="MeshInstance" parent="3D_background" index="0"]
-
+[node name="Wall" type="MeshInstance" parent="3D_background"]
 transform = Transform( 4, 0, 0, 0, -1.74846e-07, -4, 0, 4, -1.74846e-07, -2.60819, 0.589247, -2.08943 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
 mesh = SubResource( 7 )
-skeleton = NodePath("..")
 material/0 = null
 script = SubResource( 8 )
-_sections_unfolded = [ "Transform" ]
 
-[node name="Wall2" type="MeshInstance" parent="3D_background" index="1"]
-
+[node name="Wall2" type="MeshInstance" parent="3D_background"]
 transform = Transform( 4, 0, 0, 0, -1.74846e-07, -4, 0, 4, -1.74846e-07, 5.08055, 0.589247, -2.08943 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
 mesh = SubResource( 7 )
-skeleton = NodePath("..")
 material/0 = null
 script = SubResource( 8 )
-_sections_unfolded = [ "Transform" ]
 
-[node name="Wall3" type="MeshInstance" parent="3D_background" index="2"]
-
+[node name="Wall3" type="MeshInstance" parent="3D_background"]
 transform = Transform( -1.74846e-07, -4, 0, -1.74846e-07, 7.64274e-15, -4, 4, -1.74846e-07, -1.74846e-07, 9.04446, 0.589247, 1.62058 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
 mesh = SubResource( 7 )
-skeleton = NodePath("..")
 material/0 = null
 script = SubResource( 9 )
-_sections_unfolded = [ "Transform" ]
 
-[node name="Floor" type="MeshInstance" parent="3D_background" index="3"]
-
+[node name="Floor" type="MeshInstance" parent="3D_background"]
 transform = Transform( 4, 0, 0, 0, 4, 0, 0, 0, 4, -2.60819, -2.68765, 1.46502 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
 mesh = SubResource( 7 )
-skeleton = NodePath("..")
 material/0 = null
 script = SubResource( 10 )
-_sections_unfolded = [ "Transform" ]
 
-[node name="Floor2" type="MeshInstance" parent="3D_background" index="4"]
-
+[node name="Floor2" type="MeshInstance" parent="3D_background"]
 transform = Transform( 4, 0, 0, 0, 4, 0, 0, 0, 4, 5.08055, -2.68765, 1.46502 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
 mesh = SubResource( 7 )
-skeleton = NodePath("..")
 material/0 = null
 script = SubResource( 10 )
-_sections_unfolded = [ "Transform" ]
 
-[node name="Cube" type="MeshInstance" parent="3D_background" index="5"]
-
+[node name="Cube" type="MeshInstance" parent="3D_background"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4.25901, -0.598608, 0.374871 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
 mesh = SubResource( 11 )
-skeleton = NodePath("..")
 material/0 = SubResource( 12 )
 script = SubResource( 13 )
-_sections_unfolded = [ "Transform" ]
 
-[node name="Cube2" type="MeshInstance" parent="3D_background" index="6"]
-
+[node name="Cube2" type="MeshInstance" parent="3D_background"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2.88761, 2.01326, 0.374871 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
 mesh = SubResource( 11 )
-skeleton = NodePath("..")
 material/0 = SubResource( 12 )
 script = SubResource( 13 )
-_sections_unfolded = [ "Transform" ]
+

--- a/viewport/gui_in_3d/default_env.tres
+++ b/viewport/gui_in_3d/default_env.tres
@@ -2,24 +2,12 @@
 
 [sub_resource type="ProceduralSky" id=1]
 
-radiance_size = 4
 sky_top_color = Color( 0.0375977, 0.322787, 0.6875, 1 )
 sky_horizon_color = Color( 0.262024, 0.533321, 0.621094, 1 )
 sky_curve = 0.25
-sky_energy = 1.0
 ground_bottom_color = Color( 0.101961, 0.145098, 0.188235, 1 )
 ground_horizon_color = Color( 0.482353, 0.788235, 0.952941, 1 )
 ground_curve = 0.01
-ground_energy = 1.0
-sun_color = Color( 1, 1, 1, 1 )
-sun_latitude = 35.0
-sun_longitude = 0.0
-sun_angle_min = 1.0
-sun_angle_max = 100.0
-sun_curve = 0.05
-sun_energy = 16.0
-texture_size = 2
-_sections_unfolded = [ "Sky" ]
 
 [sub_resource type="GDScript" id=2]
 
@@ -33,80 +21,9 @@ func e():
 
 background_mode = 2
 background_sky = SubResource( 1 )
-background_sky_custom_fov = 0.0
-background_color = Color( 0, 0, 0, 1 )
-background_energy = 1.0
-background_canvas_max_layer = 0
 ambient_light_color = Color( 1, 1, 1, 1 )
 ambient_light_energy = 0.28
 ambient_light_sky_contribution = 0.0
-fog_enabled = false
-fog_color = Color( 0.5, 0.6, 0.7, 1 )
-fog_sun_color = Color( 1, 0.9, 0.7, 1 )
-fog_sun_amount = 0.0
-fog_depth_enabled = true
-fog_depth_begin = 10.0
-fog_depth_curve = 1.0
-fog_transmit_enabled = false
-fog_transmit_curve = 1.0
-fog_height_enabled = false
-fog_height_min = 0.0
-fog_height_max = 100.0
-fog_height_curve = 1.0
-tonemap_mode = 0
-tonemap_exposure = 1.0
-tonemap_white = 1.0
-auto_exposure_enabled = false
-auto_exposure_scale = 0.4
-auto_exposure_min_luma = 0.05
-auto_exposure_max_luma = 8.0
-auto_exposure_speed = 0.5
-ss_reflections_enabled = false
-ss_reflections_max_steps = 64
-ss_reflections_fade_in = 0.15
-ss_reflections_fade_out = 2.0
-ss_reflections_depth_tolerance = 0.2
-ss_reflections_roughness = true
-ssao_enabled = false
-ssao_radius = 1.0
-ssao_intensity = 1.0
-ssao_radius2 = 0.0
-ssao_intensity2 = 1.0
-ssao_bias = 0.01
-ssao_light_affect = 0.0
-ssao_color = Color( 0, 0, 0, 1 )
-ssao_quality = 0
 ssao_blur = 1
-ssao_edge_sharpness = 4.0
-dof_blur_far_enabled = false
-dof_blur_far_distance = 10.0
-dof_blur_far_transition = 5.0
-dof_blur_far_amount = 0.1
-dof_blur_far_quality = 1
-dof_blur_near_enabled = false
-dof_blur_near_distance = 2.0
-dof_blur_near_transition = 1.0
-dof_blur_near_amount = 0.1
-dof_blur_near_quality = 1
-glow_enabled = false
-glow_levels/1 = false
-glow_levels/2 = false
-glow_levels/3 = true
-glow_levels/4 = false
-glow_levels/5 = true
-glow_levels/6 = false
-glow_levels/7 = false
-glow_intensity = 0.8
-glow_strength = 1.0
-glow_bloom = 0.0
-glow_blend_mode = 2
-glow_hdr_threshold = 1.0
-glow_hdr_scale = 2.0
-glow_bicubic_upscale = false
-adjustment_enabled = false
-adjustment_brightness = 1.0
-adjustment_contrast = 1.0
-adjustment_saturation = 1.0
 script = SubResource( 2 )
-_sections_unfolded = [ "Ambient Light" ]
 

--- a/viewport/gui_in_3d/icon.png.import
+++ b/viewport/gui_in_3d/icon.png.import
@@ -7,16 +7,14 @@ path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 [deps]
 
 source_file="res://icon.png"
-source_md5="434c8eb4c3320b4afd88f7a34b3a12d6"
-
 dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
-dest_md5="a6b3d106eb33d75fd3532a8554f6daaa"
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
 compress/hdr_mode=0
+compress/bptc_ldr=0
 compress/normal_map=0
 flags/repeat=0
 flags/filter=true
@@ -26,6 +24,7 @@ flags/srgb=2
 process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
+process/invert_color=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/viewport/gui_in_3d/project.godot
+++ b/viewport/gui_in_3d/project.godot
@@ -6,7 +6,12 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=3
+config_version=4
+
+_global_script_classes=[  ]
+_global_script_class_icons={
+
+}
 
 [application]
 


### PR DESCRIPTION
it's fine when opening 3d in gui demo with Godot 3.0.x
![screenshot_20190123_050601](https://user-images.githubusercontent.com/8281454/51562552-7b767300-1ecd-11e9-9b7b-dae98370bb61.png)

but with Godot 3.1.beta
![screenshot_20190123_050617](https://user-images.githubusercontent.com/8281454/51562585-8a5d2580-1ecd-11e9-90dd-52e3b0815481.png)

and this show after recreating a material for gui with Godot 3.1.beta
![screenshot_20190123_050641](https://user-images.githubusercontent.com/8281454/51562648-b2e51f80-1ecd-11e9-95d0-213ec8a37de9.png)
