### PR TITLE
Fix README files, especially in Android IAP demos

### DIFF
--- a/2d/README.md
+++ b/2d/README.md
@@ -3,6 +3,6 @@
 These demos are all 2D, but otherwise do not have a common theme.
 
 Languages: Most have GDScript, some have
-[GDSL](https://docs.godotengine.org/en/latest/tutorials/shading/shading_reference/shading_language.html)
+[GDSL](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shading_language.html)
 
 Renderers: 6 of them are GLES 3, but most are GLES 2

--- a/2d/screen_space_shaders/README.md
+++ b/2d/screen_space_shaders/README.md
@@ -3,7 +3,7 @@
 Several examples of full screen 2D shader processing.
 Many common full-res effects are implemented here for reference.
 
-Language: [GDSL](https://docs.godotengine.org/en/latest/tutorials/shading/shading_reference/shading_language.html) and GDScript
+Language: [GDSL](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shading_language.html) and GDScript
 
 Renderer: GLES 3 (the blur effect is not available in GLES 2, the rest work)
 

--- a/2d/sprite_shaders/README.md
+++ b/2d/sprite_shaders/README.md
@@ -3,7 +3,7 @@
 This is a sample consisting of different shaders applied to some sprites.
 Effects include outlines, blurs, distorts, shadows, glows, and more.
 
-Language: [GDSL](https://docs.godotengine.org/en/latest/tutorials/shading/shading_reference/shading_language.html)
+Language: [GDSL](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shading_language.html)
 
 Renderer: GLES 2
 

--- a/misc/README.md
+++ b/misc/README.md
@@ -3,8 +3,8 @@
 These demos don't fit into any other category, so they go into this folder.
 
 Languages: All have GDScript, OpenSimplexNoise has
-[GDSL](https://docs.godotengine.org/en/latest/tutorials/shading/shading_reference/shading_language.html),
+[GDSL](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shading_language.html),
 OS test has some
-[C#](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/index.html)
+[C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html)
 
 Renderers: All are GLES 2

--- a/misc/os_test/README.md
+++ b/misc/os_test/README.md
@@ -7,7 +7,7 @@ new platform or to check for regressions.
 In a nutshell, this demo shows how you can get information from the
 operating system, or interact with the operating system.
 
-Language: GDScript and some [C#](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/index.html)
+Language: GDScript and some [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html)
 (Mono is NOT required to run this demo)
 
 Renderer: GLES 2
@@ -29,7 +29,7 @@ which gathers information about the OS using the OS class.
 
 On a Mono-enabled version of Godot, Godot will load `MonoTest.cs` into
 the `MonoTest` node. Then, information determined by
-[`C# preprocessor defines`](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/c_sharp_features.html#preprocessor-defines)
+[`C# preprocessor defines`](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/c_sharp_features.html#preprocessor-defines)
 will be added to the left panel.
 
 ## Screenshots

--- a/mobile/android_iap/README.md
+++ b/mobile/android_iap/README.md
@@ -1,0 +1,12 @@
+# Android IAP
+
+This demo shows how to make in-app payments in Android.
+
+Note: Running the demo requires exporting and uploading the game to Google Play.
+
+Language: GDScript
+
+Renderer: GLES 2
+
+Note: There is a C# version available
+[here](https://github.com/godotengine/godot-demo-projects/tree/master/mono/android_iap).

--- a/mono/2.5d/README.md
+++ b/mono/2.5d/README.md
@@ -4,7 +4,7 @@ This demo project shows a way to create a 2.5D game
 in Godot by mixing 2D and 3D nodes. It also adds a
 2.5D editor viewport for easily editing 2.5D levels.
 
-Language: [C#](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/index.html) and a little bit of GDScript
+Language: [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html) and a little bit of GDScript
 
 Renderer: GLES 2
 

--- a/mono/README.md
+++ b/mono/README.md
@@ -1,9 +1,9 @@
 # Mono Demos
 
-These demos are written in [C#](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/index.html).
+These demos are written in [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html).
 You must have the Mono version of Godot to run these.
 
-Languages: All have [C#](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/index.html),
+Languages: All have [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html),
 2.5D has some GDScript
 
 Renderers: Dodge the Creeps is GLES 3, rest are GLES 2

--- a/mono/android_iap/README.md
+++ b/mono/android_iap/README.md
@@ -1,11 +1,12 @@
 # Android IAP with C#
 
-These demos depend on features only available in mobile phones or tablets.
+This demo shows how to make in-app payments in Android in C#.
 
-The Android IAP demo only runs on Android.
+Note: Running the demo requires exporting and uploading the game to Google Play.
 
-Language: [C#](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/index.html)
+Language: [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html)
 
 Renderer: GLES 2
 
-Note: There is a GDScript version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/mobile/AndroidInAppPurchasesWithCSharp).
+Note: There is a GDScript version available
+[here](https://github.com/godotengine/godot-demo-projects/tree/master/mobile/android_iap).

--- a/mono/dodge_the_creeps/README.md
+++ b/mono/dodge_the_creeps/README.md
@@ -8,7 +8,7 @@ This is a finished version of the game featured in the
 tutorial in the documentation, but ported to C#. For more details,
 consider following the tutorial in the documentation.
 
-Language: [C#](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/index.html)
+Language: [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html)
 
 Renderer: GLES 3 (particles are not available in GLES 2)
 

--- a/mono/multiplayer_pong/README.md
+++ b/mono/multiplayer_pong/README.md
@@ -2,7 +2,7 @@
 
 A multiplayer demo of Pong. One player presses "host". The other presses "join". This only works locally.
 
-Language: [C#](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/index.html)
+Language: [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html)
 
 Renderer: GLES 2
 

--- a/mono/pong/README.md
+++ b/mono/pong/README.md
@@ -4,7 +4,7 @@ A simple Pong game. This demo shows best practices
 for game development in Godot, including
 [signals](https://docs.godotengine.org/en/latest/getting_started/step_by_step/signals.html).
 
-Language: [C#](https://docs.godotengine.org/en/latest/getting_started/scripting/c_sharp/index.html)
+Language: [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/index.html)
 
 Renderer: GLES 2
 

--- a/viewport/README.md
+++ b/viewport/README.md
@@ -4,6 +4,6 @@ These demos showcase various ways to use the
 [`Viewport`](https://docs.godotengine.org/en/stable/classes/class_viewport.html) node.
 
 Languages: All have GDScript, Dynamic Split Screen has
-[GDSL](https://docs.godotengine.org/en/latest/tutorials/shading/shading_reference/shading_language.html)
+[GDSL](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shading_language.html)
 
 Renderers: 3D in 2D and GUI in 3D use GLES 3, the rest are GLES 2

--- a/viewport/dynamic_split_screen/README.md
+++ b/viewport/dynamic_split_screen/README.md
@@ -3,7 +3,7 @@
 This sample project showcases an implementation of dynamic
 split screen, also called Voronoi split screen.
 
-Language: [GDSL](https://docs.godotengine.org/en/latest/tutorials/shading/shading_reference/shading_language.html) and GDScript
+Language: [GDSL](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shading_language.html) and GDScript
 
 Renderer: GLES 2
 

--- a/visual_script/README.md
+++ b/visual_script/README.md
@@ -1,8 +1,8 @@
 # VisualScript Demos
 
-These demos are written in [VisualScript](https://docs.godotengine.org/en/latest/getting_started/scripting/visual_script/index.html).
+These demos are written in [VisualScript](https://docs.godotengine.org/en/latest/tutorials/scripting/visual_script/index.html).
 
-Languages: All are [VisualScript](https://docs.godotengine.org/en/latest/getting_started/scripting/visual_script/index.html),
+Languages: All are [VisualScript](https://docs.godotengine.org/en/latest/tutorials/scripting/visual_script/index.html),
 Multitouch View has some GDScript
 
 Renderers: All are GLES 2

--- a/visual_script/circle_pop/README.md
+++ b/visual_script/circle_pop/README.md
@@ -4,7 +4,7 @@ Demo of a simple game using visual script.
 You must click the circles to "pop" them in
 order to stop their invasion of the screen.
 
-Language: [VisualScript](https://docs.godotengine.org/en/latest/getting_started/scripting/visual_script/index.html)
+Language: [VisualScript](https://docs.godotengine.org/en/latest/tutorials/scripting/visual_script/index.html)
 
 Renderer: GLES 2
 

--- a/visual_script/multitouch_view/README.md
+++ b/visual_script/multitouch_view/README.md
@@ -3,7 +3,7 @@
 Simple debugger for multitouch input.
 Shows red dots everywhere you press.
 
-Language: [VisualScript](https://docs.godotengine.org/en/latest/getting_started/scripting/visual_script/index.html)
+Language: [VisualScript](https://docs.godotengine.org/en/latest/tutorials/scripting/visual_script/index.html)
 
 Renderer: GLES 2
 

--- a/visual_script/pong/README.md
+++ b/visual_script/pong/README.md
@@ -4,7 +4,7 @@ A simple Pong game. This demo shows best practices
 for game development in Godot, including
 [signals](https://docs.godotengine.org/en/latest/getting_started/step_by_step/signals.html).
 
-Language: [VisualScript](https://docs.godotengine.org/en/latest/getting_started/scripting/visual_script/index.html)
+Language: [VisualScript](https://docs.godotengine.org/en/latest/tutorials/scripting/visual_script/index.html)
 
 Renderer: GLES 2
 


### PR DESCRIPTION
A few of the links needed updating, and also the Android IAP READMEs were wrong (one was missing, one was incorrect).