### PR TITLE
Update contact tests in physics tests for 2D & 3D

### DIFF
--- a/2d/physics_tests/test.gd
+++ b/2d/physics_tests/test.gd
@@ -83,23 +83,6 @@ func create_rigidbody(shape, pickable = false, transform = Transform.IDENTITY):
 	return body
 
 
-func create_rigidbody_collision(collision, pickable = false, transform = Transform.IDENTITY):
-	var collision_copy = collision.duplicate()
-	collision_copy.transform = transform
-
-	if collision is CollisionShape2D:
-		collision_copy.shape = collision.shape.duplicate()
-
-	var body = RigidBody2D.new()
-	body.add_child(collision_copy)
-
-	if pickable:
-		var script = load("res://utils/rigidbody_pick.gd")
-		body.set_script(script)
-
-	return body
-
-
 func create_rigidbody_box(size, pickable = false, use_icon = false, transform = Transform.IDENTITY):
 	var shape = RectangleShape2D.new()
 	shape.extents = 0.5 * size

--- a/2d/physics_tests/tests.gd
+++ b/2d/physics_tests/tests.gd
@@ -50,6 +50,10 @@ var _tests = [
 		"id": "Performance Tests/Contacts",
 		"path": "res://tests/performance/test_perf_contacts.tscn",
 	},
+	{
+		"id" : "Performance Tests/Contact Islands",
+		"path" : "res://tests/performance/test_perf_contact_islands.tscn",
+	},
 ]
 
 

--- a/2d/physics_tests/tests/performance/test_perf_contact_islands.tscn
+++ b/2d/physics_tests/tests/performance/test_perf_contact_islands.tscn
@@ -6,69 +6,100 @@
 [ext_resource path="res://tests/test_options.tscn" type="PackedScene" id=4]
 
 [sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 10, 15 )
+extents = Vector2( 5, 7 )
 
 [sub_resource type="CircleShape2D" id=2]
-radius = 15.0
+radius = 5.0
 
 [sub_resource type="CapsuleShape2D" id=3]
-height = 15.0
+radius = 5.0
+height = 7.0
 
 [node name="Test" type="Node2D"]
 script = ExtResource( 2 )
 _enable_debug_collision = false
-spawns = [ NodePath("SpawnTarget1") ]
-spawn_count = 500
+spawns = [ NodePath("SpawnTarget1"), NodePath("SpawnTarget2"), NodePath("SpawnTarget3"), NodePath("SpawnTarget4"), NodePath("SpawnTarget5"), NodePath("SpawnTarget6"), NodePath("SpawnTarget7"), NodePath("SpawnTarget8"), NodePath("SpawnTarget9") ]
+spawn_count = 300
 spawn_randomize = Vector2( 10, 10 )
 
 [node name="Options" parent="." instance=ExtResource( 4 )]
 
 [node name="SpawnTarget1" type="Node2D" parent="."]
-position = Vector2( 512, 400 )
+position = Vector2( 145.646, 109.462 )
+
+[node name="SpawnTarget2" type="Node2D" parent="."]
+position = Vector2( 508.14, 109.113 )
+
+[node name="SpawnTarget3" type="Node2D" parent="."]
+position = Vector2( 873.995, 110.042 )
+
+[node name="SpawnTarget4" type="Node2D" parent="."]
+position = Vector2( 149.646, 301.462 )
+
+[node name="SpawnTarget5" type="Node2D" parent="."]
+position = Vector2( 512.14, 301.113 )
+
+[node name="SpawnTarget6" type="Node2D" parent="."]
+position = Vector2( 877.995, 302.042 )
+
+[node name="SpawnTarget7" type="Node2D" parent="."]
+position = Vector2( 165.646, 507.462 )
+
+[node name="SpawnTarget8" type="Node2D" parent="."]
+position = Vector2( 528.14, 507.113 )
+
+[node name="SpawnTarget9" type="Node2D" parent="."]
+position = Vector2( 893.995, 508.042 )
 
 [node name="StaticScene" parent="." instance=ExtResource( 1 )]
+visible = false
 position = Vector2( 0, 125.017 )
 
 [node name="DynamicShapes" type="Node2D" parent="."]
 
 [node name="RigidBodyRectangle" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 0, 1024 )
+gravity_scale = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodyRectangle"]
 shape = SubResource( 1 )
 
 [node name="RigidBodySphere" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 100, 1024 )
+gravity_scale = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodySphere"]
 shape = SubResource( 2 )
 
 [node name="RigidBodyCapsule" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 200, 1024 )
+gravity_scale = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodyCapsule"]
 shape = SubResource( 3 )
 
 [node name="RigidBodyConvexPolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 300, 1024 )
+gravity_scale = 0.0
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="DynamicShapes/RigidBodyConvexPolygon"]
-scale = Vector2( 0.25, 0.25 )
+scale = Vector2( 0.1, 0.1 )
 polygon = PoolVector2Array( 10.7, -54.5, 28.3596, -49.4067, 47.6282, -34.3806, 57.9717, -20.9447, 50.9869, 35.2694, 38.8, 47.5, 15.9852, 54.3613, -14.9507, 54.1845, -36.5, 48.1, -50.4828, 36.33, -58.0115, -20.515, -46.9473, -34.7342, -26.0876, -50.1138, -11.4152, -54.5332 )
 
 [node name="GodotIcon" type="Sprite" parent="DynamicShapes/RigidBodyConvexPolygon"]
 self_modulate = Color( 1, 1, 1, 0.392157 )
-scale = Vector2( 0.25, 0.25 )
+scale = Vector2( 0.1, 0.1 )
 texture = ExtResource( 3 )
 
 [node name="RigidBodyConcavePolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2( 400, 1024 )
+gravity_scale = 0.0
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="DynamicShapes/RigidBodyConcavePolygon"]
-scale = Vector2( 0.25, 0.25 )
+scale = Vector2( 0.1, 0.1 )
 polygon = PoolVector2Array( -5.93512, -43.2195, 6.44476, -42.9695, 11.127, -54.3941, 26.9528, -49.4309, 26.2037, -36.508, 37.5346, -28.1737, 47.6282, -34.3806, 58.0427, -20.9631, 51.113, -10.2876, 50.9869, 35.2694, 38.8, 47.5, 15.9852, 54.3613, -14.9507, 54.1845, -36.5, 48.1, -50.4828, 36.33, -51.3668, -9.98545, -57.8889, -20.5885, -46.9473, -34.7342, -37.4014, -28.547, -26.0876, -37.0323, -26.9862, -49.15, -11.4152, -54.5332 )
 
 [node name="GodotIcon" type="Sprite" parent="DynamicShapes/RigidBodyConcavePolygon"]
 self_modulate = Color( 1, 1, 1, 0.392157 )
-scale = Vector2( 0.25, 0.25 )
+scale = Vector2( 0.1, 0.1 )
 texture = ExtResource( 3 )

--- a/2d/physics_tests/tests/performance/test_perf_contacts.gd
+++ b/2d/physics_tests/tests/performance/test_perf_contacts.gd
@@ -8,8 +8,9 @@ const OPTION_TYPE_CAPSULE = "Shape type/Capsule"
 const OPTION_TYPE_CONVEX_POLYGON = "Shape type/Convex Polygon"
 const OPTION_TYPE_CONCAVE_POLYGON = "Shape type/Concave Polygon"
 
-export(Array) var spawns = Array()
+export(Array, NodePath) var spawns = Array()
 export(int) var spawn_count = 100
+export(Vector2) var spawn_randomize
 
 onready var options = $Options
 
@@ -152,24 +153,35 @@ func _start_all_types():
 
 func _spawn_objects(type_index):
 	var template_node = _object_templates[type_index]
+
+	Log.print_log("* Spawning: " + template_node.name)
+
 	for spawn in spawns:
 		var spawn_parent = get_node(spawn)
 
-		Log.print_log("* Spawning: " + template_node.name)
-
 		for _node_index in range(spawn_count):
 			# Create a new object and shape every time to avoid the overhead of connecting many bodies to the same shape.
-			var collision = template_node.get_child(0)
-			var body = create_rigidbody_collision(collision, false, collision.transform)
+			var collision = template_node.get_child(0).duplicate()
+			if collision is CollisionShape2D:
+				collision.shape = collision.shape.duplicate()
+			var body = template_node.duplicate()
+			body.transform = Transform.IDENTITY
+			if spawn_randomize != Vector2.ZERO:
+				body.position.x = randf() * spawn_randomize.x
+				body.position.y = randf() * spawn_randomize.y
+			var prev_collision = body.get_child(0)
+			body.remove_child(prev_collision)
+			prev_collision.queue_free()
+			body.add_child(collision)
 			body.set_sleeping(true)
 			spawn_parent.add_child(body)
 
 
 func _activate_objects():
+	Log.print_log("* Activating")
+
 	for spawn in spawns:
 		var spawn_parent = get_node(spawn)
-
-		Log.print_log("* Activating")
 
 		for node_index in range(spawn_parent.get_child_count()):
 			var node = spawn_parent.get_child(node_index) as RigidBody2D
@@ -177,14 +189,14 @@ func _activate_objects():
 
 
 func _despawn_objects():
+	Log.print_log("* Despawning")
+
 	for spawn in spawns:
 		var spawn_parent = get_node(spawn)
 
 		var object_count = spawn_parent.get_child_count()
 		if object_count == 0:
 			continue
-
-		Log.print_log("* Despawning")
 
 		# Remove objects in reversed order to avoid the overhead of changing children index in parent.
 		for object_index in range(object_count):

--- a/3d/physics_tests/tests.gd
+++ b/3d/physics_tests/tests.gd
@@ -43,8 +43,8 @@ var _tests = [
 		"path": "res://tests/performance/test_perf_contacts.tscn",
 	},
 	{
-		"id" : "Performance Tests/Contacts Extended",
-		"path" : "res://tests/performance/test_perf_contacts_extended.tscn",
+		"id" : "Performance Tests/Contact Islands",
+		"path" : "res://tests/performance/test_perf_contact_islands.tscn",
 	},
 ]
 

--- a/3d/physics_tests/tests/performance/test_perf_contact_islands.tscn
+++ b/3d/physics_tests/tests/performance/test_perf_contact_islands.tscn
@@ -6,15 +6,21 @@
 [ext_resource path="res://tests/static_scene.tscn" type="PackedScene" id=5]
 
 [sub_resource type="BoxShape" id=1]
+extents = Vector3( 0.5, 0.5, 0.5 )
 
 [sub_resource type="CapsuleShape" id=2]
+radius = 0.5
+height = 0.5
 
 [sub_resource type="CylinderShape" id=3]
+radius = 0.5
+height = 1.0
 
 [sub_resource type="ConvexPolygonShape" id=4]
 points = PoolVector3Array( -0.7, 0, -0.7, -0.3, 0, 0.8, 0.8, 0, -0.3, 0, -1, 0 )
 
 [sub_resource type="SphereShape" id=5]
+radius = 0.5
 
 [sub_resource type="PlaneShape" id=6]
 
@@ -22,7 +28,8 @@ points = PoolVector3Array( -0.7, 0, -0.7, -0.3, 0, 0.8, 0.8, 0, -0.3, 0, -1, 0 )
 script = ExtResource( 1 )
 _enable_debug_collision = false
 spawns = [ "SpawnTarget1", "SpawnTarget2", "SpawnTarget3", "SpawnTarget4", "SpawnTarget5", "SpawnTarget6", "SpawnTarget7", "SpawnTarget8", "SpawnTarget9", "SpawnTarget10", "SpawnTarget11", "SpawnTarget12", "SpawnTarget13", "SpawnTarget14", "SpawnTarget15", "SpawnTarget16" ]
-spawn_count = 50
+spawn_count = 200
+spawn_randomize = Vector3( 0.2, 0.2, 0.2 )
 
 [node name="Options" parent="." instance=ExtResource( 4 )]
 
@@ -98,6 +105,7 @@ shape = SubResource( 3 )
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 0, 0 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyConvex"]
+transform = Transform( 0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0, 0 )
 shape = SubResource( 4 )
 
 [node name="RigidBodySphere" type="RigidBody" parent="DynamicShapes"]

--- a/3d/physics_tests/tests/performance/test_perf_contacts.tscn
+++ b/3d/physics_tests/tests/performance/test_perf_contacts.tscn
@@ -23,6 +23,7 @@ script = ExtResource( 2 )
 _enable_debug_collision = false
 spawns = [ "SpawnTarget1" ]
 spawn_count = 500
+spawn_randomize = Vector3( 0.2, 0.2, 0.2 )
 
 [node name="Options" parent="." instance=ExtResource( 4 )]
 


### PR DESCRIPTION
- Create bodies by duplicating the ones from the scene to allow custom settings on them for testing purpose
- Rename 3D test with multiple groups of bodies "Contact Islands" instead of "Contacts Extended" for clarity
- Added "Contact Islands" test for 2D
- Fixed log spamming with "Contact Islands" tests due to printing log messages for each group of bodies
- Added parameter to randomize spawn positions in order to make contact separation more balanced (avoids artifacts like a huge column for circles in 2D test)
- Using smaller shapes and larger amount of objects by default to test more extreme case
