### PR TITLE
Move Dodge the Creeps license information into the README files

### DIFF
--- a/2d/dodge_the_creeps/README.md
+++ b/2d/dodge_the_creeps/README.md
@@ -17,3 +17,11 @@ Note: There is a C# version available [here](https://github.com/godotengine/godo
 ## Screenshots
 
 ![GIF from the documentation](https://docs.godotengine.org/en/latest/_images/dodge_preview.gif)
+
+## Licenses
+
+`art/House In a Forest Loop.ogg` Copyright &copy; 2012 [HorrorPen](https://opengameart.org/users/horrorpen), [CC-BY 3.0: Attribution](http://creativecommons.org/licenses/by/3.0/). Source: https://opengameart.org/content/loop-house-in-a-forest
+
+Images are from "Abstract Platformer". Copyright &copy; 2010-2020 kenney.nl, [CC0 1.0 Universal](http://creativecommons.org/publicdomain/zero/1.0/). Source: https://www.kenney.nl/assets/abstract-platformer
+
+Font is "Xolonium". Copyright &copy; 2011-2016 Severin Meyer <sev.ch@web.de>, with Reserved Font Name Xolonium, SIL open font license version 1.1. Details are in `fonts/LICENSE.txt`.

--- a/2d/dodge_the_creeps/attributions.txt
+++ b/2d/dodge_the_creeps/attributions.txt
@@ -1,2 +1,0 @@
-"Abstract Platformer" by kenney.nl is licensed under http://creativecommons.org/publicdomain/zero/1.0/
-"House in a Forest Loop" by https://opengameart.org/users/horrorpen is licensed under http://creativecommons.org/licenses/by/3.0/

--- a/mono/dodge_the_creeps/README.md
+++ b/mono/dodge_the_creeps/README.md
@@ -17,3 +17,11 @@ Note: There is a GDScript version available [here](https://github.com/godotengin
 ## Screenshots
 
 ![GIF from the documentation](https://docs.godotengine.org/en/latest/_images/dodge_preview.gif)
+
+## Licenses
+
+`art/House In a Forest Loop.ogg` Copyright &copy; 2012 [HorrorPen](https://opengameart.org/users/horrorpen), [CC-BY 3.0: Attribution](http://creativecommons.org/licenses/by/3.0/). Source: https://opengameart.org/content/loop-house-in-a-forest
+
+Images are from "Abstract Platformer". Copyright &copy; 2010-2020 kenney.nl, [CC0 1.0 Universal](http://creativecommons.org/publicdomain/zero/1.0/). Source: https://www.kenney.nl/assets/abstract-platformer
+
+Font is "Xolonium". Copyright &copy; 2011-2016 Severin Meyer <sev.ch@web.de>, with Reserved Font Name Xolonium, SIL open font license version 1.1. Details are in `fonts/LICENSE.txt`.


### PR DESCRIPTION
Previously there was a separate `attributions.txt` file, but I think this information is better to have placed in the README file.

Also, Dodge the Creeps with C# was missing copyright statements at all, so technically it was violating copyright if you were to download that project without including the GDScript version that has the copyright statements (such as distribution via the asset library...).
