### PR TITLE
Disable antialiasing on the font in the 2D platformer demo

### DIFF
--- a/2d/platformer/assets/theme/fonts/kenney_mini_square.tres
+++ b/2d/platformer/assets/theme/fonts/kenney_mini_square.tres
@@ -1,0 +1,5 @@
+[gd_resource type="DynamicFontData" format=2]
+
+[resource]
+antialiased = false
+font_path = "res://assets/theme/fonts/kenney_mini_square.ttf"

--- a/2d/platformer/assets/theme/user_interface.tres
+++ b/2d/platformer/assets/theme/user_interface.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Theme" load_steps=8 format=2]
 
-[ext_resource path="res://assets/theme/fonts/kenney_mini_square.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://assets/theme/fonts/kenney_mini_square.tres" type="DynamicFontData" id=1]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 6.0


### PR DESCRIPTION
Pixel fonts look best when antialiasing is disabled.

## Preview

### Before

![Antialiasing](https://user-images.githubusercontent.com/180032/86363964-e063fa00-bc77-11ea-8925-dc568a304cff.png)

### After

![No antialiasing](https://user-images.githubusercontent.com/180032/86363961-de9a3680-bc77-11ea-8e0c-ebb979f47e0a.png)