### PR TITLE
Update Viewports tutorial to use "frame_post_draw"

### DIFF
--- a/viewport/screen_capture/screen_capture.gd
+++ b/viewport/screen_capture/screen_capture.gd
@@ -4,9 +4,8 @@ onready var captured_image = $CapturedImage
 
 func _on_CaptureButton_pressed():
 	get_viewport().set_clear_mode(Viewport.CLEAR_MODE_ONLY_NEXT_FRAME)
-	# Let two frames pass to make sure the screen was captured.
-	yield(get_tree(), "idle_frame")
-	yield(get_tree(), "idle_frame")
+	# Wait until the frame has finished before getting the texture.
+	yield(VisualServer, "frame_post_draw")
 
 	# Retrieve the captured image.
 	var img = get_viewport().get_texture().get_data()


### PR DESCRIPTION
This is to fix #345. It simply changes a double yield in the Viewports tutorial to be a single yield with "frame_post_draw" instead.
<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest stable Godot version. Do not submit a
  pull request if it only works with alpha/beta builds.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
