### PR TITLE
Replace built-in scripts and delete strange "e" scripts

### DIFF
--- a/loading/multiple_threads_loading/link_button.gd
+++ b/loading/multiple_threads_loading/link_button.gd
@@ -1,0 +1,5 @@
+extends LinkButton
+
+func _on_LinkButton_button_up():
+	# warning-ignore:return_value_discarded
+	OS.shell_open("http://docs.godotengine.org/en/3.2/tutorials/io/background_loading.html#using-multiple-threads")

--- a/loading/multiple_threads_loading/preload.tscn
+++ b/loading/multiple_threads_loading/preload.tscn
@@ -1,14 +1,7 @@
 [gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://preload.gd" type="Script" id=1]
-
-[sub_resource type="GDScript" id=1]
-script/source = "extends LinkButton
-
-func _on_LinkButton_button_up():
-	# warning-ignore:return_value_discarded
-	OS.shell_open(\"http://docs.godotengine.org/en/3.2/tutorials/io/background_loading.html#using-multiple-threads\")
-"
+[ext_resource path="res://link_button.gd" type="Script" id=2]
 
 [node name="Node" type="Node"]
 script = ExtResource( 1 )
@@ -63,7 +56,7 @@ margin_top = 80.0
 margin_right = 233.0
 margin_bottom = 94.0
 text = "http://docs.godotengine.org/en/3.2/tutorials/io/background_loading.html"
-script = SubResource( 1 )
+script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/networking/webrtc_minimal/link_button.gd
+++ b/networking/webrtc_minimal/link_button.gd
@@ -1,0 +1,4 @@
+extends LinkButton
+
+func _on_LinkButton_pressed():
+	OS.shell_open("https://github.com/godotengine/webrtc-native/releases")

--- a/networking/webrtc_minimal/main.tscn
+++ b/networking/webrtc_minimal/main.tscn
@@ -2,13 +2,7 @@
 
 [ext_resource path="res://minimal.tscn" type="PackedScene" id=1]
 [ext_resource path="res://main.gd" type="Script" id=2]
-
-[sub_resource type="GDScript" id=1]
-script/source = "extends LinkButton
-
-func _on_LinkButton_pressed():
-	OS.shell_open(\"https://github.com/godotengine/webrtc-native/releases\")
-"
+[ext_resource path="res://link_button.gd" type="Script" id=3]
 
 [node name="Main" type="Node"]
 script = ExtResource( 2 )
@@ -28,7 +22,7 @@ margin_top = 293.0
 margin_right = 785.0
 margin_bottom = 307.0
 text = "Make sure to download the GDNative WebRTC Plugin and place it in the project folder"
-script = SubResource( 1 )
+script = ExtResource( 3 )
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/viewport/2d_in_3d/2D_in_3D.tscn
+++ b/viewport/2d_in_3d/2D_in_3D.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://2D_in_3D.gd" type="Script" id=1]
 [ext_resource path="res://pong.gd" type="Script" id=2]
@@ -9,35 +9,19 @@
 
 [sub_resource type="PlaneMesh" id=1]
 
-[sub_resource type="GDScript" id=2]
-script/source = "tool
-extends Object
-func e():
-	return .7
-"
-
-[sub_resource type="SpatialMaterial" id=3]
+[sub_resource type="SpatialMaterial" id=2]
 roughness = 0.7
-script = SubResource( 2 )
 
-[sub_resource type="CubeMesh" id=4]
+[sub_resource type="CubeMesh" id=3]
 
-[sub_resource type="SpatialMaterial" id=5]
+[sub_resource type="SpatialMaterial" id=4]
 albedo_color = Color( 0.652344, 0.652344, 0.652344, 1 )
 roughness = 0.0
 
-[sub_resource type="GDScript" id=6]
-script/source = "tool
-extends Object
-func e():
-	return 0.1
-"
-
-[sub_resource type="CubeMesh" id=7]
+[sub_resource type="CubeMesh" id=5]
 size = Vector3( 1.1, 0.8, 0.1 )
-script = SubResource( 6 )
 
-[sub_resource type="SpatialMaterial" id=8]
+[sub_resource type="SpatialMaterial" id=6]
 
 [node name="2Din3D" type="Spatial"]
 script = ExtResource( 1 )
@@ -50,48 +34,48 @@ near = 0.1
 [node name="Floor" type="MeshInstance" parent="."]
 transform = Transform( 4, 0, 0, 0, 4, 0, 0, 0, 4, 0, -1, -2 )
 mesh = SubResource( 1 )
-material/0 = SubResource( 3 )
+material/0 = SubResource( 2 )
 
 [node name="Pillar1" type="Spatial" parent="."]
 transform = Transform( 0.6, 0, 0, 0, 0.6, 0, 0, 0, 0.6, -3, -0.2, -4 )
 
 [node name="PillarBottom" type="MeshInstance" parent="Pillar1"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0 )
-mesh = SubResource( 4 )
-material/0 = SubResource( 5 )
+mesh = SubResource( 3 )
+material/0 = SubResource( 4 )
 
 [node name="PillarTop" type="MeshInstance" parent="Pillar1"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5.5, 0 )
-mesh = SubResource( 4 )
-material/0 = SubResource( 5 )
+mesh = SubResource( 3 )
+material/0 = SubResource( 4 )
 
 [node name="PillarMiddle" type="MeshInstance" parent="Pillar1"]
 transform = Transform( 0.7, 0, 0, 0, 2, 0, 0, 0, 0.7, 0, 2.5, 0 )
-mesh = SubResource( 4 )
-material/0 = SubResource( 5 )
+mesh = SubResource( 3 )
+material/0 = SubResource( 4 )
 
 [node name="Pillar2" type="Spatial" parent="."]
 transform = Transform( 0.6, 0, 0, 0, 0.6, 0, 0, 0, 0.6, 3, -0.2, -4 )
 
 [node name="PillarBottom" type="MeshInstance" parent="Pillar2"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0 )
-mesh = SubResource( 4 )
-material/0 = SubResource( 5 )
+mesh = SubResource( 3 )
+material/0 = SubResource( 4 )
 
 [node name="PillarTop" type="MeshInstance" parent="Pillar2"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5.5, 0 )
-mesh = SubResource( 4 )
-material/0 = SubResource( 5 )
+mesh = SubResource( 3 )
+material/0 = SubResource( 4 )
 
 [node name="PillarMiddle" type="MeshInstance" parent="Pillar2"]
 transform = Transform( 0.7, 0, 0, 0, 2, 0, 0, 0, 0.7, 0, 2.5, 0 )
-mesh = SubResource( 4 )
-material/0 = SubResource( 5 )
+mesh = SubResource( 3 )
+material/0 = SubResource( 4 )
 
 [node name="PillarBack" type="MeshInstance" parent="."]
 transform = Transform( 4, 0, 0, 0, 4, 0, 0, 0, 4, 0, 1.2, -4.5 )
-mesh = SubResource( 7 )
-material/0 = SubResource( 5 )
+mesh = SubResource( 5 )
+material/0 = SubResource( 4 )
 
 [node name="DirectionalLight" type="DirectionalLight" parent="."]
 transform = Transform( 0.623013, -0.733525, 0.271654, 0.321394, 0.55667, 0.766044, -0.713134, -0.389948, 0.582563, 0, 10, 0 )
@@ -101,7 +85,7 @@ directional_shadow_normal_bias = 0.2
 
 [node name="ViewportQuad" type="MeshInstance" parent="."]
 transform = Transform( 2, 0, 0, 0, 0, -1.333, 0, 1, 0, 0, 1.2, -4.25 )
-material_override = SubResource( 8 )
+material_override = SubResource( 6 )
 mesh = SubResource( 1 )
 material/0 = null
 

--- a/viewport/3d_in_2d/robot_3d.tscn
+++ b/viewport/3d_in_2d/robot_3d.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://robot_3d.gd" type="Script" id=1]
 
@@ -44,20 +44,12 @@ surfaces/1 = {
 "vertex_count": 625
 }
 
-[sub_resource type="GDScript" id=4]
-script/source = "tool
-extends Object
-func e():
-	return .1
-"
-
-[sub_resource type="SpatialMaterial" id=5]
+[sub_resource type="SpatialMaterial" id=4]
 albedo_color = Color( 0.753906, 0.753906, 0.753906, 1 )
 metallic = 0.4
 roughness = 0.1
-script = SubResource( 4 )
 
-[sub_resource type="SpatialMaterial" id=6]
+[sub_resource type="SpatialMaterial" id=5]
 roughness = 0.0
 emission_enabled = true
 emission = Color( 0.203125, 0.551758, 1, 1 )
@@ -71,8 +63,8 @@ script = ExtResource( 1 )
 [node name="Model" type="MeshInstance" parent="."]
 transform = Transform( 0.3, 0, 0, 0, 0.3, 0, 0, 0, 0.3, 0, 0, 0 )
 mesh = SubResource( 3 )
-material/0 = SubResource( 5 )
-material/1 = SubResource( 6 )
+material/0 = SubResource( 4 )
+material/1 = SubResource( 5 )
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 2.75 )

--- a/viewport/gui_in_3d/default_env.tres
+++ b/viewport/gui_in_3d/default_env.tres
@@ -1,13 +1,6 @@
-[gd_resource type="Environment" load_steps=3 format=2]
+[gd_resource type="Environment" load_steps=2 format=2]
 
 [sub_resource type="ProceduralSky" id=1]
-
-[sub_resource type="GDScript" id=2]
-script/source = "tool
-extends Object
-func e():
-	return 0
-"
 
 [resource]
 background_mode = 2
@@ -16,4 +9,3 @@ ambient_light_color = Color( 1, 1, 1, 1 )
 ambient_light_energy = 0.28
 ambient_light_sky_contribution = 0.0
 ssao_blur = 1
-script = SubResource( 2 )


### PR DESCRIPTION
Keeping GDScript files in their own file makes things easier to work with, and should be preferred for the demos.

Also, this PR deletes the strange "func e()" methods. No idea where they came from, but they're useless and now they're gone.