### PR TITLE
Update README and LICENSE for Godot 3.2

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,27 +1,21 @@
-                             GODOT ENGINE
-                      http://www.godotengine.org
+Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur.  
+Copyright (c) 2014-2020 Godot Engine contributors.
 
-************************************************************************
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
- Copyright (c) 2007-2016 Juan Linietsky, Ariel Manzur.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
- Permission is hereby granted, free of charge, to any person obtaining
- a copy of this software and associated documentation files (the
- "Software"), to deal in the Software without restriction, including
- without limitation the rights to use, copy, modify, merge, publish,
- distribute, sublicense, and/or sell copies of the Software, and to
- permit persons to whom the Software is furnished to do so, subject to
- the following conditions:
-
- The above copyright notice and this permission notice shall be
- included in all copies or substantial portions of the Software.
-
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
- CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
- SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-************************************************************************
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Each folder containing a `project.godot` file is a demo project meant to
 be used with [Godot Engine](https://godotengine.org), the open source
 2D and 3D game engine.
 
-## Important note
+## Godot versions
 
-- The `master` branch is compatible with the latest stable Godot version (currently 3.1).
+- The [`master`](https://github.com/godotengine/godot-demo-projects) branch is compatible with the latest stable Godot version (currently 3.2).
 - If you are using an older version of Godot, use the appropriate branch for your Godot version:
 
+  - [`3.1`](https://github.com/godotengine/godot-demo-projects/tree/3.1) branch
+  for Godot 3.1.x.
   - [`3.0`](https://github.com/godotengine/godot-demo-projects/tree/3.0) branch
   for Godot 3.0.x.
   - [`2.1`](https://github.com/godotengine/godot-demo-projects/tree/2.1) branch


### PR DESCRIPTION
Error #404: 3.1 branch not found. Let's fix that!

As of this README update, the `master` branch will use Godot 3.2, and we will create a 3.1 branch from the merge commit of this PR. @akien-mga 

The README and LICENSE files were also updated for the older branches in #402 and #403 (these have minimal changes to the license for simplicity, also I merged them in advance, hope that's fine), and see also https://github.com/godotengine/tps-demo/pull/47.

This also closes #389 