### PR TITLE
Replace _input with _unhandled_input in most places

### DIFF
--- a/2d/finite_state_machine/player/bullet/bullet_spawner.gd
+++ b/2d/finite_state_machine/player/bullet/bullet_spawner.gd
@@ -2,7 +2,7 @@ extends Node2D
 
 var bullet = preload("Bullet.tscn")
 
-func _input(event):
+func _unhandled_input(event):
 	if event.is_action_pressed("fire"):
 		fire(owner.look_direction)
 

--- a/2d/finite_state_machine/player/player_state_machine.gd
+++ b/2d/finite_state_machine/player/player_state_machine.gd
@@ -21,7 +21,7 @@ func _change_state(state_name):
 	._change_state(state_name)
 
 
-func _input(event):
+func _unhandled_input(event):
 	# Here we only handle input that can interrupt states, attacking in this case,
 	# otherwise we let the state node handle it.
 	if event.is_action_pressed("attack"):

--- a/2d/finite_state_machine/player/weapon/sword.gd
+++ b/2d/finite_state_machine/player/weapon/sword.gd
@@ -59,7 +59,7 @@ func _change_state(new_state):
 	state = new_state
 
 
-func _input(event):
+func _unhandled_input(event):
 	if not state == States.ATTACK:
 		return
 	if attack_input_state != AttackInputStates.LISTENING:

--- a/2d/finite_state_machine/state_machine/state_machine.gd
+++ b/2d/finite_state_machine/state_machine/state_machine.gd
@@ -41,7 +41,7 @@ func set_active(value):
 		current_state = null
 
 
-func _input(event):
+func _unhandled_input(event):
 	current_state.handle_input(event)
 
 

--- a/2d/hdr/beach_cave.gd
+++ b/2d/hdr/beach_cave.gd
@@ -4,7 +4,7 @@ const CAVE_LIMIT = 1000
 
 onready var cave = $Cave
 
-func _input(event):
+func _unhandled_input(event):
 	if event is InputEventMouseMotion and event.button_mask > 0:
 		var rel_x = event.relative.x
 		var cavepos = cave.position

--- a/2d/navigation/navigation.gd
+++ b/2d/navigation/navigation.gd
@@ -10,7 +10,7 @@ func _process(delta):
 
 # The 'click' event is a custom input action defined in
 # Project > Project Settings > Input Map tab.
-func _input(event):
+func _unhandled_input(event):
 	if not event.is_action_pressed("click"):
 		return
 	_update_navigation_path($Character.position, get_local_mouse_position())

--- a/2d/navigation_astar/character.gd
+++ b/2d/navigation_astar/character.gd
@@ -27,7 +27,7 @@ func _process(_delta):
 		_target_point_world = _path[0]
 
 
-func _input(event):
+func _unhandled_input(event):
 	if event.is_action_pressed("click"):
 		var global_mouse_pos = get_global_mouse_position()
 		if Input.is_key_pressed(KEY_SHIFT):

--- a/2d/navigation_astar/pathfind_astar.gd
+++ b/2d/navigation_astar/pathfind_astar.gd
@@ -42,16 +42,6 @@ func _draw():
 		last_point = current_point
 
 
-# Click and Shift force the start and end position of the path to update,
-# and the node to redraw everything.
-#func _input(event):
-#	if event.is_action_pressed('click') and Input.is_key_pressed(KEY_SHIFT):
-#		# To call the setter method from this script we have to use the explicit self.
-#		self.path_start_position = world_to_map(get_global_mouse_position())
-#	elif event.is_action_pressed('click'):
-#		self.path_end_position = world_to_map(get_global_mouse_position())
-
-
 # Loops through all cells within the map's bounds and
 # adds all points to the astar_node, except the obstacles.
 func astar_add_walkable_cells(obstacle_list = []):

--- a/2d/platformer/assets/art/tileset/tileset.tres
+++ b/2d/platformer/assets/art/tileset/tileset.tres
@@ -47,6 +47,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 0/tile_mode = 0
 0/occluder_offset = Vector2( 0, 0 )
 0/navigation_offset = Vector2( 0, 0 )
+0/shape_offset = Vector2( 0, 0 )
+0/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+0/shape = SubResource( 1 )
+0/shape_one_way = false
+0/shape_one_way_margin = 1.0
 0/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -63,6 +68,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 1/tile_mode = 0
 1/occluder_offset = Vector2( 0, 0 )
 1/navigation_offset = Vector2( 0, 0 )
+1/shape_offset = Vector2( 0, 0 )
+1/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+1/shape = SubResource( 2 )
+1/shape_one_way = false
+1/shape_one_way_margin = 1.0
 1/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -79,6 +89,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 2/tile_mode = 0
 2/occluder_offset = Vector2( 0, 0 )
 2/navigation_offset = Vector2( 0, 0 )
+2/shape_offset = Vector2( 0, 0 )
+2/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+2/shape = SubResource( 5 )
+2/shape_one_way = false
+2/shape_one_way_margin = 1.0
 2/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -95,6 +110,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 3/tile_mode = 0
 3/occluder_offset = Vector2( 0, 0 )
 3/navigation_offset = Vector2( 0, 0 )
+3/shape_offset = Vector2( 0, 0 )
+3/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+3/shape = SubResource( 6 )
+3/shape_one_way = false
+3/shape_one_way_margin = 1.0
 3/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -111,6 +131,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 4/tile_mode = 0
 4/occluder_offset = Vector2( 0, 0 )
 4/navigation_offset = Vector2( 0, 0 )
+4/shape_offset = Vector2( 0, 0 )
+4/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+4/shape = SubResource( 7 )
+4/shape_one_way = false
+4/shape_one_way_margin = 1.0
 4/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -127,6 +152,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 5/tile_mode = 0
 5/occluder_offset = Vector2( 0, 0 )
 5/navigation_offset = Vector2( 0, 0 )
+5/shape_offset = Vector2( 0, 0 )
+5/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+5/shape = SubResource( 8 )
+5/shape_one_way = true
+5/shape_one_way_margin = 1.0
 5/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": true,
@@ -143,6 +173,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 6/tile_mode = 0
 6/occluder_offset = Vector2( 0, 0 )
 6/navigation_offset = Vector2( 0, 0 )
+6/shape_offset = Vector2( 0, 0 )
+6/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+6/shape = SubResource( 9 )
+6/shape_one_way = true
+6/shape_one_way_margin = 1.0
 6/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": true,
@@ -159,6 +194,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 7/tile_mode = 0
 7/occluder_offset = Vector2( 0, 0 )
 7/navigation_offset = Vector2( 0, 0 )
+7/shape_offset = Vector2( 0, 0 )
+7/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+7/shape = SubResource( 10 )
+7/shape_one_way = false
+7/shape_one_way_margin = 1.0
 7/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -175,6 +215,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 8/tile_mode = 0
 8/occluder_offset = Vector2( 0, 0 )
 8/navigation_offset = Vector2( 0, 0 )
+8/shape_offset = Vector2( 0, 0 )
+8/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+8/shape = SubResource( 11 )
+8/shape_one_way = false
+8/shape_one_way_margin = 1.0
 8/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -191,6 +236,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 9/tile_mode = 0
 9/occluder_offset = Vector2( 0, 0 )
 9/navigation_offset = Vector2( 0, 0 )
+9/shape_offset = Vector2( 0, 0 )
+9/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+9/shape = SubResource( 12 )
+9/shape_one_way = false
+9/shape_one_way_margin = 1.0
 9/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -207,6 +257,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 10/tile_mode = 0
 10/occluder_offset = Vector2( 0, 0 )
 10/navigation_offset = Vector2( 0, 0 )
+10/shape_offset = Vector2( 0, 0 )
+10/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+10/shape = SubResource( 3 )
+10/shape_one_way = false
+10/shape_one_way_margin = 1.0
 10/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -223,6 +278,10 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 11/tile_mode = 0
 11/occluder_offset = Vector2( 0, 0 )
 11/navigation_offset = Vector2( 0, 0 )
+11/shape_offset = Vector2( 0, 0 )
+11/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+11/shape_one_way = false
+11/shape_one_way_margin = 0.0
 11/shapes = [  ]
 11/z_index = 0
 12/name = "tree_trunk_1"
@@ -233,6 +292,10 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 12/tile_mode = 0
 12/occluder_offset = Vector2( 0, 0 )
 12/navigation_offset = Vector2( 0, 0 )
+12/shape_offset = Vector2( 0, 0 )
+12/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+12/shape_one_way = false
+12/shape_one_way_margin = 0.0
 12/shapes = [  ]
 12/z_index = 0
 13/name = "tree_base"
@@ -243,6 +306,11 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 13/tile_mode = 0
 13/occluder_offset = Vector2( 0, 0 )
 13/navigation_offset = Vector2( 0, 0 )
+13/shape_offset = Vector2( 0, 0 )
+13/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+13/shape = SubResource( 4 )
+13/shape_one_way = false
+13/shape_one_way_margin = 1.0
 13/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,
@@ -259,5 +327,9 @@ points = PoolVector2Array( 0, 0, 28, 0, 28, 24, 0, 24 )
 14/tile_mode = 0
 14/occluder_offset = Vector2( 0, 0 )
 14/navigation_offset = Vector2( 0, 0 )
+14/shape_offset = Vector2( 0, 0 )
+14/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+14/shape_one_way = false
+14/shape_one_way_margin = 0.0
 14/shapes = [  ]
 14/z_index = 0

--- a/2d/platformer/project.godot
+++ b/2d/platformer/project.godot
@@ -142,6 +142,8 @@ shoot={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":2,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"unicode":0,"echo":false,"script":null)
 , Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777350,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777238,"unicode":0,"echo":false,"script":null)
  ]
 }
 toggle_fullscreen={

--- a/2d/platformer/src/Main/Game.gd
+++ b/2d/platformer/src/Main/Game.gd
@@ -21,7 +21,7 @@ func _notification(what):
 			$Black.queue_free()
 
 
-func _input(event):
+func _unhandled_input(event):
 	if event.is_action_pressed("toggle_fullscreen"):
 		OS.window_fullscreen = not OS.window_fullscreen
 		get_tree().set_input_as_handled()

--- a/3d/ik/fps/example_player.gd
+++ b/3d/ik/fps/example_player.gd
@@ -235,6 +235,3 @@ func _input(event):
 
 func animation_finished(_anim):
 	anim_done = true
-
-
-

--- a/3d/ik/fps/weapon_pistol.dae.import
+++ b/3d/ik/fps/weapon_pistol.dae.import
@@ -24,6 +24,7 @@ meshes/ensure_tangents=true
 meshes/storage=0
 meshes/light_baking=0
 meshes/lightmap_texel_size=0.1
+skins/use_named_skins=true
 external_files/store_in_subdir=false
 animation/import=false
 animation/fps=15

--- a/3d/ik/godot_battle_bot.dae.import
+++ b/3d/ik/godot_battle_bot.dae.import
@@ -24,6 +24,7 @@ meshes/ensure_tangents=true
 meshes/storage=0
 meshes/light_baking=0
 meshes/lightmap_texel_size=0.1
+skins/use_named_skins=true
 external_files/store_in_subdir=false
 animation/import=true
 animation/fps=15

--- a/3d/navmesh/navmesh.gd
+++ b/3d/navmesh/navmesh.gd
@@ -50,7 +50,7 @@ func _process(delta):
 		set_process(false)
 
 
-func _input(event):
+func _unhandled_input(event):
 	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and event.pressed:
 		var from = get_node("CameraBase/Camera").project_ray_origin(event.position)
 		var to = from + get_node("CameraBase/Camera").project_ray_normal(event.position) * 100

--- a/misc/window_management/control.gd
+++ b/misc/window_management/control.gd
@@ -63,7 +63,7 @@ func _physics_process(_delta):
 	$Button_MouseModeCaptured.set_pressed(Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED)
 
 
-func _input(event):
+func _unhandled_input(event):
 	if event is InputEventMouseMotion:
 		mousepos = event.position
 

--- a/misc/window_management/observer/observer.gd
+++ b/misc/window_management/observer/observer.gd
@@ -25,10 +25,10 @@ func _process(delta):
 
 
 func _input(event):
-	if (event is InputEventMouseMotion):
+	if event is InputEventMouseMotion:
 		r_pos = -event.relative
 	
-	if (event.is_action("ui_cancel") and event.is_pressed() and !event.is_echo()):
+	if event.is_action("ui_cancel") and event.is_pressed() and !event.is_echo():
 		if (state == STATE_GRAB):
 			Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 			state = STATE_MENU

--- a/viewport/3d_scaling/hud.gd
+++ b/viewport/3d_scaling/hud.gd
@@ -20,7 +20,7 @@ func _ready():
 	get_viewport().connect("size_changed", self, "_root_viewport_size_changed")
 
 
-func _input(event):
+func _unhandled_input(event):
 	if event.is_action_pressed("cycle_viewport_resolution"):
 		scale_factor = wrapf(scale_factor + 0.25, 0.25, 2.25)
 		viewport.size = get_viewport().size * scale_factor

--- a/viewport/gui_in_3d/gui_3d.gd
+++ b/viewport/gui_in_3d/gui_3d.gd
@@ -32,7 +32,7 @@ func _mouse_entered_area():
 	is_mouse_inside = true
 
 
-func _input(event):
+func _unhandled_input(event):
 	# Check if the event is a non-mouse/non-touch event
 	var is_mouse_event = false
 	for mouse_event in [InputEventMouseButton, InputEventMouseMotion, InputEventScreenDrag, InputEventScreenTouch]:
@@ -161,7 +161,7 @@ func rotate_area_to_billboard():
 		look = node_area.translation + look
 		
 		# Y-Billboard: Lock Y rotation, but gives bad results if the camera is tilted.
-		if billboard_mode == 2: 
+		if billboard_mode == 2:
 			look = Vector3(look.x, 0, look.z)
 		
 		node_area.look_at(look, Vector3.UP)


### PR DESCRIPTION
Closes #344. All instances of `_input` were replaced with `_unhandled_input` except for the instances where it is used for controlling an FPS camera (Voxel, IK, and WM demos).

This also serves as a PR for updating and testing some projects with Godot 3.2.2 (beta 4).