### PR TITLE
Godot 3.2 IK demo SkeletonIK error fix

### DIFF
--- a/3d/ik/skeleton_ik.tscn
+++ b/3d/ik/skeleton_ik.tscn
@@ -35,30 +35,6 @@ material/0 = SubResource( 2 )
 [node name="DirectionalLight" type="DirectionalLight" parent="."]
 transform = Transform( 0.56827, 0.673454, -0.472789, 0, 0.574581, 0.818448, 0.822842, -0.465099, 0.326517, -9.77531, 11.5204, 11.766 )
 
-[node name="GodotBattleBot" parent="." instance=ExtResource( 4 )]
-
-[node name="godot_battle_bot" parent="GodotBattleBot/Armature/Skeleton" index="0"]
-material/0 = ExtResource( 6 )
-material/1 = ExtResource( 7 )
-
-[node name="SkeletonIK_Left" type="SkeletonIK" parent="GodotBattleBot/Armature/Skeleton" index="1"]
-process_priority = 1
-root_bone = "Left_UpperArm"
-tip_bone = "Left_Hand"
-use_magnet = true
-magnet = Vector3( 8, 6, 0 )
-target_node = NodePath("../../../../Camera/Targets/TargetLeft")
-script = ExtResource( 1 )
-
-[node name="SkeletonIK_Right" type="SkeletonIK" parent="GodotBattleBot/Armature/Skeleton" index="2"]
-process_priority = 1
-root_bone = "Right_UpperArm"
-tip_bone = "Right_Hand"
-use_magnet = true
-magnet = Vector3( -8, 6, 0 )
-target_node = NodePath("../../../../Camera/Targets/TargetRight")
-script = ExtResource( 1 )
-
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 11.5, 11 )
 fov = 74.0
@@ -87,6 +63,30 @@ transform = Transform( -0.179447, 0.98366, -0.0145678, 0.981822, 0.178142, -0.06
 
 [node name="TargetRight" type="Position3D" parent="Camera/Targets"]
 transform = Transform( -0.0217688, 0.998559, -0.0490576, 0.992503, 0.0274873, 0.119085, 0.120262, -0.0460975, -0.991671, -0.683053, 0.0251284, -0.811513 )
+
+[node name="GodotBattleBot" parent="." instance=ExtResource( 4 )]
+
+[node name="godot_battle_bot" parent="GodotBattleBot/Armature/Skeleton" index="0"]
+material/0 = ExtResource( 6 )
+material/1 = ExtResource( 7 )
+
+[node name="SkeletonIK_Left" type="SkeletonIK" parent="GodotBattleBot/Armature/Skeleton" index="1"]
+process_priority = 1
+root_bone = "Left_UpperArm"
+tip_bone = "Left_Hand"
+use_magnet = true
+magnet = Vector3( 8, 6, 0 )
+target_node = NodePath("../../../../Camera/Targets/TargetLeft")
+script = ExtResource( 1 )
+
+[node name="SkeletonIK_Right" type="SkeletonIK" parent="GodotBattleBot/Armature/Skeleton" index="2"]
+process_priority = 1
+root_bone = "Right_UpperArm"
+tip_bone = "Right_Hand"
+use_magnet = true
+magnet = Vector3( -8, 6, 0 )
+target_node = NodePath("../../../../Camera/Targets/TargetRight")
+script = ExtResource( 1 )
 
 [node name="Control" type="Control" parent="."]
 anchor_right = 1.0


### PR DESCRIPTION
Fixed bug in the IK demo where the SkeletonIK scene would print an error. The issue is that the target nodes are initialized after the SkeletonIK node. Moving the nodes fixed the issue and now no more errors are printed.
