### PR TITLE
Fixed project settings to match tutorial

### DIFF
--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -24,6 +24,8 @@ config/icon="res://icon.png"
 
 window/size/width=480
 window/size/height=720
+window/stretch/mode="2d"
+window/stretch/aspect="keep"
 
 [input]
 


### PR DESCRIPTION
The "Dodge the Creeps" project settings don't match the settings in the tutorial. In [Project Settings](https://docs.godotengine.org/en/stable/getting_started/step_by_step/your_first_game.html#project-setup) you're instructed to navigate to

**Project** -> **Project Settings** -> **Display** -> **Window** -> **Stretch**

and set

**Mode:** "2d"
**Aspect:** "keep"

This wasn't done so it's possible to go outside the play area by resizing the game. I've changed the demo project to match the tutorial's instructions.