### PR TITLE
Remove funding information to use the @godotengine default

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-patreon: godotengine
-custom: https://godotengine.org/donate


### PR DESCRIPTION
The community health files are now available in the godotengine/.github repository, which makes them apply to all repositories in the organization automatically.

See https://github.com/godotengine/godot/issues/40972.