### PR TITLE
Allow hiDPI in all demos that support multiple resolutions

### DIFF
--- a/2d/finite_state_machine/project.godot
+++ b/2d/finite_state_machine/project.godot
@@ -26,6 +26,7 @@ config/icon="res://icon.png"
 
 window/size/width=1280
 window/size/height=720
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/gd_paint/project.godot
+++ b/2d/gd_paint/project.godot
@@ -26,6 +26,7 @@ config/icon="res://icon.png"
 
 window/size/width=1280
 window/size/height=720
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 

--- a/2d/hdr/project.godot
+++ b/2d/hdr/project.godot
@@ -28,6 +28,7 @@ run/name=""
 
 window/size/width=1080
 window/size/height=720
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/hexagonal_map/project.godot
+++ b/2d/hexagonal_map/project.godot
@@ -22,6 +22,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/instancing/project.godot
+++ b/2d/instancing/project.godot
@@ -24,6 +24,7 @@ config/icon="res://icon.png"
 [display]
 
 window/size/width=800
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/isometric/project.godot
+++ b/2d/isometric/project.godot
@@ -25,6 +25,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/kinematic_character/project.godot
+++ b/2d/kinematic_character/project.godot
@@ -26,6 +26,7 @@ config/icon="res://icon.png"
 
 window/size/width=530
 window/size/height=495
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 stretch/aspect="keep"

--- a/2d/light2d_as_mask/project.godot
+++ b/2d/light2d_as_mask/project.godot
@@ -22,6 +22,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/lights_and_shadows/project.godot
+++ b/2d/lights_and_shadows/project.godot
@@ -24,6 +24,7 @@ config/icon="res://icon.png"
 [display]
 
 window/size/width=800
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 stretch/aspect="keep"

--- a/2d/navigation/project.godot
+++ b/2d/navigation/project.godot
@@ -25,6 +25,7 @@ config/icon="res://icon.png"
 [display]
 
 window/size/width=800
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 stretch/aspect="keep"

--- a/2d/navigation_astar/project.godot
+++ b/2d/navigation_astar/project.godot
@@ -23,6 +23,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/particles/project.godot
+++ b/2d/particles/project.godot
@@ -22,6 +22,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/physics_platformer/project.godot
+++ b/2d/physics_platformer/project.godot
@@ -64,6 +64,7 @@ gdscript/warnings/unsafe_call_argument=true
 
 window/size/width=800
 window/size/height=480
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 

--- a/2d/pong/project.godot
+++ b/2d/pong/project.godot
@@ -25,6 +25,7 @@ config/icon="res://icon.png"
 
 window/size/width=640
 window/size/height=400
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 stretch_2d=true

--- a/2d/role_playing_game/project.godot
+++ b/2d/role_playing_game/project.godot
@@ -26,6 +26,7 @@ config/icon="res://icon.png"
 
 window/size/width=1280
 window/size/height=720
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/screen_space_shaders/project.godot
+++ b/2d/screen_space_shaders/project.godot
@@ -24,6 +24,7 @@ config/icon="res://icon.png"
 [display]
 
 window/size/width=800
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 stretch/aspect="keep"

--- a/2d/sprite_shaders/project.godot
+++ b/2d/sprite_shaders/project.godot
@@ -23,6 +23,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/2d/tween/project.godot
+++ b/2d/tween/project.godot
@@ -28,6 +28,7 @@ gdscript/warnings/return_value_discarded=false
 [display]
 
 window/size/height=768
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 stretch/aspect="keep_width"

--- a/3d/ik/project.godot
+++ b/3d/ik/project.godot
@@ -24,6 +24,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/3d/material_testers/project.godot
+++ b/3d/material_testers/project.godot
@@ -25,6 +25,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/3d/physics_tests/project.godot
+++ b/3d/physics_tests/project.godot
@@ -41,6 +41,7 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/3d/truck_town/project.godot
+++ b/3d/truck_town/project.godot
@@ -27,6 +27,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 window/height=720

--- a/3d/voxel/project.godot
+++ b/3d/voxel/project.godot
@@ -39,6 +39,7 @@ Settings="*res://settings.gd"
 
 window/size/width=1600
 window/size/height=900
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/audio/mic_record/project.godot
+++ b/audio/mic_record/project.godot
@@ -29,6 +29,7 @@ enable_audio_input=true
 
 window/size/width=640
 window/size/height=480
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/gui/drag_and_drop/project.godot
+++ b/gui/drag_and_drop/project.godot
@@ -25,6 +25,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/gui/input_mapping/project.godot
+++ b/gui/input_mapping/project.godot
@@ -28,6 +28,7 @@ config/icon="res://icon.png"
 
 window/size/width=640
 window/size/height=480
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/gui/regex/project.godot
+++ b/gui/regex/project.godot
@@ -23,6 +23,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/gui/rich_text_bbcode/project.godot
+++ b/gui/rich_text_bbcode/project.godot
@@ -22,6 +22,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/gui/sdf_font/project.godot
+++ b/gui/sdf_font/project.godot
@@ -24,6 +24,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/gui/theming_override/project.godot
+++ b/gui/theming_override/project.godot
@@ -23,6 +23,7 @@ config/icon="res://icon.png"
 [display]
 
 window/size/height=576
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/gui/translation/project.godot
+++ b/gui/translation/project.godot
@@ -23,6 +23,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/loading/autoload/project.godot
+++ b/loading/autoload/project.godot
@@ -25,6 +25,7 @@ global="res://global.gd"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/loading/background_load/project.godot
+++ b/loading/background_load/project.godot
@@ -26,6 +26,7 @@ background_load="*res://background_load.tscn"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/loading/scene_changer/project.godot
+++ b/loading/scene_changer/project.godot
@@ -25,6 +25,7 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/loading/threads/project.godot
+++ b/loading/threads/project.godot
@@ -21,6 +21,7 @@ run/main_scene="res://thread.tscn"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/misc/joypads/project.godot
+++ b/misc/joypads/project.godot
@@ -28,6 +28,7 @@ gdscript/warnings/return_value_discarded=false
 
 window/size/width=600
 window/size/height=540
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/misc/opensimplexnoise/project.godot
+++ b/misc/opensimplexnoise/project.godot
@@ -23,6 +23,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/misc/os_test/project.godot
+++ b/misc/os_test/project.godot
@@ -26,6 +26,7 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/misc/pause/project.godot
+++ b/misc/pause/project.godot
@@ -22,6 +22,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/misc/window_management/project.godot
+++ b/misc/window_management/project.godot
@@ -23,6 +23,7 @@ config/icon="res://icon.png"
 [display]
 
 window/size/width=800
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 window/fullscreen=false

--- a/mobile/android_iap/project.godot
+++ b/mobile/android_iap/project.godot
@@ -29,6 +29,7 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/mono/android_iap/project.godot
+++ b/mono/android_iap/project.godot
@@ -25,6 +25,7 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/mono/pong/project.godot
+++ b/mono/pong/project.godot
@@ -25,6 +25,7 @@ config/icon="res://icon.png"
 
 window/size/width=640
 window/size/height=400
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 

--- a/networking/multiplayer_bomber/project.godot
+++ b/networking/multiplayer_bomber/project.godot
@@ -33,6 +33,7 @@ gdscript/warnings/return_value_discarded=false
 [display]
 
 window/vsync/use_vsync=false
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/networking/multiplayer_pong/project.godot
+++ b/networking/multiplayer_pong/project.godot
@@ -30,6 +30,7 @@ gdscript/warnings/return_value_discarded=false
 
 window/size/width=640
 window/size/height=400
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 stretch_2d=true

--- a/networking/webrtc_minimal/project.godot
+++ b/networking/webrtc_minimal/project.godot
@@ -24,6 +24,7 @@ Signaling="*res://Signaling.gd"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/networking/webrtc_signaling/project.godot
+++ b/networking/webrtc_signaling/project.godot
@@ -30,6 +30,7 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/viewport/3d_in_2d/project.godot
+++ b/viewport/3d_in_2d/project.godot
@@ -22,6 +22,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/viewport/3d_scaling/project.godot
+++ b/viewport/3d_scaling/project.godot
@@ -30,6 +30,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/viewport/screen_capture/project.godot
+++ b/viewport/screen_capture/project.godot
@@ -26,6 +26,7 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 

--- a/visual_script/pong/project.godot
+++ b/visual_script/pong/project.godot
@@ -25,6 +25,7 @@ config/icon="res://icon.png"
 
 window/size/width=640
 window/size/height=400
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 stretch_2d=true


### PR DESCRIPTION
This is required to benefit from crisp display on hiDPI monitors. This also fixes issues related to fullscreen and input handling when using an hiDPI display on Windows.

Command used:

```bash
# Install sd <https://github.com/chmln/sd> then run:
sd 'window/stretch/mode="2d"' 'window/dpi/allow_hidpi=true\nwindow/stretch/mode="2d"' **/*.godot
# After running `sd`, remove the duplicate line in `2d/platformer/project.godot`.
```