### PR TITLE
Multitouch View tweaks

### DIFF
--- a/misc/multitouch_view/TouchHelper.gd
+++ b/misc/multitouch_view/TouchHelper.gd
@@ -1,38 +1,33 @@
+extends Node
 # This will track the position of every pointer in its public `state` property, which is a
 # Dictionary, in which each key is a pointer id (integer) and each value its position (Vector2).
 # It works by listening to input events not handled by other means.
 # It also remaps the pointer indices coming from the OS to the lowest available to be friendlier.
 # It can be conveniently setup as a singleton.
 
-extends Node
-
 var state = {}
 var _os2own = {}
 
 func _unhandled_input(event):
 	if event is InputEventScreenTouch:
-		if event.pressed:
-			# Down
-			if !_os2own.has(event.index): # Defensively discard index if already known
+		if event.pressed: # Down.
+			if !_os2own.has(event.index): # Defensively discard index if already known.
 				var ptr_id = _find_free_pointer_id()
 				state[ptr_id] = event.position
 				_os2own[event.index] = ptr_id
-		else:
-			# Up
-			if _os2own.has(event.index): # Defensively discard index if not known
+		else: # Up.
+			if _os2own.has(event.index): # Defensively discard index if not known.
 				var ptr_id = _os2own[event.index]
 				state.erase(ptr_id)
 				_os2own.erase(event.index)
-		return true
-
-	elif event is InputEventScreenDrag:
-		# Move
-		if _os2own.has(event.index): # Defensively discard index if not known
+		get_tree().set_input_as_handled()
+		
+	elif event is InputEventScreenDrag: # Movement.
+		if _os2own.has(event.index): # Defensively discard index if not known.
 			var ptr_id = _os2own[event.index]
 			state[ptr_id] = event.position
-		return true
+		get_tree().set_input_as_handled()
 
-	return false
 
 func _find_free_pointer_id():
 	var used = state.keys()
@@ -40,4 +35,3 @@ func _find_free_pointer_id():
 	while i in used:
 		i += 1
 	return i
-

--- a/misc/multitouch_view/project.godot
+++ b/misc/multitouch_view/project.godot
@@ -27,6 +27,10 @@ TouchHelper="*res://TouchHelper.gd"
 
 singletons=[  ]
 
+[input_devices]
+
+pointing/emulate_touch_from_mouse=true
+
 [rendering]
 
 quality/driver/driver_name="GLES2"

--- a/visual_script/multitouch_view/TouchHelper.gd
+++ b/visual_script/multitouch_view/TouchHelper.gd
@@ -20,15 +20,13 @@ func _unhandled_input(event):
 				var ptr_id = _os2own[event.index]
 				state.erase(ptr_id)
 				_os2own.erase(event.index)
-		return true
+		get_tree().set_input_as_handled()
 		
 	elif event is InputEventScreenDrag: # Movement.
 		if _os2own.has(event.index): # Defensively discard index if not known.
 			var ptr_id = _os2own[event.index]
 			state[ptr_id] = event.position
-		return true
-	
-	return false
+		get_tree().set_input_as_handled()
 
 
 func _find_free_pointer_id():


### PR DESCRIPTION
* Enable touch input from mouse emulation in the GDScript version.

* Fix `return true` etc from a void function. Instead, set input as handled.

* Style tweaks.