### PR TITLE
Prevent additional button presses from remapping actions.

### DIFF
--- a/gui/input_mapping/ActionRemapButton.gd
+++ b/gui/input_mapping/ActionRemapButton.gd
@@ -22,6 +22,9 @@ func _unhandled_key_input(event):
 	# you want to work with gamepads.
 	remap_action_to(event)
 	pressed = false
+	
+	# Stop processing inputs once the action has been remapped.
+	set_process_unhandled_key_input(false)
 
 
 func remap_action_to(event):


### PR DESCRIPTION
Fix a bug in gui/input_mapping/ActionRemapButton.gd which causes every previously clicked button to be remapped to the last pressed action.

This may not be the ideal way to prevent the behaviour, but it succeeds in making the buttons work as expected.