### PR TITLE
Improve controls and camera handling in the Truck Town demo

### DIFF
--- a/3d/truck_town/car_base.tscn
+++ b/3d/truck_town/car_base.tscn
@@ -207,7 +207,9 @@ current = true
 fov = 74.0
 near = 0.1
 script = ExtResource( 5 )
-max_distance = 7.0
+min_distance = 3.0
+max_distance = 4.0
+height = 1.25
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 _import_path = NodePath("AnimationPlayer")

--- a/3d/truck_town/car_select.gd
+++ b/3d/truck_town/car_select.gd
@@ -18,8 +18,13 @@ func _load_scene(car):
 
 
 func _on_Back_pressed():
-	town.queue_free()
-	show()
+	if is_instance_valid(town):
+		# Currently in the town, go back to main menu.
+		town.queue_free()
+		show()
+	else:
+		# In main menu, exit the game.
+		get_tree().quit()
 
 
 func _on_MiniVan_pressed():

--- a/3d/truck_town/car_select.tscn
+++ b/3d/truck_town/car_select.tscn
@@ -48,6 +48,7 @@ margin_bottom = 400.0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 icon = ExtResource( 4 )
+
 [connection signal="pressed" from="MiniVan" to="." method="_on_MiniVan_pressed"]
 [connection signal="pressed" from="TrailerTruck" to="." method="_on_TrailerTruck_pressed"]
 [connection signal="pressed" from="TowTruck" to="." method="_on_TowTruck_pressed"]

--- a/3d/truck_town/follow_camera.gd
+++ b/3d/truck_town/follow_camera.gd
@@ -1,12 +1,11 @@
 extends Camera
 
-export var min_distance = 0.5
+export var min_distance = 2.0
 export var max_distance = 4.0
 export var angle_v_adjust = 0.0
 
 var collision_exception = []
-var max_height = 2.0
-var min_height = 0
+export var height = 1.5
 
 func _ready():
 	# Find collision exceptions for ray.
@@ -34,11 +33,7 @@ func _physics_process(_delta):
 	elif from_target.length() > max_distance:
 		from_target = from_target.normalized() * max_distance
 
-	# Check upper and lower height.
-	if from_target.y > max_height:
-		from_target.y = max_height
-	if from_target.y < min_height:
-		from_target.y = min_height
+	from_target.y = height
 
 	pos = target + from_target
 

--- a/3d/truck_town/project.godot
+++ b/3d/truck_town/project.godot
@@ -70,6 +70,10 @@ back={
  ]
 }
 
+[physics]
+
+3d/default_gravity=11.0
+
 [rasterizer]
 
 shadow_filter=3

--- a/3d/truck_town/tow_truck.tscn
+++ b/3d/truck_town/tow_truck.tscn
@@ -337,7 +337,9 @@ current = true
 fov = 74.0
 near = 0.1
 script = ExtResource( 5 )
+min_distance = 5.0
 max_distance = 7.0
+height = 1.75
 
 [node name="CollisionShape" type="CollisionShape" parent="Body"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.391365, 0.158069 )

--- a/3d/truck_town/trailer_truck.tscn
+++ b/3d/truck_town/trailer_truck.tscn
@@ -385,7 +385,9 @@ current = true
 fov = 74.0
 near = 0.1
 script = ExtResource( 5 )
+min_distance = 5.0
 max_distance = 7.0
+height = 2.5
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 _import_path = NodePath("AnimationPlayer")

--- a/3d/truck_town/vehicle.gd
+++ b/3d/truck_town/vehicle.gd
@@ -1,11 +1,11 @@
 extends VehicleBody
 
-const STEER_SPEED = 1
+const STEER_SPEED = 1.5
 const STEER_LIMIT = 0.4
 
 var steer_target = 0
 
-export var engine_force_value = 40
+export var engine_force_value = 85
 
 func _physics_process(delta):
 	var fwd_mps = transform.basis.xform_inv(linear_velocity).x


### PR DESCRIPTION
- Increase movement and steering speed significantly.
- Increase gravity slightly for a less floaty feeling.
- Simplify camera code (height is now constant).
- Tweaked camera distance and height to fit each vehicle.
- Fix script error when pressing Escape in the main menu (the demo will now quit).