### PR TITLE
Update Audio demos for Godot 3.1.1

### DIFF
--- a/audio/bpm_sync/Control.gd
+++ b/audio/bpm_sync/Control.gd
@@ -12,48 +12,46 @@ const SYNC_SOURCE_SOUND_CLOCK = 1
 
 var sync_source = SYNC_SOURCE_SYSTEM_CLOCK
 
+# Used by system clock.
+var time_begin
+var time_delay
+
 
 func strsec(secs):
 	var s = str(secs)
-	if (s.length()==1):
-		s="0"+s
+	if (secs < 10):
+		s = "0" + s
 	return s
-	
-# used by system clock
-var time_begin 
-var time_delay
 
-func _process(delta):
+
+func _process(_delta):
 	if (!playing or !$Player.playing):
 		return
 	
-	var time 
+	var time = 0.0
 	if (sync_source == SYNC_SOURCE_SYSTEM_CLOCK): 
-		# obtain from ticks
+		# Obtain from ticks.
 		time = (OS.get_ticks_usec() - time_begin) / 1000000.0
-		# compensate
-		time -= time_delay		
-	elif (sync_source == SYNC_SOURCE_SOUND_CLOCK):		
-		time = $Player.get_playback_position() + AudioServer.get_time_since_last_mix() - AudioServer.get_output_latency() + (1/COMPENSATE_HZ)*COMPENSATE_FRAMES
-		
+		# Compensate.
+		time -= time_delay
+	elif (sync_source == SYNC_SOURCE_SOUND_CLOCK):
+		time = $Player.get_playback_position() + AudioServer.get_time_since_last_mix() - AudioServer.get_output_latency() + (1 / COMPENSATE_HZ) * COMPENSATE_FRAMES
+	
 	var beat = int(time * BPM / 60.0)
 	var seconds = int(time)
 	var seconds_total = int($Player.stream.get_length())
-	$Label.text = str("BEAT: ",beat % BARS +1,"/",BARS," TIME: ",seconds/60,":",strsec(seconds%60)," / ",seconds_total/60,":",strsec(seconds_total%60))
-	
+	$Label.text = str("BEAT: ", beat % BARS + 1, "/", BARS, " TIME: ", seconds / 60, ":", strsec(seconds % 60), " / ", seconds_total / 60, ":", strsec(seconds_total % 60))
 
 
 func _on_PlaySystem_pressed():
-	pass # Replace with function body.
 	sync_source = SYNC_SOURCE_SYSTEM_CLOCK
 	time_begin = OS.get_ticks_usec()
 	time_delay = AudioServer.get_time_to_next_mix() + AudioServer.get_output_latency()
-	playing=true
+	playing = true
 	$Player.play()
 
 
 func _on_PlaySound_pressed():
 	sync_source = SYNC_SOURCE_SOUND_CLOCK
-	playing=true
+	playing = true
 	$Player.play()
-	

--- a/audio/bpm_sync/player.tscn
+++ b/audio/bpm_sync/player.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=10 format=2]
 
-[ext_resource path="res://the_comeback2.ogg" type="AudioStream" id=1]
-[ext_resource path="res://Control.gd" type="Script" id=2]
-[ext_resource path="res://lcd.ttf" type="DynamicFontData" id=3]
+[ext_resource path="res://Control.gd" type="Script" id=1]
+[ext_resource path="res://lcd.ttf" type="DynamicFontData" id=2]
+[ext_resource path="res://the_comeback2.ogg" type="AudioStream" id=3]
 [ext_resource path="res://play_system_button.png" type="Texture" id=4]
-[ext_resource path="res://play_sound_button.png" type="Texture" id=5]
-[ext_resource path="res://play_system_button_hl.png" type="Texture" id=6]
+[ext_resource path="res://play_system_button_hl.png" type="Texture" id=5]
+[ext_resource path="res://play_sound_button.png" type="Texture" id=6]
 [ext_resource path="res://play_sound_button_hl.png" type="Texture" id=7]
 
 [sub_resource type="StyleBoxFlat" id=1]
@@ -15,13 +15,16 @@ bg_color = Color( 0, 0, 0, 1 )
 size = 40
 outline_size = 2
 outline_color = Color( 0.588235, 0.886275, 0.435294, 0.239216 )
-font_data = ExtResource( 3 )
+font_data = ExtResource( 2 )
 
 [node name="Control" type="Panel"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 custom_styles/panel = SubResource( 1 )
-script = ExtResource( 2 )
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="Label" type="Label" parent="."]
 margin_left = 106.895
@@ -33,7 +36,7 @@ custom_colors/font_color = Color( 0.552941, 0.984314, 0.501961, 1 )
 align = 1
 
 [node name="Player" type="AudioStreamPlayer" parent="."]
-stream = ExtResource( 1 )
+stream = ExtResource( 3 )
 
 [node name="PlaySystem" type="TextureButton" parent="."]
 margin_left = 214.737
@@ -42,15 +45,15 @@ margin_right = 342.737
 margin_bottom = 315.368
 texture_normal = ExtResource( 4 )
 texture_pressed = ExtResource( 4 )
-texture_hover = ExtResource( 6 )
+texture_hover = ExtResource( 5 )
 
 [node name="PlaySound" type="TextureButton" parent="."]
 margin_left = 622.105
 margin_top = 183.158
 margin_right = 750.105
 margin_bottom = 311.158
-texture_normal = ExtResource( 5 )
-texture_pressed = ExtResource( 5 )
+texture_normal = ExtResource( 6 )
+texture_pressed = ExtResource( 6 )
 texture_hover = ExtResource( 7 )
 [connection signal="pressed" from="PlaySystem" to="." method="_on_PlaySystem_pressed"]
 [connection signal="pressed" from="PlaySound" to="." method="_on_PlaySound_pressed"]

--- a/audio/bpm_sync/project.godot
+++ b/audio/bpm_sync/project.godot
@@ -15,4 +15,5 @@ _global_script_class_icons={
 
 [application]
 
+config/name="BPM Sync Demo"
 run/main_scene="res://player.tscn"

--- a/audio/generator/generator.tscn
+++ b/audio/generator/generator.tscn
@@ -4,8 +4,8 @@
 
 [sub_resource type="AudioStreamGenerator" id=1]
 
-[node name="generator" type="Node"]
+[node name="Generator" type="Node"]
 script = ExtResource( 1 )
 
-[node name="player" type="AudioStreamPlayer" parent="."]
+[node name="Player" type="AudioStreamPlayer" parent="."]
 stream = SubResource( 1 )

--- a/audio/generator/generator_demo.gd
+++ b/audio/generator/generator_demo.gd
@@ -1,28 +1,27 @@
 extends Node
 
-
-var hz = 22050.0 # less samples to mix, GDScript is not super fast for this
+var sample_hz = 22050.0 # Keep the number of samples to mix low, GDScript is not super fast.
+var pulse_hz = 440.0
 var phase = 0.0
 
-var pulse_hz = 440.0
-var playback = null #object that does the actual playback
+var playback: AudioStreamPlayback = null # Actual playback stream, assigned in _ready().
 
 func _fill_buffer():
-	var increment = (1.0 / (hz / pulse_hz)) 
-		
+	var increment = pulse_hz / sample_hz
+	
 	var to_fill = playback.get_frames_available()
 	while (to_fill > 0):
-		playback.push_frame( Vector2(1.0,1.0) * sin(phase * (PI * 2.0)) ) # frames are stereo
-		phase = fmod((phase + increment), 1.0)
-		to_fill-=1;
+		playback.push_frame(Vector2.ONE * sin(phase * TAU)) # Audio frames are stereo.
+		phase = fmod(phase + increment, 1.0)
+		to_fill -= 1;
 
-func _process(delta):
+
+func _process(_delta):
 	_fill_buffer()
 
-	
-func _ready():
-	$player.stream.mix_rate=hz #setting hz is only possible before playing
-	playback = $player.get_stream_playback()
-	_fill_buffer() # prefill, do before play to avoid delay 
-	$player.play() # start
 
+func _ready():
+	$Player.stream.mix_rate = sample_hz # Setting mix rate is only possible before play().
+	playback = $Player.get_stream_playback()
+	_fill_buffer() # Prefill, do before play() to avoid delay.
+	$Player.play()

--- a/audio/generator/project.godot
+++ b/audio/generator/project.godot
@@ -15,4 +15,5 @@ _global_script_class_icons={
 
 [application]
 
+config/name="Audio Generator Demo"
 run/main_scene="res://generator.tscn"

--- a/audio/mic_record/MicRecord.gd
+++ b/audio/mic_record/MicRecord.gd
@@ -7,6 +7,7 @@ func _ready():
 	var idx = AudioServer.get_bus_index("Record")
 	effect = AudioServer.get_bus_effect(idx, 0)
 
+
 func _on_RecordButton_pressed():
 	if effect.is_recording_active():
 		recording = effect.get_recording()
@@ -22,6 +23,7 @@ func _on_RecordButton_pressed():
 		$RecordButton.text = "Stop"
 		$Status.text = "Recording..."
 
+
 func _on_PlayButton_pressed():
 	print(recording)
 	print(recording.format)
@@ -33,6 +35,7 @@ func _on_PlayButton_pressed():
 	$AudioStreamPlayer.stream = recording
 	$AudioStreamPlayer.play()
 
+
 func _on_Play_Music_pressed():
 	if $AudioStreamPlayer2.playing:
 		$AudioStreamPlayer2.stop()
@@ -40,6 +43,7 @@ func _on_Play_Music_pressed():
 	else:
 		$AudioStreamPlayer2.play()
 		$PlayMusic.text = "Stop Music"
+
 
 func _on_SaveButton_pressed():
 	var save_path = $SaveButton/Filename.text

--- a/audio/mic_record/MicRecord.tscn
+++ b/audio/mic_record/MicRecord.tscn
@@ -61,7 +61,6 @@ margin_left = 120.0
 margin_top = 300.0
 margin_right = 520.0
 margin_bottom = 340.0
-
 [connection signal="pressed" from="RecordButton" to="." method="_on_RecordButton_pressed"]
 [connection signal="pressed" from="SaveButton" to="." method="_on_SaveButton_pressed"]
 [connection signal="pressed" from="PlayButton" to="." method="_on_PlayButton_pressed"]

--- a/audio/mic_record/default_bus_layout.tres
+++ b/audio/mic_record/default_bus_layout.tres
@@ -12,4 +12,3 @@ bus/1/volume_db = 0.0
 bus/1/send = "Master"
 bus/1/effect/0/effect = SubResource( 1 )
 bus/1/effect/0/enabled = true
-

--- a/audio/mic_record/default_env.tres
+++ b/audio/mic_record/default_env.tres
@@ -9,4 +9,3 @@ ground_horizon_color = Color( 0.423529, 0.396078, 0.372549, 1 )
 [resource]
 background_mode = 2
 background_sky = SubResource( 1 )
-

--- a/audio/spectrum/project.godot
+++ b/audio/spectrum/project.godot
@@ -15,4 +15,5 @@ _global_script_class_icons={
 
 [application]
 
+config/name="Audio Spectrum Demo"
 run/main_scene="res://show_spectrum.tscn"

--- a/audio/spectrum/show_spectrum.gd
+++ b/audio/spectrum/show_spectrum.gd
@@ -1,7 +1,6 @@
 extends Node2D
 
-
-const VU_COUNT=16
+const VU_COUNT = 16
 const FREQ_MAX = 11050.0
 
 const WIDTH = 400
@@ -12,25 +11,21 @@ const MIN_DB = 60
 var spectrum
 
 func _draw():
-		
+	#warning-ignore:integer_division
 	var w = WIDTH / VU_COUNT
 	var prev_hz = 0
-	for i in range(1,VU_COUNT+1):	
+	for i in range(1, VU_COUNT+1):	
 		var hz = i * FREQ_MAX / VU_COUNT;
-		var f = spectrum.get_magnitude_for_frequency_range(prev_hz,hz)
-		var energy = clamp((MIN_DB + linear2db(f.length()))/MIN_DB,0,1)
-		#print("db ",db,": ",f.length())
+		var magnitude: float = spectrum.get_magnitude_for_frequency_range(prev_hz, hz).length()
+		var energy = clamp((MIN_DB + linear2db(magnitude)) / MIN_DB, 0, 1)
 		var height = energy * HEIGHT
-		draw_rect(Rect2(w*i,HEIGHT-height,w,height),Color(1,1,1))
+		draw_rect(Rect2(w * i, HEIGHT - height, w, height), Color.white)
 		prev_hz = hz
-	
 
-func _process(delta):
+
+func _process(_delta):
 	update()
+
 
 func _ready():
 	spectrum = AudioServer.get_bus_effect_instance(0,0)
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#	pass

--- a/audio/spectrum/show_spectrum.tscn
+++ b/audio/spectrum/show_spectrum.tscn
@@ -3,9 +3,9 @@
 [ext_resource path="res://show_spectrum.gd" type="Script" id=1]
 [ext_resource path="res://maldita.ogg" type="AudioStream" id=2]
 
-[node name="show_spectrum" type="Node2D"]
+[node name="ShowSpectrum" type="Node2D"]
 script = ExtResource( 1 )
 
-[node name="player" type="AudioStreamPlayer" parent="."]
+[node name="Player" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 2 )
 autoplay = true


### PR DESCRIPTION
A lot of this is just style and typo fixes, but there are also some minor optimizations and renamings, as well as fixing warnings. Also, 3 of the 4 projects were lacking a `config/name`, so I added them.

Note: The BPM Sync demo requires Godot 3.2. I still made some improvements to it, but it doesn't actually work in 3.1.1. We can remove the BPM Sync demo in the 3.1 branch after 3.2's release.