### PR TITLE
Automatic brake/reverse

### DIFF
--- a/3d/truck_town/vehicle.gd
+++ b/3d/truck_town/vehicle.gd
@@ -10,6 +10,8 @@ var steer_target = 0
 export var engine_force_value = 40
 
 func _physics_process(delta):
+	var fwd_mps = transform.basis.xform_inv(linear_velocity).x
+	
 	if Input.is_action_pressed("ui_left"):
 		steer_target = STEER_LIMIT
 	elif Input.is_action_pressed("ui_right"):
@@ -23,7 +25,10 @@ func _physics_process(delta):
 		engine_force = 0
 	
 	if Input.is_action_pressed("ui_down"):
-		brake = 1
+		if (fwd_mps >= -1):
+			engine_force = -engine_force_value
+		else:
+			brake = 1
 	else:
 		brake = 0.0
 	


### PR DESCRIPTION
Value fwd_mps converts global velocity into a velocity vector which is rotated to cars local coordinate system (in this example x-axis).
Then if key "ui_down" is pressed and the fwd_mps value is greater or equal to -1 (which seems to be very good spot and represents car still moving forward but nearly standing still) the car reverses (negative engine_force_value). If this condition isn't met (which means the car is moving forward) then the car brakes.

Tested and working on Godot 3.1 Beta 3.

Suggestions:
In this case, if you want something more realistic, the -engine_force_value can be much lower because no car reverses in same speed as it goes forward but for the sake of demo project I left it as it is.

Created for my own project with help of user wombatstampede from godotdevelopers.org/forum