### PR TITLE
Physics Tests 3.3 update

### DIFF
--- a/2d/physics_tests/tests/functional/test_shapes.tscn
+++ b/2d/physics_tests/tests/functional/test_shapes.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://assets/texture/godot-head.png" type="Texture" id=1]
 [ext_resource path="res://test.gd" type="Script" id=2]
+[ext_resource path="res://utils/rigidbody_pick.gd" type="Script" id=3]
 [ext_resource path="res://tests/static_scene.tscn" type="PackedScene" id=6]
 
 [sub_resource type="RectangleShape2D" id=1]
@@ -21,6 +22,7 @@ script = ExtResource( 2 )
 
 [node name="RigidBodyRectangle" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 96, 127 )
+script = ExtResource( 3 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodyRectangle"]
 rotation = 0.675442
@@ -28,6 +30,7 @@ shape = SubResource( 1 )
 
 [node name="RigidBodyCapsule" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 270.165, 139.444 )
+script = ExtResource( 3 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodyCapsule"]
 rotation = -0.202458
@@ -35,6 +38,7 @@ shape = SubResource( 2 )
 
 [node name="RigidBodyConcavePolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 683.614, 132.749 )
+script = ExtResource( 3 )
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="DynamicShapes/RigidBodyConcavePolygon"]
 scale = Vector2( 0.5, 0.5 )
@@ -47,6 +51,7 @@ texture = ExtResource( 1 )
 
 [node name="RigidBodyConvexPolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 473.536, 134.336 )
+script = ExtResource( 3 )
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="DynamicShapes/RigidBodyConvexPolygon"]
 scale = Vector2( 0.5, 0.5 )
@@ -59,6 +64,7 @@ texture = ExtResource( 1 )
 
 [node name="RigidBodySphere" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 919.968, 115.129 )
+script = ExtResource( 3 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodySphere"]
 shape = SubResource( 3 )

--- a/3d/physics_tests/test.gd
+++ b/3d/physics_tests/test.gd
@@ -46,23 +46,33 @@ func add_sphere(pos, radius, color):
 
 
 func add_shape(shape, transform, color):
+	var body = StaticBody.new()
+	body.collision_layer = 0
+	body.collision_mask = 0
+
 	var collision = CollisionShape.new()
+	collision.transform = transform
 	collision.shape = shape
 
-	_drawn_nodes.push_back(collision)
-	add_child(collision)
+	body.add_child(collision)
 
-	var mesh_instance = collision.get_child(0)
+	add_child(body)
+	_drawn_nodes.push_back(body)
+
+	call_deferred("initialize_shape_material", body, color)
+
+
+func initialize_shape_material(body, color):
+	var mesh_instance = body.get_child(1)
 	var material = SpatialMaterial.new()
 	material.flags_unshaded = true
 	material.albedo_color = color
 	mesh_instance.material_override = material
 
-	collision.global_transform = transform
-
 
 func clear_drawn_nodes():
 	for node in _drawn_nodes:
+		remove_child(node)
 		node.queue_free()
 	_drawn_nodes.clear()
 

--- a/3d/physics_tests/tests/functional/test_collision_pairs.tscn
+++ b/3d/physics_tests/tests/functional/test_collision_pairs.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://assets/robot_head/godot3_robot_head_collision.tres" type="Shape" id=1]
 [ext_resource path="res://tests/functional/test_collision_pairs.gd" type="Script" id=2]
-[ext_resource path="res://utils/exception_cylinder.gd" type="Script" id=3]
 [ext_resource path="res://utils/camera_orbit.gd" type="Script" id=4]
 [ext_resource path="res://tests/test_options.tscn" type="PackedScene" id=5]
 
@@ -141,7 +140,6 @@ shape = SubResource( 3 )
 [node name="RigidBodyCylinder" type="RigidBody" parent="Shapes"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0, 0 )
 mode = 3
-script = ExtResource( 3 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Shapes/RigidBodyCylinder"]
 transform = Transform( 0.772741, -0.258819, 2.59821e-08, 0.2, 0.933013, -0.207055, 0.0535898, 0.25, 0.772741, 0, 0, 0 )

--- a/3d/physics_tests/tests/functional/test_raycasting.tscn
+++ b/3d/physics_tests/tests/functional/test_raycasting.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://assets/robot_head/godot3_robot_head_collision.tres" type="Shape" id=1]
 [ext_resource path="res://tests/functional/test_raycasting.gd" type="Script" id=2]
-[ext_resource path="res://utils/exception_cylinder.gd" type="Script" id=3]
 [ext_resource path="res://utils/camera_orbit.gd" type="Script" id=4]
 
 [sub_resource type="BoxShape" id=1]
@@ -48,7 +47,6 @@ shape = SubResource( 3 )
 [node name="RigidBodyCylinder" type="RigidBody" parent="Shapes"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0, 0 )
 mode = 3
-script = ExtResource( 3 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Shapes/RigidBodyCylinder"]
 transform = Transform( 0.772741, -0.258819, 2.59821e-08, 0.2, 0.933013, -0.207055, 0.0535898, 0.25, 0.772741, 0, 0, 0 )

--- a/3d/physics_tests/tests/functional/test_shapes.tscn
+++ b/3d/physics_tests/tests/functional/test_shapes.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=10 format=2]
 
+[ext_resource path="res://utils/rigidbody_pick.gd" type="Script" id=1]
 [ext_resource path="res://test.gd" type="Script" id=2]
-[ext_resource path="res://utils/exception_cylinder.gd" type="Script" id=3]
 [ext_resource path="res://utils/camera_orbit.gd" type="Script" id=4]
 [ext_resource path="res://tests/static_scene.tscn" type="PackedScene" id=6]
 
@@ -24,6 +24,7 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 9.35591, 0 )
 
 [node name="RigidBodyBox" type="RigidBody" parent="DynamicShapes"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, 0 )
+script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyBox"]
 transform = Transform( 0.579556, 0.0885213, 0.145926, 0, 0.939693, -0.205212, -0.155291, 0.330366, 0.544604, 0, 0, 0 )
@@ -31,13 +32,14 @@ shape = SubResource( 1 )
 
 [node name="RigidBodyCapsule" type="RigidBody" parent="DynamicShapes"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 0, 0 )
+script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyCapsule"]
 transform = Transform( 0.8, 0, 0, 0, -1.30337e-07, -0.8, 0, 0.8, -1.30337e-07, 0, 0, 0 )
 shape = SubResource( 2 )
 
 [node name="RigidBodyCylinder" type="RigidBody" parent="DynamicShapes"]
-script = ExtResource( 3 )
+script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyCylinder"]
 transform = Transform( 0.772741, -0.258819, 2.59821e-08, 0.2, 0.933013, -0.207055, 0.0535898, 0.25, 0.772741, 0, 0, 0 )
@@ -45,6 +47,7 @@ shape = SubResource( 3 )
 
 [node name="RigidBodyConvex" type="RigidBody" parent="DynamicShapes"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0, 0 )
+script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyConvex"]
 transform = Transform( 1.5, 0, 0, 0, 1.93185, -0.388229, 0, 0.517638, 1.44889, 0, 0, 0 )
@@ -52,6 +55,7 @@ shape = SubResource( 4 )
 
 [node name="RigidBodySphere" type="RigidBody" parent="DynamicShapes"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 0, 0 )
+script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodySphere"]
 transform = Transform( 0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0, 0 )

--- a/3d/physics_tests/tests/performance/test_perf_contacts.tscn
+++ b/3d/physics_tests/tests/performance/test_perf_contacts.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://tests/static_scene.tscn" type="PackedScene" id=1]
 [ext_resource path="res://tests/performance/test_perf_contacts.gd" type="Script" id=2]
-[ext_resource path="res://utils/exception_cylinder.gd" type="Script" id=3]
 [ext_resource path="res://tests/test_options.tscn" type="PackedScene" id=4]
 [ext_resource path="res://utils/camera_orbit.gd" type="Script" id=5]
 
@@ -46,7 +45,6 @@ shape = SubResource( 2 )
 
 [node name="RigidBodyCylinder" type="RigidBody" parent="DynamicShapes"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 0 )
-script = ExtResource( 3 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyCylinder"]
 shape = SubResource( 3 )

--- a/3d/physics_tests/tests/performance/test_perf_contacts_extended.tscn
+++ b/3d/physics_tests/tests/performance/test_perf_contacts_extended.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://tests/performance/test_perf_contacts.gd" type="Script" id=1]
-[ext_resource path="res://utils/exception_cylinder.gd" type="Script" id=2]
 [ext_resource path="res://utils/camera_orbit.gd" type="Script" id=3]
 [ext_resource path="res://tests/test_options.tscn" type="PackedScene" id=4]
 [ext_resource path="res://tests/static_scene.tscn" type="PackedScene" id=5]
@@ -91,7 +90,6 @@ shape = SubResource( 2 )
 
 [node name="RigidBodyCylinder" type="RigidBody" parent="DynamicShapes"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 0 )
-script = ExtResource( 2 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyCylinder"]
 shape = SubResource( 3 )

--- a/3d/physics_tests/utils/exception_cylinder.gd
+++ b/3d/physics_tests/utils/exception_cylinder.gd
@@ -1,8 +1,0 @@
-extends Node
-
-
-func _enter_tree():
-	if System.get_physics_engine() == System.PhysicsEngine.GODOT_PHYSICS:
-		Log.print_error("Cylinder shapes not supported, removing '%s'." % name)
-		get_parent().remove_child(self)
-		queue_free()


### PR DESCRIPTION
Fix custom collision shape drawing in physics tests:
CollisionShape debug draw has changed in 3.3 and now requires a body to be rendered, so the trick to display custom physics shapes in the physics tests had to be updated.

Cylinder support:
Now cylinders are supported in Godot Physics, so the exception to avoid spamming errors when cylinders are used can be removed.

Rigid body picking:
Added mouse-picking to Test Shapes in both 2D and 3D.
