### PR TITLE
Have waypoints check if the camera is current

### DIFF
--- a/3d/physics_tests/utils/rigidbody_ground_check.gd
+++ b/3d/physics_tests/utils/rigidbody_ground_check.gd
@@ -44,4 +44,3 @@ func ground_check():
 		_is_on_floor = true
 	else:
 		_is_on_floor = false
-

--- a/3d/waypoints/waypoint.gd
+++ b/3d/waypoints/waypoint.gd
@@ -23,6 +23,9 @@ func _ready() -> void:
 
 
 func _process(_delta):
+	if not camera.current:
+		# If the camera we have isn't the current one, get the current camera.
+		camera = get_viewport().get_camera()
 	var parent_translation = parent.global_transform.origin
 	var camera_transform = camera.global_transform
 	var camera_translation = camera_transform.origin


### PR DESCRIPTION
If not, get the current camera. Implements and closes #605. This isn't really necessary, but it's a simple fix and it's a cheap check.