### PR TITLE
Update copyright statements for 2021

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-Copyright (c) 2007-2020 Juan Linietsky, Ariel Manzur. \
-Copyright (c) 2014-2020 Godot Engine contributors.
+Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur. \
+Copyright (c) 2014-2021 Godot Engine contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
It's now 2021, not 2020, so this PR updates the copyright statements for 2021.