### PR TITLE
Add trailing commas to enums

### DIFF
--- a/2d/gd_paint/paint_control.gd
+++ b/2d/gd_paint/paint_control.gd
@@ -9,10 +9,15 @@ const IMAGE_SIZE = Vector2(930, 720)
 
 # Enums for the various modes and brush shapes that can be applied.
 enum BrushModes {
-	PENCIL, ERASER, CIRCLE_SHAPE, RECTANGLE_SHAPE
+	PENCIL,
+	ERASER,
+	CIRCLE_SHAPE,
+	RECTANGLE_SHAPE,
 }
+
 enum BrushShapes {
-	RECTANGLE, CIRCLE
+	RECTANGLE,
+	CIRCLE,
 }
 
 # The top-left position of the canvas.

--- a/2d/physics_platformer/enemy/enemy.gd
+++ b/2d/physics_platformer/enemy/enemy.gd
@@ -5,7 +5,7 @@ const WALK_SPEED = 50
 
 enum State {
 	WALKING,
-	DYING
+	DYING,
 }
 
 var state = State.WALKING

--- a/2d/platformer/src/Actors/Enemy.gd
+++ b/2d/platformer/src/Actors/Enemy.gd
@@ -4,7 +4,7 @@ extends Actor
 
 enum State {
 	WALKING,
-	DEAD
+	DEAD,
 }
 
 var _state = State.WALKING

--- a/mono/android_iap/GodotGooglePlayBilling/GooglePlayBilling.cs
+++ b/mono/android_iap/GodotGooglePlayBilling/GooglePlayBilling.cs
@@ -6,7 +6,7 @@ namespace AndroidInAppPurchasesWithCSharp.GodotGooglePlayBilling
     public enum PurchaseType
     {
         InApp,
-        Subs
+        Subs,
     }
 
     public class GooglePlayBilling : Node

--- a/mono/android_iap/GodotGooglePlayBilling/Purchase.cs
+++ b/mono/android_iap/GodotGooglePlayBilling/Purchase.cs
@@ -9,7 +9,7 @@ namespace AndroidInAppPurchasesWithCSharp.GodotGooglePlayBilling
     {
         UnspecifiedState = 0,
         Purchased = 1,
-        Pending = 2
+        Pending = 2,
     }
 
     public class Purchase


### PR DESCRIPTION
This is a minor style fix to conform to the [GDScript style guide's trailing comma rule](https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_styleguide.html#trailing-comma).