### PR TITLE
Use ETC instead of ETC2 for all GLES2 demos

### DIFF
--- a/2d/finite_state_machine/project.godot
+++ b/2d/finite_state_machine/project.godot
@@ -102,3 +102,5 @@ attack={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/2d/gd_paint/project.godot
+++ b/2d/gd_paint/project.godot
@@ -37,3 +37,5 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/2d/hexagonal_map/project.godot
+++ b/2d/hexagonal_map/project.godot
@@ -68,4 +68,6 @@ move_up={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.172549, 0.219608, 0.129412, 1 )

--- a/2d/instancing/project.godot
+++ b/2d/instancing/project.godot
@@ -39,4 +39,6 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.301961, 0.301961, 0.301961, 1 )

--- a/2d/isometric/project.godot
+++ b/2d/isometric/project.godot
@@ -80,4 +80,6 @@ use_pixel_snap=true
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.0784314, 0.105882, 0.145098, 1 )

--- a/2d/kinematic_character/project.godot
+++ b/2d/kinematic_character/project.godot
@@ -76,4 +76,6 @@ multithread/thread_rid_pool_prealloc=60
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.156, 0.1325, 0.25, 1 )

--- a/2d/light2d_as_mask/project.godot
+++ b/2d/light2d_as_mask/project.godot
@@ -37,3 +37,5 @@ shadow_filter=3
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/2d/lights_and_shadows/project.godot
+++ b/2d/lights_and_shadows/project.godot
@@ -41,3 +41,5 @@ shadow_filter=2
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/2d/navigation/project.godot
+++ b/2d/navigation/project.godot
@@ -46,4 +46,6 @@ click={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.160784, 0.172549, 0.278431, 1 )

--- a/2d/navigation_astar/project.godot
+++ b/2d/navigation_astar/project.godot
@@ -38,3 +38,5 @@ click={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/2d/physics_tests/project.godot
+++ b/2d/physics_tests/project.godot
@@ -120,5 +120,7 @@ limits/message_queue/max_size_kb=10240
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.184314, 0.184314, 0.184314, 1 )
 quality/filters/msaa=2

--- a/2d/pong/project.godot
+++ b/2d/pong/project.godot
@@ -71,4 +71,6 @@ right_move_up={
 
 quality/driver/driver_name="GLES2"
 quality/2d/use_pixel_snap=true
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 viewport/default_clear_color=Color( 0, 0, 0, 1 )

--- a/2d/role_playing_game/project.godot
+++ b/2d/role_playing_game/project.godot
@@ -68,3 +68,5 @@ ui_down={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/2d/sprite_shaders/project.godot
+++ b/2d/sprite_shaders/project.godot
@@ -30,3 +30,5 @@ window/stretch/aspect="expand"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/2d/tween/project.godot
+++ b/2d/tween/project.godot
@@ -45,4 +45,6 @@ multithread/thread_rid_pool_prealloc=60
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.2349, 0.2349, 0.27, 1 )

--- a/3d/navmesh/particle.png.import
+++ b/3d/navmesh/particle.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="StreamTexture"
 path.s3tc="res://.import/particle.png-c2ba3d91e96c62035d672392a1197218.s3tc.stex"
-path.etc2="res://.import/particle.png-c2ba3d91e96c62035d672392a1197218.etc2.stex"
+path.etc="res://.import/particle.png-c2ba3d91e96c62035d672392a1197218.etc.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
+"imported_formats": [ "s3tc", "etc" ],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://particle.png"
-dest_files=[ "res://.import/particle.png-c2ba3d91e96c62035d672392a1197218.s3tc.stex", "res://.import/particle.png-c2ba3d91e96c62035d672392a1197218.etc2.stex" ]
+dest_files=[ "res://.import/particle.png-c2ba3d91e96c62035d672392a1197218.s3tc.stex", "res://.import/particle.png-c2ba3d91e96c62035d672392a1197218.etc.stex" ]
 
 [params]
 

--- a/3d/navmesh/project.godot
+++ b/3d/navmesh/project.godot
@@ -31,5 +31,7 @@ singletons=[  ]
 
 quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=3
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 quality/shadows/filter_mode=2
 quality/filters/msaa=2

--- a/3d/physics_tests/project.godot
+++ b/3d/physics_tests/project.godot
@@ -92,5 +92,7 @@ toggle_pause={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.184314, 0.184314, 0.184314, 1 )
 quality/filters/msaa=2

--- a/3d/truck_town/Images/cement.png.import
+++ b/3d/truck_town/Images/cement.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="StreamTexture"
 path.s3tc="res://.import/cement.png-702c83258feb3e054c70d5eef03c8880.s3tc.stex"
-path.etc2="res://.import/cement.png-702c83258feb3e054c70d5eef03c8880.etc2.stex"
+path.etc="res://.import/cement.png-702c83258feb3e054c70d5eef03c8880.etc.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
+"imported_formats": [ "s3tc", "etc" ],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://Images/cement.png"
-dest_files=[ "res://.import/cement.png-702c83258feb3e054c70d5eef03c8880.s3tc.stex", "res://.import/cement.png-702c83258feb3e054c70d5eef03c8880.etc2.stex" ]
+dest_files=[ "res://.import/cement.png-702c83258feb3e054c70d5eef03c8880.s3tc.stex", "res://.import/cement.png-702c83258feb3e054c70d5eef03c8880.etc.stex" ]
 
 [params]
 

--- a/3d/truck_town/Images/grass.png.import
+++ b/3d/truck_town/Images/grass.png.import
@@ -3,16 +3,16 @@
 importer="texture"
 type="StreamTexture"
 path.s3tc="res://.import/grass.png-6ab6f9e06dc0919bf6b674e512573aeb.s3tc.stex"
-path.etc2="res://.import/grass.png-6ab6f9e06dc0919bf6b674e512573aeb.etc2.stex"
+path.etc="res://.import/grass.png-6ab6f9e06dc0919bf6b674e512573aeb.etc.stex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
+"imported_formats": [ "s3tc", "etc" ],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://Images/grass.png"
-dest_files=[ "res://.import/grass.png-6ab6f9e06dc0919bf6b674e512573aeb.s3tc.stex", "res://.import/grass.png-6ab6f9e06dc0919bf6b674e512573aeb.etc2.stex" ]
+dest_files=[ "res://.import/grass.png-6ab6f9e06dc0919bf6b674e512573aeb.s3tc.stex", "res://.import/grass.png-6ab6f9e06dc0919bf6b674e512573aeb.etc.stex" ]
 
 [params]
 

--- a/3d/truck_town/project.godot
+++ b/3d/truck_town/project.godot
@@ -78,6 +78,8 @@ shadow_filter=3
 
 quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=3
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 quality/shadows/filter_mode=2
 quality/filters/msaa=2
 environment/default_environment="res://default_env.tres"

--- a/audio/bpm_sync/project.godot
+++ b/audio/bpm_sync/project.godot
@@ -23,3 +23,5 @@ config/icon="res://icon.png"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/audio/device_changer/project.godot
+++ b/audio/device_changer/project.godot
@@ -100,3 +100,5 @@ ui_end={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/audio/generator/project.godot
+++ b/audio/generator/project.godot
@@ -24,3 +24,5 @@ run/main_scene="res://generator.tscn"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/audio/mic_record/project.godot
+++ b/audio/mic_record/project.godot
@@ -36,3 +36,5 @@ window/stretch/aspect="expand"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/audio/spectrum/project.godot
+++ b/audio/spectrum/project.godot
@@ -23,3 +23,5 @@ config/icon="res://icon.png"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/gui/drag_and_drop/project.godot
+++ b/gui/drag_and_drop/project.godot
@@ -36,3 +36,5 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/gui/input_mapping/project.godot
+++ b/gui/input_mapping/project.godot
@@ -67,3 +67,5 @@ dash={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/gui/regex/project.godot
+++ b/gui/regex/project.godot
@@ -34,3 +34,5 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/gui/rich_text_bbcode/project.godot
+++ b/gui/rich_text_bbcode/project.godot
@@ -37,4 +37,6 @@ multithread/thread_rid_pool_prealloc=60
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.145098, 0.145098, 0.164706, 1 )

--- a/gui/translation/project.godot
+++ b/gui/translation/project.godot
@@ -46,4 +46,6 @@ multithread/thread_rid_pool_prealloc=60
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.145098, 0.145098, 0.164706, 1 )

--- a/loading/autoload/project.godot
+++ b/loading/autoload/project.godot
@@ -40,3 +40,5 @@ multithread/thread_rid_pool_prealloc=60
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/loading/background_load/project.godot
+++ b/loading/background_load/project.godot
@@ -110,3 +110,5 @@ ui_end={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/loading/multiple_threads_loading/project.godot
+++ b/loading/multiple_threads_loading/project.godot
@@ -24,3 +24,5 @@ config/icon="res://icon.png"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/loading/scene_changer/project.godot
+++ b/loading/scene_changer/project.godot
@@ -36,3 +36,5 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/loading/threads/project.godot
+++ b/loading/threads/project.godot
@@ -36,3 +36,5 @@ multithread/thread_rid_pool_prealloc=60
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/misc/2.5d/project.godot
+++ b/misc/2.5d/project.godot
@@ -196,3 +196,5 @@ exit={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/misc/joypads/project.godot
+++ b/misc/joypads/project.godot
@@ -44,3 +44,5 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/misc/matrix_transform/project.godot
+++ b/misc/matrix_transform/project.godot
@@ -38,4 +38,6 @@ config/icon="res://icon.png"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_environment="res://default_env.tres"

--- a/misc/pause/project.godot
+++ b/misc/pause/project.godot
@@ -34,4 +34,6 @@ singletons=[  ]
 
 quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=3
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 quality/filters/msaa=2

--- a/misc/window_management/project.godot
+++ b/misc/window_management/project.godot
@@ -79,4 +79,6 @@ move_right={
 
 quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=3
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 quality/filters/msaa=2

--- a/mobile/android_iap/project.godot
+++ b/mobile/android_iap/project.godot
@@ -40,3 +40,5 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/mobile/multitouch_cubes/project.godot
+++ b/mobile/multitouch_cubes/project.godot
@@ -28,5 +28,7 @@ singletons=[  ]
 quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=0
 quality/intended_usage/framebuffer_allocation.mobile=0
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.113725, 0.133333, 0.196078, 1 )
 environment/default_environment="res://default_env.tres"

--- a/mobile/multitouch_view/project.godot
+++ b/mobile/multitouch_view/project.godot
@@ -35,4 +35,6 @@ pointing/emulate_touch_from_mouse=true
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.113725, 0.133333, 0.196078, 1 )

--- a/mobile/sensors/project.godot
+++ b/mobile/sensors/project.godot
@@ -26,4 +26,6 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_environment="res://default_env.tres"

--- a/mono/2.5d/project.godot
+++ b/mono/2.5d/project.godot
@@ -173,3 +173,5 @@ exit={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/mono/android_iap/project.godot
+++ b/mono/android_iap/project.godot
@@ -37,3 +37,4 @@ singletons=[  ]
 
 quality/driver/driver_name="GLES2"
 vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/mono/multiplayer_pong/project.godot
+++ b/mono/multiplayer_pong/project.godot
@@ -54,3 +54,5 @@ move_up={
 
 quality/driver/driver_name="GLES2"
 quality/2d/use_pixel_snap=true
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/mono/pong/project.godot
+++ b/mono/pong/project.godot
@@ -69,4 +69,6 @@ right_move_up={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 viewport/default_clear_color=Color( 0, 0, 0, 1 )

--- a/networking/multiplayer_pong/project.godot
+++ b/networking/multiplayer_pong/project.godot
@@ -64,3 +64,5 @@ move_up={
 
 quality/driver/driver_name="GLES2"
 quality/2d/use_pixel_snap=true
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/networking/webrtc_minimal/project.godot
+++ b/networking/webrtc_minimal/project.godot
@@ -35,3 +35,5 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/networking/webrtc_signaling/project.godot
+++ b/networking/webrtc_signaling/project.godot
@@ -46,3 +46,5 @@ modules/webrtc_gdnative_script="res://demo/webrtc/webrtc.gdns"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/networking/websocket_chat/project.godot
+++ b/networking/websocket_chat/project.godot
@@ -30,3 +30,5 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/networking/websocket_minimal/project.godot
+++ b/networking/websocket_minimal/project.godot
@@ -21,3 +21,5 @@ run/main_scene="res://Main.tscn"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/networking/websocket_multiplayer/project.godot
+++ b/networking/websocket_multiplayer/project.godot
@@ -22,3 +22,5 @@ config/icon="res://icon.png"
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/viewport/2d_in_3d/project.godot
+++ b/viewport/2d_in_3d/project.godot
@@ -50,4 +50,6 @@ right_move_down={
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_environment="res://default_env.tres"

--- a/viewport/3d_scaling/project.godot
+++ b/viewport/3d_scaling/project.godot
@@ -47,4 +47,6 @@ toggle_filtering={
 
 quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=3
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_environment="res://default_env.tres"

--- a/viewport/dynamic_split_screen/project.godot
+++ b/viewport/dynamic_split_screen/project.godot
@@ -90,6 +90,8 @@ move_right_player2={
 
 quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=3
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 quality/shadows/filter_mode=2
 environment/default_clear_color=Color( 1, 1, 1, 1 )
 environment/default_environment="res://default_env.tres"

--- a/viewport/screen_capture/project.godot
+++ b/viewport/screen_capture/project.godot
@@ -37,3 +37,5 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false

--- a/visual_script/circle_pop/project.godot
+++ b/visual_script/circle_pop/project.godot
@@ -29,4 +29,6 @@ singletons=[  ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.113725, 0.133333, 0.196078, 1 )

--- a/visual_script/multitouch_view/project.godot
+++ b/visual_script/multitouch_view/project.godot
@@ -36,4 +36,6 @@ pointing/emulate_touch_from_mouse=true
 [rendering]
 
 quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_clear_color=Color( 0.113725, 0.133333, 0.196078, 1 )

--- a/visual_script/pong/project.godot
+++ b/visual_script/pong/project.godot
@@ -71,4 +71,6 @@ right_move_up={
 
 quality/driver/driver_name="GLES2"
 quality/2d/use_pixel_snap=true
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 viewport/default_clear_color=Color( 0, 0, 0, 1 )


### PR DESCRIPTION
This was missed when converting the demos to GLES2, and pointed out by @akien-mga. This PR fixes it.

All of the affected demos have been opened and tested to make sure they work, but only Truck Town had additional diffs.