### PR TITLE
Use p2p in multiplayer bomber player exchange.

### DIFF
--- a/networking/multiplayer_bomber/player.gd
+++ b/networking/multiplayer_bomber/player.gd
@@ -13,7 +13,7 @@ sync func setup_bomb(bomb_name, pos, by_who):
 	bomb.set_name(bomb_name) # Ensure unique name for the bomb
 	bomb.position = pos
 	bomb.from_player = by_who
-	# No need to set network mode to bomb, will be owned by master by default
+	# No need to set network master to bomb, will be owned by server by default
 	get_node("../..").add_child(bomb)
 
 var current_anim = ""


### PR DESCRIPTION
We used to broadcast player info on connect and have the server relay it
to other clients.
With this approach, each peer (including server) sends its own info once
to other peers as soon as they connects.
When a new player connects, it is notified of all the already connected
peers by the `network_peer_connected` signal.
Any already connected peer is also notified of the newly connected peer
by the same signal.

References godotengine/godot#18436