### PR TITLE
Remove useless "_find_free_pointer_id" method in Multitouch View

### DIFF
--- a/misc/multitouch_view/TouchHelper.gd
+++ b/misc/multitouch_view/TouchHelper.gd
@@ -12,7 +12,7 @@ func _unhandled_input(event):
 	if event is InputEventScreenTouch:
 		if event.pressed: # Down.
 			if !_os2own.has(event.index): # Defensively discard index if already known.
-				var ptr_id = _find_free_pointer_id()
+				var ptr_id = state.size()
 				state[ptr_id] = event.position
 				_os2own[event.index] = ptr_id
 		else: # Up.
@@ -27,11 +27,3 @@ func _unhandled_input(event):
 			var ptr_id = _os2own[event.index]
 			state[ptr_id] = event.position
 		get_tree().set_input_as_handled()
-
-
-func _find_free_pointer_id():
-	var used = state.keys()
-	var i = 0
-	while i in used:
-		i += 1
-	return i

--- a/visual_script/multitouch_view/TouchHelper.gd
+++ b/visual_script/multitouch_view/TouchHelper.gd
@@ -12,7 +12,7 @@ func _unhandled_input(event):
 	if event is InputEventScreenTouch:
 		if event.pressed: # Down.
 			if !_os2own.has(event.index): # Defensively discard index if already known.
-				var ptr_id = _find_free_pointer_id()
+				var ptr_id = state.size()
 				state[ptr_id] = event.position
 				_os2own[event.index] = ptr_id
 		else: # Up.
@@ -27,11 +27,3 @@ func _unhandled_input(event):
 			var ptr_id = _os2own[event.index]
 			state[ptr_id] = event.position
 		get_tree().set_input_as_handled()
-
-
-func _find_free_pointer_id():
-	var used = state.keys()
-	var i = 0
-	while i in used:
-		i += 1
-	return i


### PR DESCRIPTION
This method incremented a number for every item in `state.keys()` and then returned it. That's the same as `state.keys().size()`, and `state.size()` is the same as that, so we can just replace the helper method with `state.size()`.