### PR TITLE
Simplify the 3D scaling demo setup, enable filtering by default

### DIFF
--- a/viewport/3d_scaling/README.md
+++ b/viewport/3d_scaling/README.md
@@ -1,14 +1,10 @@
 # 3D Viewport Scaling
 
-This demo shows how to scale the 3D viewport rendering without affecting
-2D elements such as the HUD. It also demonstrates how to toggle filtering
-on a viewport by using TextureRect to display the ViewportTexture
-delivered by the Viewport node. This technique can be useful in 2D games
-as well. For instance, it can be used to have a "pixel art" viewport for
-the main game area and a non-pixel-art viewport for HUD elements.
-
-ViewportContainer can also be used to display a viewport in a GUI, but it
-doesn't offer the ability to enable filtering.
+This demo shows how to scale the 3D viewport rendering without affecting 2D
+elements such as the HUD. It also demonstrates how to toggle filtering on a
+viewport. This technique can be useful in 2D games as well. For instance, it can
+be used to have a "pixel art" viewport for the main game area and a
+non-pixel-art viewport for HUD elements.
 
 Language: GDScript
 

--- a/viewport/3d_scaling/hud.gd
+++ b/viewport/3d_scaling/hud.gd
@@ -1,20 +1,18 @@
 extends Control
 
-# The viewport is displayed using a TextureRect node instead of a ViewportContainer.
-# This allows filtering the texture that's displayed in the root viewport.
-
 # The 3D viewport's scale factor. For instance, 1.0 is full resolution,
 # 0.5 is half resolution and 2.0 is double resolution. Higher values look
 # sharper but are slower to render. Values above 1 can be used for supersampling
-# (SSAA), but filtering must be enabled for this to work.
+# (SSAA), but filtering must be enabled for supersampling to work.
 var scale_factor = 1.0
 
-onready var texture_rect = $TextureRect
-onready var viewport = $Viewport
+onready var viewport = $ViewportContainer/Viewport
 onready var scale_label = $VBoxContainer/Scale
 onready var filter_label = $VBoxContainer/Filter
 
 func _ready():
+	viewport.get_texture().flags = Texture.FLAG_FILTER
+
 	# Required to change the 3D viewport's size when the window is resized.
 	# warning-ignore:return_value_discarded
 	get_viewport().connect("size_changed", self, "_root_viewport_size_changed")
@@ -28,9 +26,9 @@ func _unhandled_input(event):
 
 	if event.is_action_pressed("toggle_filtering"):
 		# Toggle the Filter flag on the ViewportTexture.
-		texture_rect.texture.flags ^= ImageTexture.FLAG_FILTER
+		viewport.get_texture().flags ^= Texture.FLAG_FILTER
 
-		var filter_enabled = texture_rect.texture.flags & ImageTexture.FLAG_FILTER
+		var filter_enabled = viewport.get_texture().flags & Texture.FLAG_FILTER
 		filter_label.text = "Filter: %s" % ("Enabled" if filter_enabled else "Disabled")
 
 

--- a/viewport/3d_scaling/hud.tscn
+++ b/viewport/3d_scaling/hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://noto_sans_ui_regular.ttf" type="DynamicFontData" id=1]
 [ext_resource path="res://cubes.tscn" type="PackedScene" id=2]
@@ -11,9 +11,6 @@ font_data = ExtResource( 1 )
 [sub_resource type="Theme" id=2]
 default_font = SubResource( 1 )
 
-[sub_resource type="ViewportTexture" id=3]
-viewport_path = NodePath("Viewport")
-
 [node name="HUD" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -23,32 +20,22 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Viewport" type="Viewport" parent="."]
+[node name="ViewportContainer" type="ViewportContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+stretch = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Viewport" type="Viewport" parent="ViewportContainer"]
 size = Vector2( 1024, 600 )
 handle_input_locally = false
 usage = 3
 render_target_update_mode = 3
 shadow_atlas_size = 4096
 
-[node name="Cubes" parent="Viewport" instance=ExtResource( 2 )]
-
-[node name="TextureRect" type="TextureRect" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
-texture = SubResource( 3 )
-expand = true
-flip_v = true
-__meta__ = {
-"_edit_use_anchors_": false,
-"_editor_description_": ""
-}
-
-[node name="ViewportContainer" type="ViewportContainer" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="Cubes" parent="ViewportContainer/Viewport" instance=ExtResource( 2 )]
 
 [node name="Help" type="Label" parent="."]
 anchor_top = 1.0
@@ -98,7 +85,7 @@ custom_colors/font_color_shadow = Color( 0, 0, 0, 0.752941 )
 custom_constants/shadow_offset_x = 2
 custom_constants/shadow_offset_y = 2
 custom_constants/shadow_as_outline = 0
-text = "Filter: Disabled"
+text = "Filter: Enabled"
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/viewport/3d_scaling/project.godot
+++ b/viewport/3d_scaling/project.godot
@@ -16,15 +16,11 @@ _global_script_class_icons={
 [application]
 
 config/name="3D Viewport Scaling"
-config/description="This demo shows how to scale the 3D viewport rendering without affecting
-2D elements such as the HUD. It also demonstrates how to toggle filtering
-on a viewport by using TextureRect to display the ViewportTexture
-delivered by the Viewport node. This technique can be useful in 2D games
-as well. For instance, it can be used to have a 'pixel art' viewport for
-the main game area and a non-pixel-art viewport for HUD elements.
-
-ViewportContainer can also be used to display a viewport in a GUI, but it
-doesn't offer the ability to enable filtering."
+config/description="This demo shows how to scale the 3D viewport rendering without affecting 2D
+elements such as the HUD. It also demonstrates how to toggle filtering on a
+viewport. This technique can be useful in 2D games as well. For instance, it can
+be used to have a \"pixel art\" viewport for the main game area and a
+non-pixel-art viewport for HUD elements."
 run/main_scene="res://hud.tscn"
 config/icon="res://icon.png"
 


### PR DESCRIPTION
It turns out using a TextureRect node isn't necessary :slightly_smiling_face: 
I found this out while working on https://github.com/RodZill4/material-maker/pull/284.

The typical ViewportContainer + Viewport setup can be used just fine to enable filtering on the ViewportTexture returned by the Viewport.

The performance of the new method is equivalent to the old one.