### PR TITLE
Added interpolation functionality to ik_look_at node

### DIFF
--- a/3d/ik/addons/sade/ik_look_at.gd
+++ b/3d/ik/addons/sade/ik_look_at.gd
@@ -5,6 +5,7 @@ export(NodePath) var skeleton_path setget _set_skeleton_path
 export(String) var bone_name = ""
 export(int, "_process", "_physics_process", "_notification", "none") var update_mode = 0 setget _set_update
 export(int, "X-up", "Y-up", "Z-up") var look_at_axis = 1
+export(float, 0,1,0.001) var interpolation = 0;
 export(bool) var use_our_rotation_x = false
 export(bool) var use_our_rotation_y = false
 export(bool) var use_our_rotation_z = false
@@ -127,7 +128,7 @@ func update_skeleton():
 		rest.origin = additional_bone_pos.origin - additional_bone_pos.basis.z.normalized() * additional_bone_length
 
 	# Finally, apply the new rotation to the bone in the skeleton.
-	skeleton_to_use.set_bone_global_pose_override(bone, rest, 1.0, true)
+	skeleton_to_use.set_bone_global_pose_override(bone, rest, interpolation, true)
 
 
 func _setup_for_editor():

--- a/3d/ik/addons/sade/ik_look_at.gd
+++ b/3d/ik/addons/sade/ik_look_at.gd
@@ -5,7 +5,7 @@ export(NodePath) var skeleton_path setget _set_skeleton_path
 export(String) var bone_name = ""
 export(int, "_process", "_physics_process", "_notification", "none") var update_mode = 0 setget _set_update
 export(int, "X-up", "Y-up", "Z-up") var look_at_axis = 1
-export(float, 0.0, 1.0, 0.001) var interpolation = 1.0;
+export(float, 0.0, 1.0, 0.001) var interpolation = 1.0
 export(bool) var use_our_rotation_x = false
 export(bool) var use_our_rotation_y = false
 export(bool) var use_our_rotation_z = false

--- a/3d/ik/addons/sade/ik_look_at.gd
+++ b/3d/ik/addons/sade/ik_look_at.gd
@@ -5,7 +5,7 @@ export(NodePath) var skeleton_path setget _set_skeleton_path
 export(String) var bone_name = ""
 export(int, "_process", "_physics_process", "_notification", "none") var update_mode = 0 setget _set_update
 export(int, "X-up", "Y-up", "Z-up") var look_at_axis = 1
-export(float, 0,1,0.001) var interpolation = 1;
+export(float, 0.0, 1.0, 0.001) var interpolation = 1.0;
 export(bool) var use_our_rotation_x = false
 export(bool) var use_our_rotation_y = false
 export(bool) var use_our_rotation_z = false

--- a/3d/ik/addons/sade/ik_look_at.gd
+++ b/3d/ik/addons/sade/ik_look_at.gd
@@ -5,7 +5,7 @@ export(NodePath) var skeleton_path setget _set_skeleton_path
 export(String) var bone_name = ""
 export(int, "_process", "_physics_process", "_notification", "none") var update_mode = 0 setget _set_update
 export(int, "X-up", "Y-up", "Z-up") var look_at_axis = 1
-export(float, 0,1,0.001) var interpolation = 0;
+export(float, 0,1,0.001) var interpolation = 1;
 export(bool) var use_our_rotation_x = false
 export(bool) var use_our_rotation_y = false
 export(bool) var use_our_rotation_z = false


### PR DESCRIPTION
a slider with a range of 0 - 1 will now appear in the editor. Control of the bone is interpolated between the original bone rotation and the IK lookat rotation. In my opinion, this is basic functionality that should have been included in the first place, seeing as the Godot built in IK node has an interpolation slider.

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest stable Godot version. Do not submit a
  pull request if it only works with alpha/beta builds.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
