### PR TITLE
Update README for the new 3.2 branch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,10 +2,15 @@
 root = true
 
 # Unix-style newlines with a newline ending every file.
-[*.cs]
+[*]
+charset = utf-8
+end_of_line = lf
 insert_final_newline = true
+
+[*.cs]
 csharp_space_after_cast = false
 indent_size = 4
 
 [*.csproj]
+insert_final_newline = false
 indent_size = 2

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug Report
 about: Report a bug with one of the demo projects.
-title: ''
+title: ""
 labels: bug
-assignees: ''
+assignees: ""
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature---enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature---enhancement-request.md
@@ -1,9 +1,9 @@
 ---
 name: Feature / Enhancement Request
 about: Adding new features or improving existing ones.
-title: ''
+title: ""
 labels: enhancement
-assignees: ''
+assignees: ""
 
 ---
 

--- a/2d/physics_tests/README.md
+++ b/2d/physics_tests/README.md
@@ -4,6 +4,7 @@ This demo contains a series of tests for the 2D
 physics engine.
 
 They can be used for different purpose:
+
 - Functional tests to check for regressions and
   behavior of the 2D physics engine
 - Performance tests to evaluate performance

--- a/3d/physics_tests/README.md
+++ b/3d/physics_tests/README.md
@@ -4,6 +4,7 @@ This demo contains a series of tests for the 3D
 physics engine.
 
 They can be used for different purpose:
+
 - Functional tests to check for regressions and
   compare the behavior between physics engines
 - Performance tests to evaluate and compare

--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@ be used with [Godot Engine](https://godotengine.org), the open source
 
 ## Godot versions
 
-- The [`master`](https://github.com/godotengine/godot-demo-projects) branch is compatible with the latest stable Godot version (currently 3.2).
+- The [`master`](https://github.com/godotengine/godot-demo-projects) branch is compatible with the latest stable Godot version (currently 3.3.x).
 - If you are using an older version of Godot, use the appropriate branch for your Godot version:
 
-  - [`3.1`](https://github.com/godotengine/godot-demo-projects/tree/3.1) branch
-  for Godot 3.1.x.
-  - [`3.0`](https://github.com/godotengine/godot-demo-projects/tree/3.0) branch
-  for Godot 3.0.x.
-  - [`2.1`](https://github.com/godotengine/godot-demo-projects/tree/2.1) branch
-  for Godot 2.1.x.
+  - [`3.2`](https://github.com/godotengine/godot-demo-projects/tree/3.2)
+    branch for Godot 3.2.x.
+  - [`3.1`](https://github.com/godotengine/godot-demo-projects/tree/3.1)
+    branch for Godot 3.1.x.
+  - [`3.0`](https://github.com/godotengine/godot-demo-projects/tree/3.0)
+    branch for Godot 3.0.x.
+  - [`2.1`](https://github.com/godotengine/godot-demo-projects/tree/2.1)
+    branch for Godot 2.1.x.
 
 ## Importing all demos
 
@@ -40,6 +42,7 @@ desktop. For the best performance, consider downloading the demos.
 - [Source code](https://github.com/godotengine/godot)
 - [Documentation](http://docs.godotengine.org)
 - [Community hub](https://godotengine.org/community)
+- [TPS demo](https://github.com/godotengine/tps-demo)
 
 ## License
 

--- a/networking/webrtc_signaling/README.md
+++ b/networking/webrtc_signaling/README.md
@@ -17,6 +17,7 @@ Check out this demo on the asset library: https://godotengine.org/asset-library/
 The protocol is text based, and composed by a command and possibly multiple payload arguments, each separated by a new line.
 
 Messages without payload must still end with a newline and are the following:
+
 - `J: ` (or `J: <ROOM>`), must be sent by client immediately after connection to get a lobby assigned or join a known one.
   This messages is also sent by server back to the client to notify assigned lobby, or simply a successful join.
 - `I: <ID>`, sent by server to identify the client when it joins a room.
@@ -27,6 +28,7 @@ Messages without payload must still end with a newline and are the following:
 When a lobby is sealed, no new client will be able to join, and the lobby will be destroyed (and clients disconnected) after 10 seconds.
 
 Messages with payload (used to transfer WebRTC parameters) are:
+
 - `O: <ID>`, used to send an offer.
 - `A: <ID>`, used to send an answer.
 - `C: <ID>`, used to send a candidate.


### PR DESCRIPTION
This PR updates the README for Godot 3.3 and a few other misc things.

After this PR, there will be a 3.2 branch, and the master branch of the demos will be targeting Godot 3.3.x.