### PR TITLE
Updated rotation of Quad to be right side up

### DIFF
--- a/viewport/gui_in_3d/Gui_in_3D.tscn
+++ b/viewport/gui_in_3d/Gui_in_3D.tscn
@@ -125,7 +125,7 @@ input_ray_pickable = true
 input_capture_on_drag = true
 
 [node name="Quad" type="MeshInstance" parent="Area"]
-transform = Transform( -1, 8.74228e-08, -4.37114e-08, -4.37114e-08, 1.91069e-15, 1, 8.74228e-08, 1, 1.91069e-15, 0, 0, 0 )
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0 )
 mesh = SubResource( 1 )
 material/0 = SubResource( 3 )
 


### PR DESCRIPTION
I pulled down the samples and started playing with the 3D GUI and..noticed the GUI was upside down. It was pretty easy to flip it upright, so I thought I'd go ahead and do that and make a pull request. If this isn't the appropriate fix, please advise. 