### PR TITLE
Changed key bindings in physics tests 2D/3D

### DIFF
--- a/2d/physics_tests/main.tscn
+++ b/2d/physics_tests/main.tscn
@@ -41,7 +41,7 @@ margin_left = 157.0
 margin_top = 13.0
 margin_right = 646.0
 margin_bottom = 27.0
-text = "P - TOGGLE PAUSE / R - RESTART / D - TOGGLE COLLISION / F - TOGGLE FULL SCREEN / ESC - QUIT"
+text = "P - TOGGLE PAUSE / R - RESTART / C - TOGGLE COLLISION / F - TOGGLE FULL SCREEN / ESC - QUIT"
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/2d/physics_tests/project.godot
+++ b/2d/physics_tests/project.godot
@@ -47,6 +47,22 @@ window/stretch/aspect="expand"
 
 [input]
 
+ui_left={
+"deadzone": 0.5,
+"events": [  ]
+}
+ui_right={
+"deadzone": 0.5,
+"events": [  ]
+}
+ui_up={
+"deadzone": 0.5,
+"events": [  ]
+}
+ui_down={
+"deadzone": 0.5,
+"events": [  ]
+}
 toggle_full_screen={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":70,"unicode":0,"echo":false,"script":null)
@@ -59,7 +75,7 @@ exit={
 }
 toggle_debug_collision={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":67,"unicode":0,"echo":false,"script":null)
  ]
 }
 restart_test={

--- a/3d/physics_tests/main.tscn
+++ b/3d/physics_tests/main.tscn
@@ -41,7 +41,7 @@ margin_left = 157.0
 margin_top = 13.0
 margin_right = 375.0
 margin_bottom = 27.0
-text = "P - TOGGLE PAUSE / R - RESTART / D - TOGGLE COLLISION / F - TOGGLE FULL SCREEN / ESC - QUIT"
+text = "P - TOGGLE PAUSE / R - RESTART / C - TOGGLE COLLISION / F - TOGGLE FULL SCREEN / ESC - QUIT"
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/3d/physics_tests/project.godot
+++ b/3d/physics_tests/project.godot
@@ -47,6 +47,22 @@ window/stretch/aspect="expand"
 
 [input]
 
+ui_left={
+"deadzone": 0.5,
+"events": [  ]
+}
+ui_right={
+"deadzone": 0.5,
+"events": [  ]
+}
+ui_up={
+"deadzone": 0.5,
+"events": [  ]
+}
+ui_down={
+"deadzone": 0.5,
+"events": [  ]
+}
 toggle_full_screen={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":70,"unicode":0,"echo":false,"script":null)
@@ -59,7 +75,7 @@ exit={
 }
 toggle_debug_collision={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":67,"unicode":0,"echo":false,"script":null)
  ]
 }
 restart_test={


### PR DESCRIPTION
Changed debug collision shortcut from 'D' to 'C' to keep WASD available for other functions in some tests.

Unbound arrows from UI shortcuts for the same reason.

Based on https://github.com/godotengine/godot-demo-projects/pull/577#discussion_r562879147.
