### PR TITLE
Add instructions for port forwarding in the high-level multiplayer demos

### DIFF
--- a/networking/multiplayer_bomber/gamestate.gd
+++ b/networking/multiplayer_bomber/gamestate.gd
@@ -1,6 +1,8 @@
 extends Node
 
-# Default game port. Can be any number between 1024 and 49151.
+# Default game server port. Can be any number between 1024 and 49151.
+# Not on the list of registered or common ports as of November 2020:
+# https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
 const DEFAULT_PORT = 10567
 
 # Max number of players.

--- a/networking/multiplayer_bomber/lobby.gd
+++ b/networking/multiplayer_bomber/lobby.gd
@@ -86,3 +86,7 @@ func refresh_lobby():
 
 func _on_start_pressed():
 	gamestate.begin_game()
+
+
+func _on_find_public_ip_pressed():
+	OS.shell_open("https://icanhazip.com/")

--- a/networking/multiplayer_bomber/lobby.tscn
+++ b/networking/multiplayer_bomber/lobby.tscn
@@ -51,6 +51,24 @@ margin_bottom = 296.0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 
+[node name="PortForward" type="Label" parent="Players"]
+margin_left = -124.0
+margin_top = 375.0
+margin_right = 128.0
+margin_bottom = 429.0
+custom_constants/line_spacing = 6
+text = "If you want non-LAN clients to connect,
+make sure the port 10567 in UDP
+is forwarded on your router."
+align = 1
+
+[node name="FindPublicIP" type="LinkButton" parent="Players"]
+margin_left = 168.0
+margin_top = 393.5
+margin_right = 341.0
+margin_bottom = 407.5
+text = "Find your public IP address"
+
 [node name="Connect" type="Panel" parent="."]
 anchor_left = 0.5
 anchor_top = 0.5
@@ -133,5 +151,6 @@ margin_bottom = 58.0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 [connection signal="pressed" from="Players/Start" to="." method="_on_start_pressed"]
+[connection signal="pressed" from="Players/FindPublicIP" to="." method="_on_find_public_ip_pressed"]
 [connection signal="pressed" from="Connect/Host" to="." method="_on_host_pressed"]
 [connection signal="pressed" from="Connect/Join" to="." method="_on_join_pressed"]

--- a/networking/multiplayer_bomber/player.tscn
+++ b/networking/multiplayer_bomber/player.tscn
@@ -166,4 +166,3 @@ size_flags_vertical = 0
 custom_fonts/font = SubResource( 8 )
 text = "Player 1"
 align = 1
-

--- a/networking/multiplayer_bomber/project.godot
+++ b/networking/multiplayer_bomber/project.godot
@@ -32,8 +32,8 @@ gdscript/warnings/return_value_discarded=false
 
 [display]
 
-window/vsync/use_vsync=false
 window/dpi/allow_hidpi=true
+window/vsync/use_vsync=false
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/networking/multiplayer_bomber/tileset.tres
+++ b/networking/multiplayer_bomber/tileset.tres
@@ -1,27 +1,43 @@
-[gd_resource type="TileSet" load_steps=2 format=2]
+[gd_resource type="TileSet" load_steps=3 format=2]
 
 [ext_resource path="res://brickfloor.png" type="Texture" id=1]
 
 [sub_resource type="RectangleShape2D" id=1]
-
-custom_solver_bias = 0.0
 extents = Vector2( 24, 24 )
 
 [resource]
-
 0/name = "wall"
 0/texture = ExtResource( 1 )
 0/tex_offset = Vector2( 0, 0 )
+0/modulate = Color( 1, 1, 1, 1 )
 0/region = Rect2( 0, 0, 48, 48 )
+0/tile_mode = 0
 0/occluder_offset = Vector2( 24, 24 )
 0/navigation_offset = Vector2( 24, 24 )
 0/shape_offset = Vector2( 24, 24 )
-0/shapes = [ SubResource( 1 ) ]
+0/shape_transform = Transform2D( 1, 0, 0, 1, 24, 24 )
+0/shape = SubResource( 1 )
+0/shape_one_way = false
+0/shape_one_way_margin = 1.0
+0/shapes = [ {
+"autotile_coord": Vector2( 0, 0 ),
+"one_way": false,
+"one_way_margin": 1.0,
+"shape": SubResource( 1 ),
+"shape_transform": Transform2D( 1, 0, 0, 1, 24, 24 )
+} ]
+0/z_index = 0
 1/name = "floor"
 1/texture = ExtResource( 1 )
 1/tex_offset = Vector2( 0, 0 )
+1/modulate = Color( 1, 1, 1, 1 )
 1/region = Rect2( 48, 0, 48, 48 )
+1/tile_mode = 0
 1/occluder_offset = Vector2( 24, 24 )
 1/navigation_offset = Vector2( 24, 24 )
 1/shape_offset = Vector2( 0, 0 )
+1/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+1/shape_one_way = false
+1/shape_one_way_margin = 0.0
 1/shapes = [  ]
+1/z_index = 0

--- a/networking/multiplayer_pong/lobby.tscn
+++ b/networking/multiplayer_pong/lobby.tscn
@@ -92,5 +92,32 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 custom_colors/font_color = Color( 1, 0, 0, 1 )
 align = 1
+
+[node name="PortForward" type="Label" parent="LobbyPanel"]
+visible = false
+margin_left = -128.0
+margin_top = 136.0
+margin_right = 124.0
+margin_bottom = 184.0
+custom_constants/line_spacing = 6
+text = "If you want non-LAN clients to connect,
+make sure the port 8910 in UDP
+is forwarded on your router."
+align = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="FindPublicIP" type="LinkButton" parent="LobbyPanel"]
+visible = false
+margin_left = 155.0
+margin_top = 152.0
+margin_right = 328.0
+margin_bottom = 166.0
+text = "Find your public IP address"
+__meta__ = {
+"_edit_use_anchors_": false
+}
 [connection signal="pressed" from="LobbyPanel/HostButton" to="LobbyPanel" method="_on_host_pressed"]
 [connection signal="pressed" from="LobbyPanel/JoinButton" to="LobbyPanel" method="_on_join_pressed"]
+[connection signal="pressed" from="LobbyPanel/FindPublicIP" to="LobbyPanel" method="_on_find_public_ip_pressed"]

--- a/networking/multiplayer_pong/logic/lobby.gd
+++ b/networking/multiplayer_pong/logic/lobby.gd
@@ -1,12 +1,17 @@
 extends Control
 
-const DEFAULT_PORT = 8910 # An arbitrary number.
+# Default game server port. Can be any number between 1024 and 49151.
+# Not on the list of registered or common ports as of November 2020:
+# https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
+const DEFAULT_PORT = 8910
 
 onready var address = $Address
 onready var host_button = $HostButton
 onready var join_button = $JoinButton
 onready var status_ok = $StatusOk
 onready var status_fail = $StatusFail
+onready var port_forward_label = $PortForward
+onready var find_public_ip_button = $FindPublicIP
 
 var peer = null
 
@@ -95,6 +100,10 @@ func _on_host_pressed():
 	join_button.set_disabled(true)
 	_set_status("Waiting for player...", true)
 
+	# Only show hosting instructions when relevant.
+	port_forward_label.visible = true
+	find_public_ip_button.visible = true
+
 
 func _on_join_pressed():
 	var ip = address.get_text()
@@ -108,3 +117,7 @@ func _on_join_pressed():
 	get_tree().set_network_peer(peer)
 
 	_set_status("Connecting...", true)
+
+
+func _on_find_public_ip_pressed():
+	OS.shell_open("https://icanhazip.com/")


### PR DESCRIPTION
The instructions will only show when the player is hosting a server.

This also includes a button to get your public IP address.

This partially addresses #535.

## Preview

![Multiplayer Bomber server lobby](https://user-images.githubusercontent.com/180032/98467953-88667280-21d8-11eb-931b-243bad1f53ff.png)

![Multiplayer Pong server lobby](https://user-images.githubusercontent.com/180032/98467990-b9df3e00-21d8-11eb-972d-0b0925540431.png)
