### PR TITLE
Update broadphase performance test in physics tests

### DIFF
--- a/2d/physics_tests/project.godot
+++ b/2d/physics_tests/project.godot
@@ -73,6 +73,10 @@ toggle_pause={
  ]
 }
 
+[memory]
+
+limits/message_queue/max_size_kb=10240
+
 [rendering]
 
 quality/driver/driver_name="GLES2"

--- a/2d/physics_tests/test.gd
+++ b/2d/physics_tests/test.gd
@@ -4,6 +4,8 @@ extends Node2D
 
 signal wait_done()
 
+export var _enable_debug_collision = true
+
 var _timer
 var _timer_started = false
 
@@ -19,6 +21,11 @@ class Circle2D:
 		draw_circle(center, radius, color)
 
 var _drawn_nodes = []
+
+
+func _enter_tree():
+	if not _enable_debug_collision:
+		get_tree().debug_collisions_hint = false
 
 
 func _physics_process(_delta):

--- a/2d/physics_tests/tests/performance/test_perf_broadphase.gd
+++ b/2d/physics_tests/tests/performance/test_perf_broadphase.gd
@@ -15,29 +15,36 @@ var _log_physics_time_start = 0
 
 
 func _ready():
-	_create_objects()
+	yield(start_timer(1.0), "timeout")
+	if is_timer_canceled():
+		return
 
 	_log_physics_start()
+
+	_create_objects()
+
 	yield(wait_for_physics_ticks(5), "wait_done")
 	_log_physics_stop()
 
 	yield(start_timer(1.0), "timeout")
 	if is_timer_canceled():
 		return
+
+	_log_physics_start()
 
 	_add_objects()
 
-	_log_physics_start()
 	yield(wait_for_physics_ticks(5), "wait_done")
 	_log_physics_stop()
 
 	yield(start_timer(1.0), "timeout")
 	if is_timer_canceled():
 		return
+
+	_log_physics_start()
 
 	_move_objects()
 
-	_log_physics_start()
 	yield(wait_for_physics_ticks(5), "wait_done")
 	_log_physics_stop()
 
@@ -45,9 +52,10 @@ func _ready():
 	if is_timer_canceled():
 		return
 
+	_log_physics_start()
+
 	_remove_objects()
 
-	_log_physics_start()
 	yield(wait_for_physics_ticks(5), "wait_done")
 	_log_physics_stop()
 
@@ -85,9 +93,6 @@ func _log_physics_stop():
 func _create_objects():
 	_objects.clear()
 
-	var template_body = create_rigidbody_box(BOX_SIZE)
-	template_body.gravity_scale = 0.0
-
 	Log.print_log("* Creating objects...")
 	var timer = OS.get_ticks_usec()
 
@@ -97,9 +102,10 @@ func _create_objects():
 		var pos_y = -0.5 * (column_size - 1) * BOX_SPACE.y
 
 		for column in column_size:
-			var box = template_body.duplicate()
+			# Create a new object and shape every time to avoid the overhead of connecting many bodies to the same shape.
+			var box = create_rigidbody_box(BOX_SIZE)
+			box.gravity_scale = 0.0
 			box.position = Vector2(pos_x, pos_y)
-			box.name = "Box%03d" % (row * column + 1)
 			_objects.push_back(box)
 
 			pos_y += BOX_SPACE.y
@@ -108,8 +114,6 @@ func _create_objects():
 
 	timer = OS.get_ticks_usec() - timer
 	Log.print_log("  Create Time: %.3f ms" % (0.001 * timer))
-
-	template_body.queue_free()
 
 
 func _add_objects():
@@ -142,8 +146,10 @@ func _remove_objects():
 	Log.print_log("* Removing objects...")
 	var timer = OS.get_ticks_usec()
 
-	for object in _objects:
-		root_node.remove_child(object)
+	# Remove objects in reversed order to avoid the overhead of changing children index in parent.
+	var object_count = _objects.size()
+	for object_index in object_count:
+		root_node.remove_child(_objects[object_count - object_index - 1])
 
 	timer = OS.get_ticks_usec() - timer
 	Log.print_log("  Remove Time: %.3f ms" % (0.001 * timer))

--- a/2d/physics_tests/tests/performance/test_perf_broadphase.tscn
+++ b/2d/physics_tests/tests/performance/test_perf_broadphase.tscn
@@ -4,6 +4,9 @@
 
 [node name="Test" type="Node2D"]
 script = ExtResource( 1 )
+_enable_debug_collision = false
+row_size = 300
+column_size = 300
 
 [node name="Objects" type="Node2D" parent="."]
 position = Vector2( 512, 300 )

--- a/3d/physics_tests/main.tscn
+++ b/3d/physics_tests/main.tscn
@@ -41,7 +41,7 @@ margin_left = 157.0
 margin_top = 13.0
 margin_right = 375.0
 margin_bottom = 27.0
-text = "R - RESTART / D - TOGGLE COLLISION / F - TOGGLE FULL SCREEN / ESC - QUIT"
+text = "P - TOGGLE PAUSE / R - RESTART / D - TOGGLE COLLISION / F - TOGGLE FULL SCREEN / ESC - QUIT"
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/3d/physics_tests/test.gd
+++ b/3d/physics_tests/test.gd
@@ -4,12 +4,19 @@ extends Node
 
 signal wait_done()
 
+export var _enable_debug_collision = true
+
 var _timer
 var _timer_started = false
 
 var _wait_physics_ticks_counter = 0
 
 var _drawn_nodes = []
+
+
+func _enter_tree():
+	if not _enable_debug_collision:
+		get_tree().debug_collisions_hint = false
 
 
 func _physics_process(_delta):
@@ -60,7 +67,7 @@ func clear_drawn_nodes():
 	_drawn_nodes.clear()
 
 
-func create_rigidbody_box(size, pickable):
+func create_rigidbody_box(size, pickable = false):
 	var shape = BoxShape.new()
 	shape.extents = 0.5 * size
 

--- a/3d/physics_tests/tests/performance/test_perf_broadphase.tscn
+++ b/3d/physics_tests/tests/performance/test_perf_broadphase.tscn
@@ -1,13 +1,12 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://tests/performance/test_perf_broadphase.gd" type="Script" id=1]
-[ext_resource path="res://utils/camera_orbit.gd" type="Script" id=5]
 
 [node name="Test" type="Spatial"]
 script = ExtResource( 1 )
+_enable_debug_collision = false
+row_size = 50
+column_size = 50
+depth_size = 50
 
 [node name="Objects" type="Spatial" parent="."]
-
-[node name="Camera" type="Camera" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 29.8407 )
-script = ExtResource( 5 )


### PR DESCRIPTION
Improvements and fixes for broadphase performance tests in 2D/3D.

- Start logging physics tick one frame earlier for each operation
- Disable debug collision to avoid rendering bottleneck
- Fixes in adding/removing bodies to avoid bottlenecks outside of physics
- 2D: Increase message queue size to allow adding more objects at once
- 3D: Remove camera to disable rendering altogether
- 3D: Fix error with create_rigidbody_box missing default value