### PR TITLE
Funding and issue template files, and update gitignore

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+patreon: godotengine
+custom: https://godotengine.org/donate

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Please search existing issues for potential duplicates before filing yours:
+https://github.com/godotengine/godot-demo-projects/issues?q=is%3Aissue
+-->
+
+**Which demo project is affected:**
+<!-- Specify the project name or path. -->
+
+
+**OS/device including version:**
+<!-- Specify GPU model and drivers if graphics-related. -->
+
+
+**Issue description:**
+<!-- What happened, and what was expected. -->
+
+
+**Screenshots of issue:**
+<!-- Drag in an image, or link in the form of "![]()". If not relevant, remove this section. -->

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ export_presets.cfg
 
 # Mono-specific ignores
 .mono/
+mono_crash.*.json
 
 # System/tool-specific ignores
 .directory


### PR DESCRIPTION
The mono_crash ignore is because they generated anytime there was a crash and I got them often.  
If accepted I will add this to Godot's gitignore file on GitHub's gitignore repo too. @akien-mga 

The rest of the files mirror the main Godot repo, with FUNDING being the exact same, but the ISSUE_TEMPLATE changed to better reflect this repo (questions such as which demo project, etc). We could also eventually add a CODEOWNERS file if we can get people to maintain specific demos.