### PR TITLE
Improve the issue template and add a PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,8 @@
-<!-- Please search existing issues for potential duplicates before filing yours:
+<!--
+Please search existing issues for potential duplicates before filing yours:
 https://github.com/godotengine/godot-demo-projects/issues?q=is%3Aissue
+
+Only submit an issue if it is reproducible with the latest stable Godot version.
 -->
 
 **Which demo project is affected:**
@@ -11,8 +14,12 @@ https://github.com/godotengine/godot-demo-projects/issues?q=is%3Aissue
 
 
 **Issue description:**
-<!-- What happened, and what was expected. -->
+<!-- What happened, what was expected, and what went wrong. -->
 
 
 **Screenshots of issue:**
-<!-- Drag in an image, or link in the form of "![]()". If not relevant, remove this section. -->
+<!--
+This section is optional.
+Drag in an image, or post an image with a link in the form of:
+![Alt Text Here](https://pbs.twimg.com/media/DW5AJnZVAAM1805?format=jpg)
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+Only submit a pull request if all of the following conditions are met:
+
+* It must work with the latest stable Godot version. Do not submit a
+  pull request if it only works with alpha/beta builds.
+
+* It must follow all of the Godot style guides, including the GDScript
+  style guide and the C# style guide.
+
+* The demo should not be overcomplicated. Simplicity is usually preferred.
+
+* If you are submitting a new demo, please ensure that it includes a
+  README file similar to the other demos.
+
+* If you are submitting a copy of a demo translated to C# etc:
+
+    * Please ensure that there is a good reason to have this demo translated.
+      We don't want to have multiple copies of every single project.
+
+    * Please ensure that the code mirrors the original closely.
+
+    * In the project.godot file and in the README, include "with C#" etc in
+      the title, and also include a link to the original in the README.
+-->


### PR DESCRIPTION
Improve the comments in the issue template, and the PR template is entirely one comment.

Both mention working with the latest stable version, closes #440.