### PR TITLE
Fix MIDI devices scanning

### DIFF
--- a/misc/os_test/os_test.gd
+++ b/misc/os_test/os_test.gd
@@ -39,6 +39,13 @@ func datetime_to_string(date):
 		})
 
 
+func scan_midi_devices():
+	OS.open_midi_inputs()
+	var devices = OS.get_connected_midi_inputs().join(", ")
+	OS.close_midi_inputs()
+	return devices
+
+
 func add_header(header):
 	rtl.append_bbcode("\n[b][u][color=#6df]{header}[/color][/u][/b]\n".format({
 		header = header,
@@ -58,7 +65,7 @@ func _ready():
 	for i in OS.get_audio_driver_count():
 		audio_drivers.push_back(OS.get_audio_driver_name(i))
 	add_line("Available drivers", audio_drivers.join(", "))
-	add_line("MIDI inputs", OS.get_connected_midi_inputs().join(", "))
+	add_line("MIDI inputs", scan_midi_devices())
 
 	add_header("Date")
 	add_line("Date and time (local)", datetime_to_string(OS.get_datetime()))


### PR DESCRIPTION
<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest stable Godot version. Do not submit a
  pull request if it only works with alpha/beta builds.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->

Fixes #603.

Calls `OS.open_midi_inputs()` before `OS.get_connected_midi_inputs()` and then close MIDI inputs.
