### PR TITLE
simplifying steering to a single line with move_toward

### DIFF
--- a/3d/truck_town/vehicle.gd
+++ b/3d/truck_town/vehicle.gd
@@ -1,9 +1,8 @@
 extends VehicleBody
 
-const STEER_SPEED = 0.2
+const STEER_SPEED = 1
 const STEER_LIMIT = 0.4
 
-var steer_angle = 0
 var steer_target = 0
 
 export var engine_force_value = 40
@@ -27,4 +26,4 @@ func _physics_process(delta):
 	else:
 		brake = 0.0
 	
-	steering = lerp(steering, steer_target, STEER_SPEED)
+	steering = move_toward(steering, steer_target, STEER_SPEED*delta)

--- a/3d/truck_town/vehicle.gd
+++ b/3d/truck_town/vehicle.gd
@@ -26,4 +26,4 @@ func _physics_process(delta):
 	else:
 		brake = 0.0
 	
-	steering = move_toward(steering, steer_target, STEER_SPEED*delta)
+	steering = move_toward(steering, steer_target, STEER_SPEED * delta)

--- a/3d/truck_town/vehicle.gd
+++ b/3d/truck_town/vehicle.gd
@@ -1,6 +1,6 @@
 extends VehicleBody
 
-const STEER_SPEED = 1
+const STEER_SPEED = 0.2
 const STEER_LIMIT = 0.4
 
 var steer_angle = 0
@@ -27,13 +27,4 @@ func _physics_process(delta):
 	else:
 		brake = 0.0
 	
-	if steer_target < steer_angle:
-		steer_angle -= STEER_SPEED * delta
-		if steer_target > steer_angle:
-			steer_angle = steer_target
-	elif steer_target > steer_angle:
-		steer_angle += STEER_SPEED * delta
-		if steer_target < steer_angle:
-			steer_angle = steer_target
-	
-	steering = steer_angle
+	steering = lerp(steering, steer_target, STEER_SPEED)


### PR DESCRIPTION
Replaced:
```
	if steer_target < steer_angle:
		steer_angle -= STEER_SPEED * delta
		if steer_target > steer_angle:
			steer_angle = steer_target
	elif steer_target > steer_angle:
		steer_angle += STEER_SPEED * delta
		if steer_target < steer_angle:
			steer_angle = steer_target
	
	steering = steer_angle
```
with
`	steering = move_toward(steering, steer_target, STEER_SPEED * delta)`


<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest stable Godot version. Do not submit a
  pull request if it only works with alpha/beta builds.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
