### PR TITLE
Add memory usage to the Voxel demo

### DIFF
--- a/3d/voxel/menu/debug.gd
+++ b/3d/voxel/menu/debug.gd
@@ -12,6 +12,7 @@ func _process(_delta):
 	text = "Position: " + _vector_to_string_appropriate_digits(player.transform.origin)
 	text += "\nEffective render distance: " + str(voxel_world.effective_render_distance)
 	text += "\nLooking: " + _cardinal_string_from_radians(player.transform.basis.get_euler().y)
+	text += "\nMemory: " + "%3.0f" % (OS.get_static_memory_usage() / 1048576.0) + " MiB"
 	text += "\nFPS: " + str(Engine.get_frames_per_second())
 
 


### PR DESCRIPTION
I recently added this to the TPS demo's debug menu, so I figured I would add it to the Voxel demo too.