### PR TITLE
Avoid freeing network peer during signal emission.

### DIFF
--- a/networking/multiplayer_bomber/gamestate.gd
+++ b/networking/multiplayer_bomber/gamestate.gd
@@ -6,6 +6,8 @@ const DEFAULT_PORT = 10567
 # Max number of players.
 const MAX_PEERS = 12
 
+var peer = null
+
 # Name for my player.
 var player_name = "The Warrior"
 
@@ -125,16 +127,16 @@ remote func ready_to_start(id):
 
 func host_game(new_player_name):
 	player_name = new_player_name
-	var host = NetworkedMultiplayerENet.new()
-	host.create_server(DEFAULT_PORT, MAX_PEERS)
-	get_tree().set_network_peer(host)
+	peer = NetworkedMultiplayerENet.new()
+	peer.create_server(DEFAULT_PORT, MAX_PEERS)
+	get_tree().set_network_peer(peer)
 
 
 func join_game(ip, new_player_name):
 	player_name = new_player_name
-	var client = NetworkedMultiplayerENet.new()
-	client.create_client(ip, DEFAULT_PORT)
-	get_tree().set_network_peer(client)
+	peer = NetworkedMultiplayerENet.new()
+	peer.create_client(ip, DEFAULT_PORT)
+	get_tree().set_network_peer(peer)
 
 
 func get_player_list():

--- a/networking/multiplayer_pong/logic/lobby.gd
+++ b/networking/multiplayer_pong/logic/lobby.gd
@@ -8,6 +8,8 @@ onready var join_button = $JoinButton
 onready var status_ok = $StatusOk
 onready var status_fail = $StatusFail
 
+var peer = null
+
 func _ready():
 	# Connect all the callbacks related to networking.
 	get_tree().connect("network_peer_connected", self, "_player_connected")
@@ -46,7 +48,6 @@ func _connected_fail():
 	_set_status("Couldn't connect", false)
 	
 	get_tree().set_network_peer(null) # Remove peer.
-	
 	host_button.set_disabled(false)
 	join_button.set_disabled(false)
 
@@ -80,15 +81,15 @@ func _set_status(text, isok):
 
 
 func _on_host_pressed():
-	var host = NetworkedMultiplayerENet.new()
-	host.set_compression_mode(NetworkedMultiplayerENet.COMPRESS_RANGE_CODER)
-	var err = host.create_server(DEFAULT_PORT, 1) # Maximum of 1 peer, since it's a 2-player game.
+	peer = NetworkedMultiplayerENet.new()
+	peer.set_compression_mode(NetworkedMultiplayerENet.COMPRESS_RANGE_CODER)
+	var err = peer.create_server(DEFAULT_PORT, 1) # Maximum of 1 peer, since it's a 2-player game.
 	if err != OK:
 		# Is another server running?
 		_set_status("Can't host, address in use.",false)
 		return
 	
-	get_tree().set_network_peer(host)
+	get_tree().set_network_peer(peer)
 	host_button.set_disabled(true)
 	join_button.set_disabled(true)
 	_set_status("Waiting for player...", true)
@@ -100,9 +101,9 @@ func _on_join_pressed():
 		_set_status("IP address is invalid", false)
 		return
 	
-	var host = NetworkedMultiplayerENet.new()
-	host.set_compression_mode(NetworkedMultiplayerENet.COMPRESS_RANGE_CODER)
-	host.create_client(ip, DEFAULT_PORT)
-	get_tree().set_network_peer(host)
+	peer = NetworkedMultiplayerENet.new()
+	peer.set_compression_mode(NetworkedMultiplayerENet.COMPRESS_RANGE_CODER)
+	peer.create_client(ip, DEFAULT_PORT)
+	get_tree().set_network_peer(peer)
 	
 	_set_status("Connecting...", true)

--- a/networking/websocket_multiplayer/script/main.gd
+++ b/networking/websocket_multiplayer/script/main.gd
@@ -10,6 +10,8 @@ onready var _name_edit = $Panel/VBoxContainer/HBoxContainer/NameEdit
 onready var _host_edit = $Panel/VBoxContainer/HBoxContainer2/Hostname
 onready var _game = $Panel/VBoxContainer/Game
 
+var peer = null
+
 func _ready():
 	#warning-ignore-all:return_value_discarded
 	get_tree().connect("network_peer_disconnected", self, "_peer_disconnected")
@@ -68,10 +70,10 @@ func _peer_disconnected(id):
 
 
 func _on_Host_pressed():
-	var host = WebSocketServer.new()
-	host.listen(DEF_PORT, PoolStringArray(["ludus"]), true)
+	peer = WebSocketServer.new()
+	peer.listen(DEF_PORT, PoolStringArray(["ludus"]), true)
 	get_tree().connect("server_disconnected", self, "_close_network")
-	get_tree().set_network_peer(host)
+	get_tree().set_network_peer(peer)
 	_game.add_player(1, _name_edit.text)
 	start_game()
 
@@ -81,9 +83,9 @@ func _on_Disconnect_pressed():
 
 
 func _on_Connect_pressed():
-	var host = WebSocketClient.new()
-	host.connect_to_url("ws://" + _host_edit.text + ":" + str(DEF_PORT), PoolStringArray([PROTO_NAME]), true)
+	peer = WebSocketClient.new()
+	peer.connect_to_url("ws://" + _host_edit.text + ":" + str(DEF_PORT), PoolStringArray([PROTO_NAME]), true)
 	get_tree().connect("connection_failed", self, "_close_network")
 	get_tree().connect("connected_to_server", self, "_connected")
-	get_tree().set_network_peer(host)
+	get_tree().set_network_peer(peer)
 	start_game()


### PR DESCRIPTION
Always keep a reference to the last used peer even when removing it
from tree.

Fixes godotengine/godot#33290