### PR TITLE
Fix minor problems with Dodge the Creeps metadata

### DIFF
--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -20,8 +20,8 @@ config/description="This is a simple game where your character must move
 and avoid the enemies for as long as possible.
 
 This is a finished version of the game featured in the 'Your first game'
-tutorial in the documentation, but ported to C#. For more details,
-consider following the tutorial in the documentation."
+tutorial in the documentation. For more details, consider
+following the tutorial in the documentation."
 run/main_scene="res://Main.tscn"
 config/icon="res://icon.png"
 

--- a/mono/dodge_the_creeps/README.md
+++ b/mono/dodge_the_creeps/README.md
@@ -18,10 +18,10 @@ Note: There is a GDScript version available [here](https://github.com/godotengin
 
 ![GIF from the documentation](https://docs.godotengine.org/en/latest/_images/dodge_preview.gif)
 
-## Licenses
+## Copying
 
 `art/House In a Forest Loop.ogg` Copyright &copy; 2012 [HorrorPen](https://opengameart.org/users/horrorpen), [CC-BY 3.0: Attribution](http://creativecommons.org/licenses/by/3.0/). Source: https://opengameart.org/content/loop-house-in-a-forest
 
-Images are from "Abstract Platformer". Copyright &copy; 2010-2020 kenney.nl, [CC0 1.0 Universal](http://creativecommons.org/publicdomain/zero/1.0/). Source: https://www.kenney.nl/assets/abstract-platformer
+Images are from "Abstract Platformer". Created in 2016 by kenney.nl, [CC0 1.0 Universal](http://creativecommons.org/publicdomain/zero/1.0/). Source: https://www.kenney.nl/assets/abstract-platformer
 
 Font is "Xolonium". Copyright &copy; 2011-2016 Severin Meyer <sev.ch@web.de>, with Reserved Font Name Xolonium, SIL open font license version 1.1. Details are in `fonts/LICENSE.txt`.


### PR DESCRIPTION
Fix incorrect text in the project description and fix the copying section in the C# version's README.