### PR TITLE
Disable ETC2 texture compression in the Material Testers demo

### DIFF
--- a/3d/material_testers/project.godot
+++ b/3d/material_testers/project.godot
@@ -29,4 +29,5 @@ multithread/thread_rid_pool_prealloc=60
 
 [rendering]
 
+vram_compression/import_etc2=false
 quality/filters/msaa=2


### PR DESCRIPTION
Importing ETC2 textures is slow and requires a lot of RAM, so it makes sense to disable it. Those who would like to run the demo on mobile platforms can re-enable it in the Project Settings.