### PR TITLE
Android IAP Response Code can now return null.

### DIFF
--- a/mobile/android_iap/iap_demo.gd
+++ b/mobile/android_iap/iap_demo.gd
@@ -116,7 +116,7 @@ func _on_QuerySkuDetailsButton_pressed():
 func _on_PurchaseButton_pressed():
 	var response = payment.purchase(TEST_ITEM_SKU)
 	if response.status != OK:
-		show_alert("Purchase error %d: %s" % [response.response_code, response.debug_message])
+		show_alert("Purchase error %s: %s" % [response.response_code, response.debug_message])
 
 
 func _on_ConsumeButton_pressed():

--- a/mono/android_iap/GodotGooglePlayBilling/BillingResult.cs
+++ b/mono/android_iap/GodotGooglePlayBilling/BillingResult.cs
@@ -51,7 +51,7 @@ namespace Android_Iap.GodotGooglePlayBilling
             try
             {
                 Status = (int)billingResult["status"];
-                ResponseCode = (billingResult.Contains("response_code") ? (BillingResponseCode)billingResult["response_code"] : BillingResponseCode.Ok);
+                ResponseCode = (billingResult.Contains("response_code") ? (BillingResponseCode?)billingResult["response_code"] : null);
                 DebugMessage = (billingResult.Contains("debug_message") ? (string)billingResult["debug_message"] : null);
             }
             catch (System.Exception ex)
@@ -61,7 +61,7 @@ namespace Android_Iap.GodotGooglePlayBilling
         }
 
         public int Status { get; set; }
-        public BillingResponseCode ResponseCode { get; set; }
+        public BillingResponseCode? ResponseCode { get; set; }
         public string DebugMessage { get; set; }
     }
 }

--- a/mono/android_iap/Main.cs
+++ b/mono/android_iap/Main.cs
@@ -99,11 +99,11 @@ namespace Android_Iap
             var result = _googlePlayBilling.Purchase("android.test.purchased");
             if (result != null && result.Status == (int)Error.Ok)
             {
-                GD.Print("Bought");
+                GD.Print("Purchase Requested");
             }
             else
             {
-                GD.Print("Failed");
+                GD.Print($"Purchase Failed {result.ResponseCode} {result.DebugMessage}");
             }
         }
 
@@ -112,11 +112,11 @@ namespace Android_Iap
             var result = _googlePlayBilling.Purchase("android.test.canceled");
             if (result != null && result.Status == (int)Error.Ok)
             {
-                GD.Print("Bought");
+                GD.Print("Purchase Requested");
             }
             else
             {
-                GD.Print("Failed");
+                GD.Print($"Purchase Failed {result.ResponseCode} {result.DebugMessage}");
             }
         }
         private void OnButton2_pressed()
@@ -124,11 +124,11 @@ namespace Android_Iap
             var result = _googlePlayBilling.Purchase("android.test.refunded");
             if (result != null && result.Status == (int)Error.Ok)
             {
-                GD.Print("Bought");
+                GD.Print("Purchase Requested");
             }
             else
             {
-                GD.Print("Failed");
+                GD.Print($"Purchase Failed {result.ResponseCode} {result.DebugMessage}");
             }
         }
         private void OnButton3_pressed()
@@ -136,11 +136,11 @@ namespace Android_Iap
             var result = _googlePlayBilling.Purchase("android.test.item_unavailable");
             if (result != null && result.Status == (int)Error.Ok)
             {
-                GD.Print("Bought");
+                GD.Print("Purchase Requested");
             }
             else
             {
-                GD.Print("Failed");
+                GD.Print($"Purchase Failed {result.ResponseCode} {result.DebugMessage}");
             }
         }
 


### PR DESCRIPTION
<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest stable Godot version. Do not submit a
  pull request if it only works with alpha/beta builds.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
After this PR https://github.com/godotengine/godot-google-play-billing/pull/6 "Response Code" can return null.
I made a tine update on the GDscript since if it comes with null vale the interpolation with %d fails. And I chanced the C# version to nullable enum. And I update the messages for test purpose.