### PR TITLE
Improve Dodge the Creeps demo

### DIFF
--- a/mono/dodge_the_creeps/Dodge the Creeps with C#.csproj
+++ b/mono/dodge_the_creeps/Dodge the Creeps with C#.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Godot.NET.Sdk/3.2.3">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
+    <RootNamespace>DodgeTheCreeps</RootNamespace>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
1. restore net472:
```
Sdk is referencing Microsoft.NETFramework.ReferenceAssemblies: https://github.com/godotengine/godot/blob/cc3c671f3b636cbfac9fc74095d5bee753e71ed5/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets#L18-L33
```
I was mistaken previously because of this one time warning in Rider https://youtrack.jetbrains.com/issue/RIDER-52053

2. restore RootNamespace, since default one contains spaces.
Using default one would cause new added script be invalid, at least as I tried in Rider