### PR TITLE
Update impact, rigid groundcheck, moving platform

### DIFF
--- a/3d/physics_tests/tests/functional/test_moving_platform.gd
+++ b/3d/physics_tests/tests/functional/test_moving_platform.gd
@@ -10,6 +10,13 @@ const OPTION_FRICTION = "Physics options/Friction (Rigid only)"
 const OPTION_ROUGH = "Physics options/Rough (Rigid only)"
 const OPTION_PROCESS_PHYSICS = "Physics options/AnimationPlayer physics process mode"
 
+const SHAPE_CAPSULE = "Collision shapes/Capsule"
+const SHAPE_BOX = "Collision shapes/Box"
+const SHAPE_CILINDER = "Collision shapes/Cilinder"
+const SHAPE_SPHERE = "Collision shapes/Sphere"
+const SHAPE_CONVEX = "Collision shapes/Convex"
+const SHAPE_RAY = "Collision shapes/Ray"
+
 var _gravity = false
 var _slope = false
 var _snap = false
@@ -24,6 +31,9 @@ var _current_body_key = ""
 var _current_body = null
 var _body_type = ["KinematicBody", "RigidBody"]
 
+var _shapes = {}
+var _current_shape = ""
+
 
 func _ready():
 	var options = $Options
@@ -36,6 +46,13 @@ func _ready():
 		_body_scene[option_name] = get_packed_scene(body)
 		body.queue_free()
 
+	options.add_menu_item(SHAPE_CAPSULE)
+	options.add_menu_item(SHAPE_BOX)
+	options.add_menu_item(SHAPE_CILINDER)
+	options.add_menu_item(SHAPE_SPHERE)
+	options.add_menu_item(SHAPE_CONVEX)
+	options.add_menu_item(SHAPE_RAY)
+
 	options.add_menu_item(OPTION_GRAVITY, true, false)
 	options.add_menu_item(OPTION_SLOPE, true, false)
 	options.add_menu_item(OPTION_SNAP, true, false)
@@ -45,6 +62,14 @@ func _ready():
 
 	options.connect("option_selected", self, "_on_option_selected")
 	options.connect("option_changed", self, "_on_option_changed")
+
+	_shapes[SHAPE_CAPSULE] = "Capsule"
+	_shapes[SHAPE_BOX] = "Box"
+	_shapes[SHAPE_CILINDER] = "Cilinder"
+	_shapes[SHAPE_SPHERE] = "Sphere"
+	_shapes[SHAPE_CONVEX] = "Convex"
+	_shapes[SHAPE_RAY] = "Ray"
+	_current_shape = _shapes[SHAPE_CAPSULE]
 
 	spawn_body_index(_current_body_index)
 
@@ -60,6 +85,26 @@ func _input(event):
 func _on_option_selected(option):
 	if _body_scene.has(option):
 		spawn_body_key(option)
+	else:
+		match option:
+			SHAPE_CAPSULE:
+				_current_shape = _shapes[SHAPE_CAPSULE]
+				spawn_body_index(_current_body_index)
+			SHAPE_BOX:
+				_current_shape = _shapes[SHAPE_BOX]
+				spawn_body_index(_current_body_index)
+			SHAPE_CILINDER:
+				_current_shape = _shapes[SHAPE_CILINDER]
+				spawn_body_index(_current_body_index)
+			SHAPE_SPHERE:
+				_current_shape = _shapes[SHAPE_SPHERE]
+				spawn_body_index(_current_body_index)
+			SHAPE_CONVEX:
+				_current_shape = _shapes[SHAPE_CONVEX]
+				spawn_body_index(_current_body_index)
+			SHAPE_RAY:
+				_current_shape = _shapes[SHAPE_RAY]
+				spawn_body_index(_current_body_index)
 
 
 func _on_option_changed(option, checked):
@@ -91,9 +136,10 @@ func spawn_body_index(body_index):
 	_current_body_key = _key_list[body_index]
 	var body_parent = $Bodies
 	var body = _body_scene[_key_list[body_index]].instance()
-	body_parent.add_child(body)
 	_current_body = body
 	init_body()
+	body_parent.add_child(body)
+	start_test()
 
 
 func spawn_body_key(body_key):
@@ -103,9 +149,10 @@ func spawn_body_key(body_key):
 	_current_body_index = _key_list.find(body_key)
 	var body_parent = $Bodies
 	var body = _body_scene[body_key].instance()
-	body_parent.add_child(body)
 	_current_body = body
 	init_body()
+	body_parent.add_child(body)
+	start_test()
 
 
 func init_body():
@@ -116,7 +163,13 @@ func init_body():
 	elif _current_body is RigidBody:
 		_current_body.physics_material_override.rough = _rough
 		_current_body.physics_material_override.friction = 1.0 if _friction else 0.0
+	for shape in _current_body.get_children():
+		if shape is CollisionShape:
+			if shape.name != _current_shape:
+				shape.queue_free()
 
+
+func start_test():
 	var animation_player = $Platforms/KinematicPlatform/AnimationPlayer
 	animation_player.stop()
 	if _animation_physics:
@@ -125,7 +178,7 @@ func init_body():
 		animation_player.playback_process_mode = AnimationPlayer.ANIMATION_PROCESS_IDLE
 	animation_player.play("Move")
 
-	$LabelBodyType.text = "Body Type: " + _body_type[_current_body_index]
+	$LabelBodyType.text = "Body Type: " + _body_type[_current_body_index] + " \nCollision Shape: " + _current_shape
 
 
 func get_packed_scene(node):

--- a/3d/physics_tests/tests/functional/test_moving_platform.gd
+++ b/3d/physics_tests/tests/functional/test_moving_platform.gd
@@ -12,7 +12,7 @@ const OPTION_PROCESS_PHYSICS = "Physics options/AnimationPlayer physics process 
 
 const SHAPE_CAPSULE = "Collision shapes/Capsule"
 const SHAPE_BOX = "Collision shapes/Box"
-const SHAPE_CILINDER = "Collision shapes/Cilinder"
+const SHAPE_CYLINDER = "Collision shapes/Cylinder"
 const SHAPE_SPHERE = "Collision shapes/Sphere"
 const SHAPE_CONVEX = "Collision shapes/Convex"
 const SHAPE_RAY = "Collision shapes/Ray"
@@ -48,7 +48,7 @@ func _ready():
 
 	options.add_menu_item(SHAPE_CAPSULE)
 	options.add_menu_item(SHAPE_BOX)
-	options.add_menu_item(SHAPE_CILINDER)
+	options.add_menu_item(SHAPE_CYLINDER)
 	options.add_menu_item(SHAPE_SPHERE)
 	options.add_menu_item(SHAPE_CONVEX)
 	options.add_menu_item(SHAPE_RAY)
@@ -65,7 +65,7 @@ func _ready():
 
 	_shapes[SHAPE_CAPSULE] = "Capsule"
 	_shapes[SHAPE_BOX] = "Box"
-	_shapes[SHAPE_CILINDER] = "Cilinder"
+	_shapes[SHAPE_CYLINDER] = "Cylinder"
 	_shapes[SHAPE_SPHERE] = "Sphere"
 	_shapes[SHAPE_CONVEX] = "Convex"
 	_shapes[SHAPE_RAY] = "Ray"
@@ -93,8 +93,8 @@ func _on_option_selected(option):
 			SHAPE_BOX:
 				_current_shape = _shapes[SHAPE_BOX]
 				spawn_body_index(_current_body_index)
-			SHAPE_CILINDER:
-				_current_shape = _shapes[SHAPE_CILINDER]
+			SHAPE_CYLINDER:
+				_current_shape = _shapes[SHAPE_CYLINDER]
 				spawn_body_index(_current_body_index)
 			SHAPE_SPHERE:
 				_current_shape = _shapes[SHAPE_SPHERE]

--- a/3d/physics_tests/tests/functional/test_moving_platform.gd
+++ b/3d/physics_tests/tests/functional/test_moving_platform.gd
@@ -182,7 +182,6 @@ func start_test():
 
 
 func get_packed_scene(node):
-	node.owner = self
 	for child in node.get_children():
 		child.owner = node
 	var packed_scene = PackedScene.new()

--- a/3d/physics_tests/tests/functional/test_moving_platform.tscn
+++ b/3d/physics_tests/tests/functional/test_moving_platform.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://utils/camera_orbit.gd" type="Script" id=1]
 [ext_resource path="res://tests/functional/test_moving_platform.gd" type="Script" id=2]
@@ -8,13 +8,29 @@
 [sub_resource type="CapsuleShape" id=1]
 radius = 0.3
 
+[sub_resource type="BoxShape" id=5]
+extents = Vector3( 0.3, 0.8, 0.3 )
+
+[sub_resource type="CylinderShape" id=7]
+radius = 0.3
+height = 1.60005
+
+[sub_resource type="SphereShape" id=6]
+radius = 0.79945
+
+[sub_resource type="ConvexPolygonShape" id=9]
+points = PoolVector3Array( -0.7, 0, -0.7, -0.3, 0, 0.8, 0.8, 0, -0.3, 0, -0.8, 0 )
+
+[sub_resource type="RayShape" id=8]
+length = 0.8
+
 [sub_resource type="PhysicsMaterial" id=2]
 
 [sub_resource type="BoxShape" id=3]
 extents = Vector3( 2, 0.2, 1 )
 
 [sub_resource type="Animation" id=4]
-length = 4.0
+length = 9.0
 tracks/0/type = "bezier"
 tracks/0/path = NodePath(".:translation:x")
 tracks/0/interp = 1
@@ -22,8 +38,18 @@ tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"points": PoolRealArray( -7, -0.25, 0, 0.25, 0, -7, -0.25, 0, 0.245766, 0.531658, 6, -0.132614, -0.374802, 0.25, 0 ),
-"times": PoolRealArray( 0, 0.5, 4 )
+"points": PoolRealArray( -7, -0.25, 0, 0.25, 0, -7, -0.25, 0, 0.25, 0, 6, -0.25, 0, 0.25, 0 ),
+"times": PoolRealArray( 0, 3, 6.5 )
+}
+tracks/1/type = "bezier"
+tracks/1/path = NodePath(".:translation:y")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"points": PoolRealArray( -4.23538, -0.25, 0, 0.25, 0, -4.23538, -0.25, 0, 0.25, 0, 3, -0.25, 0, 0.25, 0, 3, -0.25, 0, 0.25, 0, -4.23538, -0.25, 0, 0.25, 0 ),
+"times": PoolRealArray( 0, 0.5, 3, 6.5, 9 )
 }
 
 [node name="Test" type="Spatial"]
@@ -40,36 +66,78 @@ __meta__ = {
 }
 
 [node name="Options" parent="." instance=ExtResource( 3 )]
+margin_top = 120.0
+margin_bottom = 140.0
 
 [node name="Bodies" type="Spatial" parent="."]
 
 [node name="KinematicBody" type="KinematicBody" parent="Bodies"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -1.95, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -4.18538, 0 )
 collision_layer = 2
 script = ExtResource( 4 )
 _stop_on_slopes = true
 _use_snap = true
 
-[node name="CollisionShape" type="CollisionShape" parent="Bodies/KinematicBody"]
+[node name="Capsule" type="CollisionShape" parent="Bodies/KinematicBody"]
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.8, 0 )
 shape = SubResource( 1 )
 
+[node name="Box" type="CollisionShape" parent="Bodies/KinematicBody"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
+shape = SubResource( 5 )
+
+[node name="Cilinder" type="CollisionShape" parent="Bodies/KinematicBody"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
+shape = SubResource( 7 )
+
+[node name="Sphere" type="CollisionShape" parent="Bodies/KinematicBody"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
+shape = SubResource( 6 )
+
+[node name="Convex" type="CollisionShape" parent="Bodies/KinematicBody"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
+shape = SubResource( 9 )
+
+[node name="Ray" type="CollisionShape" parent="Bodies/KinematicBody"]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.8, 0 )
+shape = SubResource( 8 )
+
 [node name="RigidBody" type="RigidBody" parent="Bodies"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -1.95, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -4.18538, 0 )
 collision_layer = 4
 physics_material_override = SubResource( 2 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
 
-[node name="CollisionShape" type="CollisionShape" parent="Bodies/RigidBody"]
+[node name="Capsule" type="CollisionShape" parent="Bodies/RigidBody"]
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.8, 0 )
 shape = SubResource( 1 )
+
+[node name="Box" type="CollisionShape" parent="Bodies/RigidBody"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
+shape = SubResource( 5 )
+
+[node name="Cilinder" type="CollisionShape" parent="Bodies/RigidBody"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
+shape = SubResource( 7 )
+
+[node name="Sphere" type="CollisionShape" parent="Bodies/RigidBody"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
+shape = SubResource( 6 )
+
+[node name="Convex" type="CollisionShape" parent="Bodies/RigidBody"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
+shape = SubResource( 9 )
+
+[node name="Ray" type="CollisionShape" parent="Bodies/RigidBody"]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.8, 0 )
+shape = SubResource( 8 )
 
 [node name="Platforms" type="Spatial" parent="."]
 
 [node name="KinematicPlatform" type="KinematicBody" parent="Platforms"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -2, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -4.23538, 0 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Platforms/KinematicPlatform"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.2, 0 )

--- a/3d/physics_tests/tests/functional/test_moving_platform.tscn
+++ b/3d/physics_tests/tests/functional/test_moving_platform.tscn
@@ -99,7 +99,7 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
 shape = SubResource( 5 )
 
 [node name="Ray" type="CollisionShape" parent="Bodies/KinematicBody"]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.8, 0 )
+transform = Transform( 1, 0, 0, 0, 0, -1, 0, 1, 0, 0, 0.8, 0 )
 shape = SubResource( 6 )
 
 [node name="RigidBody" type="RigidBody" parent="Bodies"]
@@ -131,13 +131,13 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
 shape = SubResource( 5 )
 
 [node name="Ray" type="CollisionShape" parent="Bodies/RigidBody"]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.8, 0 )
+transform = Transform( 1, 0, 0, 0, 0, -1, 0, 1, 0, 0, 0.8, 0 )
 shape = SubResource( 6 )
 
 [node name="Platforms" type="Spatial" parent="."]
 
 [node name="KinematicPlatform" type="KinematicBody" parent="Platforms"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -4.23538, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -4.25, 0 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Platforms/KinematicPlatform"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.2, 0 )

--- a/3d/physics_tests/tests/functional/test_moving_platform.tscn
+++ b/3d/physics_tests/tests/functional/test_moving_platform.tscn
@@ -8,28 +8,28 @@
 [sub_resource type="CapsuleShape" id=1]
 radius = 0.3
 
-[sub_resource type="BoxShape" id=5]
+[sub_resource type="BoxShape" id=2]
 extents = Vector3( 0.3, 0.8, 0.3 )
 
-[sub_resource type="CylinderShape" id=7]
+[sub_resource type="CylinderShape" id=3]
 radius = 0.3
 height = 1.60005
 
-[sub_resource type="SphereShape" id=6]
+[sub_resource type="SphereShape" id=4]
 radius = 0.79945
 
-[sub_resource type="ConvexPolygonShape" id=9]
+[sub_resource type="ConvexPolygonShape" id=5]
 points = PoolVector3Array( -0.7, 0, -0.7, -0.3, 0, 0.8, 0.8, 0, -0.3, 0, -0.8, 0 )
 
-[sub_resource type="RayShape" id=8]
+[sub_resource type="RayShape" id=6]
 length = 0.8
 
-[sub_resource type="PhysicsMaterial" id=2]
+[sub_resource type="PhysicsMaterial" id=7]
 
-[sub_resource type="BoxShape" id=3]
+[sub_resource type="BoxShape" id=8]
 extents = Vector3( 2, 0.2, 1 )
 
-[sub_resource type="Animation" id=4]
+[sub_resource type="Animation" id=9]
 length = 9.0
 tracks/0/type = "bezier"
 tracks/0/path = NodePath(".:translation:x")
@@ -84,28 +84,28 @@ shape = SubResource( 1 )
 
 [node name="Box" type="CollisionShape" parent="Bodies/KinematicBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
-shape = SubResource( 5 )
+shape = SubResource( 2 )
 
-[node name="Cilinder" type="CollisionShape" parent="Bodies/KinematicBody"]
+[node name="Cylinder" type="CollisionShape" parent="Bodies/KinematicBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
-shape = SubResource( 7 )
+shape = SubResource( 3 )
 
 [node name="Sphere" type="CollisionShape" parent="Bodies/KinematicBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
-shape = SubResource( 6 )
+shape = SubResource( 4 )
 
 [node name="Convex" type="CollisionShape" parent="Bodies/KinematicBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
-shape = SubResource( 9 )
+shape = SubResource( 5 )
 
 [node name="Ray" type="CollisionShape" parent="Bodies/KinematicBody"]
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.8, 0 )
-shape = SubResource( 8 )
+shape = SubResource( 6 )
 
 [node name="RigidBody" type="RigidBody" parent="Bodies"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -4.18538, 0 )
 collision_layer = 4
-physics_material_override = SubResource( 2 )
+physics_material_override = SubResource( 7 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -116,23 +116,23 @@ shape = SubResource( 1 )
 
 [node name="Box" type="CollisionShape" parent="Bodies/RigidBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
-shape = SubResource( 5 )
+shape = SubResource( 2 )
 
-[node name="Cilinder" type="CollisionShape" parent="Bodies/RigidBody"]
+[node name="Cylinder" type="CollisionShape" parent="Bodies/RigidBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
-shape = SubResource( 7 )
+shape = SubResource( 3 )
 
 [node name="Sphere" type="CollisionShape" parent="Bodies/RigidBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
-shape = SubResource( 6 )
+shape = SubResource( 4 )
 
 [node name="Convex" type="CollisionShape" parent="Bodies/RigidBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.8, 0 )
-shape = SubResource( 9 )
+shape = SubResource( 5 )
 
 [node name="Ray" type="CollisionShape" parent="Bodies/RigidBody"]
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.8, 0 )
-shape = SubResource( 8 )
+shape = SubResource( 6 )
 
 [node name="Platforms" type="Spatial" parent="."]
 
@@ -141,10 +141,10 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -7, -4.23538, 0 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Platforms/KinematicPlatform"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.2, 0 )
-shape = SubResource( 3 )
+shape = SubResource( 8 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Platforms/KinematicPlatform"]
-anims/Move = SubResource( 4 )
+anims/Move = SubResource( 9 )
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10 )

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.gd
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.gd
@@ -69,7 +69,6 @@ func restart_scene():
 
 
 func get_packed_scene(node):
-	node.owner = self
 	for child in node.get_children():
 		child.owner = node
 		for child1 in child.get_children():

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.gd
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.gd
@@ -61,7 +61,7 @@ func restart_scene():
 	_current_bodies = dynamic_bodies
 	add_child(dynamic_bodies)
 
-	var floor_inst = _floor_shapes[_current_floor_name+_floor_size].instance()
+	var floor_inst = _floor_shapes[_current_floor_name + _floor_size].instance()
 	_current_floor = floor_inst
 	$Floors.add_child(floor_inst)
 
@@ -78,5 +78,4 @@ func get_packed_scene(node):
 	var packed_scene = PackedScene.new()
 	packed_scene.pack(node)
 	return packed_scene
-
 

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.gd
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.gd
@@ -20,12 +20,12 @@ var _current_floor
 func _ready():
 	var options = $Options
 	_dynamic_shapes_scene = get_packed_scene($DynamicShapes/Bodies)
-	_floor_shapes[SHAPE_CONVEX+"Small"] = get_packed_scene($"Floors/ConvexSmall")
-	_floor_shapes[SHAPE_CONVEX+"Big"] = get_packed_scene($"Floors/ConvexBig")
-	_floor_shapes[SHAPE_CONCAVE+"Big"] = get_packed_scene($"Floors/ConcaveBig")
-	_floor_shapes[SHAPE_CONCAVE+"Small"] = get_packed_scene($"Floors/ConcaveSmall")
-	_floor_shapes[SHAPE_BOX+"Big"] = get_packed_scene($"Floors/BoxBig")
-	_floor_shapes[SHAPE_BOX+"Small"] = get_packed_scene($"Floors/BoxSmall")
+	_floor_shapes[SHAPE_CONVEX + "Small"] = get_packed_scene($"Floors/ConvexSmall")
+	_floor_shapes[SHAPE_CONVEX + "Big"] = get_packed_scene($"Floors/ConvexBig")
+	_floor_shapes[SHAPE_CONCAVE + "Big"] = get_packed_scene($"Floors/ConcaveBig")
+	_floor_shapes[SHAPE_CONCAVE + "Small"] = get_packed_scene($"Floors/ConcaveSmall")
+	_floor_shapes[SHAPE_BOX + "Big"] = get_packed_scene($"Floors/BoxBig")
+	_floor_shapes[SHAPE_BOX + "Small"] = get_packed_scene($"Floors/BoxSmall")
 	$DynamicShapes/Bodies.queue_free()
 	for floorNode in $Floors.get_children():
 		floorNode.queue_free()

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.gd
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.gd
@@ -1,0 +1,83 @@
+extends Test
+
+
+const OPTION_BIG = "Floor options/Big"
+const OPTION_SMALL = "Floor options/Small"
+
+const SHAPE_CONCAVE = "Collision shapes/Concave"
+const SHAPE_CONVEX = "Collision shapes/Convex"
+const SHAPE_BOX = "Collision shapes/Box"
+
+var _dynamic_shapes_scene
+var _floor_shapes = {}
+var _floor_size = "Small"
+
+var _current_floor_name = SHAPE_CONCAVE
+var _current_bodies
+var _current_floor
+
+
+func _ready():
+	var options = $Options
+	_dynamic_shapes_scene = get_packed_scene($DynamicShapes/Bodies)
+	_floor_shapes[SHAPE_CONVEX+"Small"] = get_packed_scene($"Floors/ConvexSmall")
+	_floor_shapes[SHAPE_CONVEX+"Big"] = get_packed_scene($"Floors/ConvexBig")
+	_floor_shapes[SHAPE_CONCAVE+"Big"] = get_packed_scene($"Floors/ConcaveBig")
+	_floor_shapes[SHAPE_CONCAVE+"Small"] = get_packed_scene($"Floors/ConcaveSmall")
+	_floor_shapes[SHAPE_BOX+"Big"] = get_packed_scene($"Floors/BoxBig")
+	_floor_shapes[SHAPE_BOX+"Small"] = get_packed_scene($"Floors/BoxSmall")
+	$DynamicShapes/Bodies.queue_free()
+	for floorNode in $Floors.get_children():
+		floorNode.queue_free()
+
+	options.add_menu_item(OPTION_SMALL)
+	options.add_menu_item(OPTION_BIG)
+	options.add_menu_item(SHAPE_CONCAVE)
+	options.add_menu_item(SHAPE_CONVEX)
+	options.add_menu_item(SHAPE_BOX)
+
+	options.connect("option_selected", self, "_on_option_selected")
+	restart_scene()
+
+
+func _on_option_selected(option):
+	match option:
+		OPTION_BIG:
+			_floor_size = "Big"
+		OPTION_SMALL:
+			_floor_size = "Small"
+		_:
+			_current_floor_name = option
+	restart_scene()
+
+
+func restart_scene():
+	if _current_bodies:
+		_current_bodies.queue_free()
+	if _current_floor:
+		_current_floor.queue_free()
+
+	var dynamic_bodies = _dynamic_shapes_scene.instance()
+	_current_bodies = dynamic_bodies
+	add_child(dynamic_bodies)
+
+	var floor_inst = _floor_shapes[_current_floor_name+_floor_size].instance()
+	_current_floor = floor_inst
+	$Floors.add_child(floor_inst)
+
+	$LabelBodyType.text = "Floor Type: " + _current_floor_name.rsplit("/", true, 1)[1] + "\nSize: " + _floor_size
+
+
+func get_packed_scene(node):
+	node.owner = self
+	for child in node.get_children():
+		child.owner = node
+		for child1 in child.get_children():
+			child1.owner = node
+			for child2 in child1.get_children():
+				child2.owner = node
+	var packed_scene = PackedScene.new()
+	packed_scene.pack(node)
+	return packed_scene
+
+

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
@@ -204,7 +204,7 @@ axis_lock_angular_z = true
 script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/Bodies/RigidBodyRay"]
-transform = Transform( 0.8, 0, 0, 0, -3.49691e-08, -0.8, 0, 0.8, -3.49691e-08, 0, 0, 0 )
+transform = Transform( 0.8, 0, 0, 0, 0, -0.8, 0, 0.8, 0, 0, 0, 0 )
 shape = SubResource( 21 )
 
 [node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/Bodies/RigidBodyRay/CollisionShape"]
@@ -212,7 +212,6 @@ mesh = SubResource( 22 )
 material/0 = SubResource( 20 )
 
 [node name="Floors" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1 )
 
 [node name="ConvexSmall" type="Spatial" parent="Floors"]
 

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
@@ -72,19 +72,19 @@ height = 1.0
 [sub_resource type="PlaneMesh" id=23]
 size = Vector2( 50, 20 )
 
+[sub_resource type="ConvexPolygonShape" id=24]
+points = PoolVector3Array( 25, 0, 10, -25, 0, 10, 25, 0, -10, -25, 0, -10 )
+
 [sub_resource type="ConvexPolygonShape" id=25]
 points = PoolVector3Array( 25, 0, 10, -25, 0, 10, 25, 0, -10, -25, 0, -10 )
 
 [sub_resource type="ConvexPolygonShape" id=26]
-points = PoolVector3Array( 25, 0, 10, -25, 0, 10, 25, 0, -10, -25, 0, -10 )
-
-[sub_resource type="ConvexPolygonShape" id=31]
 points = PoolVector3Array( 50, 0, 50, -50, 0, 50, 50, 0, -50, -50, 0, -50 )
 
-[sub_resource type="ConcavePolygonShape" id=24]
+[sub_resource type="ConcavePolygonShape" id=27]
 data = PoolVector3Array( -1, 0, 1, 1, 0, -1, 1, 0, 1, -1, 0, 1, -1, 0, -1, 1, 0, -1 )
 
-[sub_resource type="ConcavePolygonShape" id=32]
+[sub_resource type="ConcavePolygonShape" id=28]
 data = PoolVector3Array( 50, 0, 50, -50, 0, 50, 50, 0, -50, -50, 0, 50, -50, 0, -50, 50, 0, -50 )
 
 [sub_resource type="BoxShape" id=29]
@@ -227,7 +227,7 @@ mesh = SubResource( 23 )
 material/0 = null
 
 [node name="CollisionShape" type="CollisionShape" parent="Floors/ConvexSmall/ConvexFloor"]
-shape = SubResource( 25 )
+shape = SubResource( 24 )
 
 [node name="ConvexFloor2" type="StaticBody" parent="Floors/ConvexSmall"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10 )
@@ -240,8 +240,7 @@ mesh = SubResource( 23 )
 material/0 = null
 
 [node name="CollisionShape" type="CollisionShape" parent="Floors/ConvexSmall/ConvexFloor2"]
-visible = false
-shape = SubResource( 26 )
+shape = SubResource( 25 )
 
 [node name="ConvexBig" type="Spatial" parent="Floors"]
 
@@ -255,7 +254,7 @@ mesh = SubResource( 23 )
 material/0 = null
 
 [node name="CollisionShape" type="CollisionShape" parent="Floors/ConvexBig/ConvexFloor"]
-shape = SubResource( 31 )
+shape = SubResource( 26 )
 
 [node name="ConcaveSmall" type="Spatial" parent="Floors"]
 
@@ -271,7 +270,7 @@ material/0 = null
 
 [node name="CollisionShape" type="CollisionShape" parent="Floors/ConcaveSmall/ConcaveFloor"]
 transform = Transform( 25, 0, 0, 0, 1, 0, 0, 0, 10, 0, 0, 0 )
-shape = SubResource( 24 )
+shape = SubResource( 27 )
 
 [node name="ConcaveFloor2" type="StaticBody" parent="Floors/ConcaveSmall"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10 )
@@ -285,7 +284,7 @@ material/0 = null
 
 [node name="CollisionShape" type="CollisionShape" parent="Floors/ConcaveSmall/ConcaveFloor2"]
 transform = Transform( 25, 0, 0, 0, 1, 0, 0, 0, 10, 0, 0, 0 )
-shape = SubResource( 24 )
+shape = SubResource( 27 )
 
 [node name="ConcaveBig" type="Spatial" parent="Floors"]
 
@@ -299,7 +298,7 @@ mesh = SubResource( 23 )
 material/0 = null
 
 [node name="CollisionShape" type="CollisionShape" parent="Floors/ConcaveBig/ConcaveFloor"]
-shape = SubResource( 32 )
+shape = SubResource( 28 )
 
 [node name="BoxSmall" type="Spatial" parent="Floors"]
 
@@ -348,6 +347,7 @@ shape = SubResource( 30 )
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.604, 22.124 )
+far = 1000.0
 script = ExtResource( 4 )
 
 [node name="OmniLight" type="OmniLight" parent="Camera"]

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=29 format=2]
+[gd_scene load_steps=35 format=2]
 
 [ext_resource path="res://utils/rigidbody_ground_check.gd" type="Script" id=1]
-[ext_resource path="res://test.gd" type="Script" id=2]
+[ext_resource path="res://tests/test_options.tscn" type="PackedScene" id=2]
+[ext_resource path="res://tests/functional/test_rigidbody_ground_check.gd" type="Script" id=3]
 [ext_resource path="res://utils/camera_orbit.gd" type="Script" id=4]
 
 [sub_resource type="PhysicsMaterial" id=1]
@@ -71,19 +72,51 @@ height = 1.0
 [sub_resource type="PlaneMesh" id=23]
 size = Vector2( 50, 20 )
 
+[sub_resource type="ConvexPolygonShape" id=25]
+points = PoolVector3Array( 25, 0, 10, -25, 0, 10, 25, 0, -10, -25, 0, -10 )
+
+[sub_resource type="ConvexPolygonShape" id=26]
+points = PoolVector3Array( 25, 0, 10, -25, 0, 10, 25, 0, -10, -25, 0, -10 )
+
+[sub_resource type="ConvexPolygonShape" id=31]
+points = PoolVector3Array( 50, 0, 50, -50, 0, 50, 50, 0, -50, -50, 0, -50 )
+
 [sub_resource type="ConcavePolygonShape" id=24]
 data = PoolVector3Array( -1, 0, 1, 1, 0, -1, 1, 0, 1, -1, 0, 1, -1, 0, -1, 1, 0, -1 )
 
-[sub_resource type="ConvexPolygonShape" id=25]
-points = PoolVector3Array( -25, 0.25, 10, 25, 0.25, -10, 25, 0.25, 10, -25, 0.25, -10, -25, -0.25, 10, 25, -0.25, -10, 25, -0.25, 10, -25, -0.25, -10, 25, 0.25, 10, -25, 0.25, -10, 25, 0.25, -10, -25, 0.25, 10, 25, -0.25, 10, -25, -0.25, -10, 25, -0.25, -10, -25, -0.25, 10, 25, 0.25, 10, -25, -0.25, 10, -25, 0.25, 10, 25, -0.25, 10, 25, 0.25, -10, -25, -0.25, -10, -25, 0.25, -10, 25, -0.25, -10 )
+[sub_resource type="ConcavePolygonShape" id=32]
+data = PoolVector3Array( 50, 0, 50, -50, 0, 50, 50, 0, -50, -50, 0, 50, -50, 0, -50, 50, 0, -50 )
+
+[sub_resource type="BoxShape" id=29]
+extents = Vector3( 50, 1, 20 )
+
+[sub_resource type="BoxShape" id=30]
+extents = Vector3( 100, 1, 100 )
 
 [node name="Test" type="Spatial"]
-script = ExtResource( 2 )
+script = ExtResource( 3 )
+
+[node name="LabelBodyType" type="Label" parent="."]
+margin_left = 14.0
+margin_top = 78.0
+margin_right = 171.0
+margin_bottom = 92.0
+text = "Floor Type: "
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Options" parent="." instance=ExtResource( 2 )]
+margin_top = 120.0
+margin_bottom = 140.0
+focus_mode = 2
 
 [node name="DynamicShapes" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 9.35591, 0 )
 
-[node name="RigidBodyBox" type="RigidBody" parent="DynamicShapes"]
+[node name="Bodies" type="Spatial" parent="DynamicShapes"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5.2912, 0 )
+
+[node name="RigidBodyBox" type="RigidBody" parent="DynamicShapes/Bodies"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, 0 )
 physics_material_override = SubResource( 1 )
 axis_lock_angular_x = true
@@ -91,15 +124,15 @@ axis_lock_angular_y = true
 axis_lock_angular_z = true
 script = ExtResource( 1 )
 
-[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyBox"]
+[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/Bodies/RigidBodyBox"]
 transform = Transform( 0.6, 0, 0, 0, 1, 0, 0, 0, 0.6, 0, 0, 0 )
 shape = SubResource( 2 )
 
-[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/RigidBodyBox/CollisionShape"]
+[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/Bodies/RigidBodyBox/CollisionShape"]
 mesh = SubResource( 3 )
 material/0 = SubResource( 4 )
 
-[node name="RigidBodyCapsule" type="RigidBody" parent="DynamicShapes"]
+[node name="RigidBodyCapsule" type="RigidBody" parent="DynamicShapes/Bodies"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 0, 0 )
 physics_material_override = SubResource( 5 )
 axis_lock_angular_x = true
@@ -107,30 +140,30 @@ axis_lock_angular_y = true
 axis_lock_angular_z = true
 script = ExtResource( 1 )
 
-[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyCapsule"]
+[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/Bodies/RigidBodyCapsule"]
 transform = Transform( 0.8, 0, 0, 0, -3.49691e-08, -0.8, 0, 0.8, -3.49691e-08, 0, 0, 0 )
 shape = SubResource( 6 )
 
-[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/RigidBodyCapsule/CollisionShape"]
+[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/Bodies/RigidBodyCapsule/CollisionShape"]
 mesh = SubResource( 7 )
 material/0 = SubResource( 8 )
 
-[node name="RigidBodyCylinder" type="RigidBody" parent="DynamicShapes"]
+[node name="RigidBodyCylinder" type="RigidBody" parent="DynamicShapes/Bodies"]
 physics_material_override = SubResource( 9 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
 script = ExtResource( 1 )
 
-[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyCylinder"]
+[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/Bodies/RigidBodyCylinder"]
 transform = Transform( 0.8, 0, 0, 0, 1, 0, 0, 0, 0.8, 0, 0, 0 )
 shape = SubResource( 10 )
 
-[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/RigidBodyCylinder/CollisionShape"]
+[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/Bodies/RigidBodyCylinder/CollisionShape"]
 mesh = SubResource( 11 )
 material/0 = SubResource( 12 )
 
-[node name="RigidBodyConvex" type="RigidBody" parent="DynamicShapes"]
+[node name="RigidBodyConvex" type="RigidBody" parent="DynamicShapes/Bodies"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0.974548, 0 )
 physics_material_override = SubResource( 13 )
 axis_lock_angular_x = true
@@ -138,15 +171,15 @@ axis_lock_angular_y = true
 axis_lock_angular_z = true
 script = ExtResource( 1 )
 
-[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyConvex"]
+[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/Bodies/RigidBodyConvex"]
 transform = Transform( 1.5, 0, 0, 0, 2, 0, 0, 0, 1.5, 0, 0, 0 )
 shape = SubResource( 14 )
 
-[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/RigidBodyConvex/CollisionShape"]
+[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/Bodies/RigidBodyConvex/CollisionShape"]
 mesh = SubResource( 15 )
 material/0 = SubResource( 16 )
 
-[node name="RigidBodySphere" type="RigidBody" parent="DynamicShapes"]
+[node name="RigidBodySphere" type="RigidBody" parent="DynamicShapes/Bodies"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 0, 0 )
 physics_material_override = SubResource( 17 )
 axis_lock_angular_x = true
@@ -154,15 +187,15 @@ axis_lock_angular_y = true
 axis_lock_angular_z = true
 script = ExtResource( 1 )
 
-[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodySphere"]
+[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/Bodies/RigidBodySphere"]
 transform = Transform( 0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0, 0 )
 shape = SubResource( 18 )
 
-[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/RigidBodySphere/CollisionShape"]
+[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/Bodies/RigidBodySphere/CollisionShape"]
 mesh = SubResource( 19 )
 material/0 = SubResource( 20 )
 
-[node name="RigidBodyRay" type="RigidBody" parent="DynamicShapes"]
+[node name="RigidBodyRay" type="RigidBody" parent="DynamicShapes/Bodies"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 8.42391, 0, 0 )
 physics_material_override = SubResource( 17 )
 axis_lock_angular_x = true
@@ -170,44 +203,148 @@ axis_lock_angular_y = true
 axis_lock_angular_z = true
 script = ExtResource( 1 )
 
-[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyRay"]
+[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/Bodies/RigidBodyRay"]
 transform = Transform( 0.8, 0, 0, 0, -3.49691e-08, -0.8, 0, 0.8, -3.49691e-08, 0, 0, 0 )
 shape = SubResource( 21 )
 
-[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/RigidBodyRay/CollisionShape"]
+[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/Bodies/RigidBodyRay/CollisionShape"]
 mesh = SubResource( 22 )
 material/0 = SubResource( 20 )
 
 [node name="Floors" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4.85544 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1 )
 
-[node name="ConcaveFloor" type="StaticBody" parent="Floors"]
+[node name="ConvexSmall" type="Spatial" parent="Floors"]
+
+[node name="ConvexFloor" type="StaticBody" parent="Floors/ConvexSmall"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10 )
 collision_layer = 2
 collision_mask = 3
 
-[node name="MeshInstance" type="MeshInstance" parent="Floors/ConcaveFloor"]
+[node name="MeshInstance" type="MeshInstance" parent="Floors/ConvexSmall/ConvexFloor"]
 visible = false
 mesh = SubResource( 23 )
 material/0 = null
 
-[node name="CollisionShape" type="CollisionShape" parent="Floors/ConcaveFloor"]
-transform = Transform( 25, 0, 0, 0, 1, 0, 0, 0, 10, 0, 0, 0 )
-shape = SubResource( 24 )
+[node name="CollisionShape" type="CollisionShape" parent="Floors/ConvexSmall/ConvexFloor"]
+shape = SubResource( 25 )
 
-[node name="ConvexFloor" type="StaticBody" parent="Floors"]
+[node name="ConvexFloor2" type="StaticBody" parent="Floors/ConvexSmall"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10 )
 collision_layer = 2
 collision_mask = 3
 
-[node name="MeshInstance" type="MeshInstance" parent="Floors/ConvexFloor"]
+[node name="MeshInstance" type="MeshInstance" parent="Floors/ConvexSmall/ConvexFloor2"]
 visible = false
 mesh = SubResource( 23 )
 material/0 = null
 
-[node name="BoxShape" type="CollisionShape" parent="Floors/ConvexFloor"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.25, 0 )
-shape = SubResource( 25 )
+[node name="CollisionShape" type="CollisionShape" parent="Floors/ConvexSmall/ConvexFloor2"]
+visible = false
+shape = SubResource( 26 )
+
+[node name="ConvexBig" type="Spatial" parent="Floors"]
+
+[node name="ConvexFloor" type="StaticBody" parent="Floors/ConvexBig"]
+collision_layer = 2
+collision_mask = 3
+
+[node name="MeshInstance" type="MeshInstance" parent="Floors/ConvexBig/ConvexFloor"]
+visible = false
+mesh = SubResource( 23 )
+material/0 = null
+
+[node name="CollisionShape" type="CollisionShape" parent="Floors/ConvexBig/ConvexFloor"]
+shape = SubResource( 31 )
+
+[node name="ConcaveSmall" type="Spatial" parent="Floors"]
+
+[node name="ConcaveFloor" type="StaticBody" parent="Floors/ConcaveSmall"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10 )
+collision_layer = 2
+collision_mask = 3
+
+[node name="MeshInstance" type="MeshInstance" parent="Floors/ConcaveSmall/ConcaveFloor"]
+visible = false
+mesh = SubResource( 23 )
+material/0 = null
+
+[node name="CollisionShape" type="CollisionShape" parent="Floors/ConcaveSmall/ConcaveFloor"]
+transform = Transform( 25, 0, 0, 0, 1, 0, 0, 0, 10, 0, 0, 0 )
+shape = SubResource( 24 )
+
+[node name="ConcaveFloor2" type="StaticBody" parent="Floors/ConcaveSmall"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10 )
+collision_layer = 2
+collision_mask = 3
+
+[node name="MeshInstance" type="MeshInstance" parent="Floors/ConcaveSmall/ConcaveFloor2"]
+visible = false
+mesh = SubResource( 23 )
+material/0 = null
+
+[node name="CollisionShape" type="CollisionShape" parent="Floors/ConcaveSmall/ConcaveFloor2"]
+transform = Transform( 25, 0, 0, 0, 1, 0, 0, 0, 10, 0, 0, 0 )
+shape = SubResource( 24 )
+
+[node name="ConcaveBig" type="Spatial" parent="Floors"]
+
+[node name="ConcaveFloor" type="StaticBody" parent="Floors/ConcaveBig"]
+collision_layer = 2
+collision_mask = 3
+
+[node name="MeshInstance" type="MeshInstance" parent="Floors/ConcaveBig/ConcaveFloor"]
+visible = false
+mesh = SubResource( 23 )
+material/0 = null
+
+[node name="CollisionShape" type="CollisionShape" parent="Floors/ConcaveBig/ConcaveFloor"]
+shape = SubResource( 32 )
+
+[node name="BoxSmall" type="Spatial" parent="Floors"]
+
+[node name="BoxFloor" type="StaticBody" parent="Floors/BoxSmall"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10 )
+collision_layer = 2
+collision_mask = 3
+
+[node name="MeshInstance" type="MeshInstance" parent="Floors/BoxSmall/BoxFloor"]
+visible = false
+mesh = SubResource( 23 )
+material/0 = null
+
+[node name="CollisionShape" type="CollisionShape" parent="Floors/BoxSmall/BoxFloor"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
+shape = SubResource( 29 )
+
+[node name="BoxFloor2" type="StaticBody" parent="Floors/BoxSmall"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10 )
+collision_layer = 2
+collision_mask = 3
+
+[node name="MeshInstance" type="MeshInstance" parent="Floors/BoxSmall/BoxFloor2"]
+visible = false
+mesh = SubResource( 23 )
+material/0 = null
+
+[node name="CollisionShape" type="CollisionShape" parent="Floors/BoxSmall/BoxFloor2"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
+shape = SubResource( 29 )
+
+[node name="BoxBig" type="Spatial" parent="Floors"]
+
+[node name="BoxFloor" type="StaticBody" parent="Floors/BoxBig"]
+collision_layer = 2
+collision_mask = 3
+
+[node name="MeshInstance" type="MeshInstance" parent="Floors/BoxBig/BoxFloor"]
+visible = false
+mesh = SubResource( 23 )
+material/0 = null
+
+[node name="CollisionShape" type="CollisionShape" parent="Floors/BoxBig/BoxFloor"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
+shape = SubResource( 30 )
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.604, 22.124 )

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=25 format=2]
+[gd_scene load_steps=29 format=2]
 
 [ext_resource path="res://utils/rigidbody_ground_check.gd" type="Script" id=1]
 [ext_resource path="res://test.gd" type="Script" id=2]
-[ext_resource path="res://tests/static_scene_plane.tscn" type="PackedScene" id=3]
 [ext_resource path="res://utils/camera_orbit.gd" type="Script" id=4]
 
 [sub_resource type="PhysicsMaterial" id=1]
@@ -61,6 +60,22 @@ friction = 0.0
 [sub_resource type="SphereMesh" id=19]
 
 [sub_resource type="SpatialMaterial" id=20]
+
+[sub_resource type="RayShape" id=21]
+length = 1.5
+
+[sub_resource type="SphereMesh" id=22]
+radius = 0.5
+height = 1.0
+
+[sub_resource type="PlaneMesh" id=23]
+size = Vector2( 50, 20 )
+
+[sub_resource type="ConcavePolygonShape" id=24]
+data = PoolVector3Array( -1, 0, 1, 1, 0, -1, 1, 0, 1, -1, 0, 1, -1, 0, -1, 1, 0, -1 )
+
+[sub_resource type="ConvexPolygonShape" id=25]
+points = PoolVector3Array( -25, 0.25, 10, 25, 0.25, -10, 25, 0.25, 10, -25, 0.25, -10, -25, -0.25, 10, 25, -0.25, -10, 25, -0.25, 10, -25, -0.25, -10, 25, 0.25, 10, -25, 0.25, -10, 25, 0.25, -10, -25, 0.25, 10, 25, -0.25, 10, -25, -0.25, -10, 25, -0.25, -10, -25, -0.25, 10, 25, 0.25, 10, -25, -0.25, 10, -25, 0.25, 10, 25, -0.25, 10, 25, 0.25, -10, -25, -0.25, -10, -25, 0.25, -10, 25, -0.25, -10 )
 
 [node name="Test" type="Spatial"]
 script = ExtResource( 2 )
@@ -147,13 +162,57 @@ shape = SubResource( 18 )
 mesh = SubResource( 19 )
 material/0 = SubResource( 20 )
 
-[node name="StaticBodyPlane" parent="." instance=ExtResource( 3 )]
+[node name="RigidBodyRay" type="RigidBody" parent="DynamicShapes"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 8.42391, 0, 0 )
+physics_material_override = SubResource( 17 )
+axis_lock_angular_x = true
+axis_lock_angular_y = true
+axis_lock_angular_z = true
+script = ExtResource( 1 )
+
+[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyRay"]
+transform = Transform( 0.8, 0, 0, 0, -3.49691e-08, -0.8, 0, 0.8, -3.49691e-08, 0, 0, 0 )
+shape = SubResource( 21 )
+
+[node name="MeshInstance" type="MeshInstance" parent="DynamicShapes/RigidBodyRay/CollisionShape"]
+mesh = SubResource( 22 )
+material/0 = SubResource( 20 )
+
+[node name="Floors" type="Spatial" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4.85544 )
+
+[node name="ConcaveFloor" type="StaticBody" parent="Floors"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10 )
 collision_layer = 2
 collision_mask = 3
+
+[node name="MeshInstance" type="MeshInstance" parent="Floors/ConcaveFloor"]
+visible = false
+mesh = SubResource( 23 )
+material/0 = null
+
+[node name="CollisionShape" type="CollisionShape" parent="Floors/ConcaveFloor"]
+transform = Transform( 25, 0, 0, 0, 1, 0, 0, 0, 10, 0, 0, 0 )
+shape = SubResource( 24 )
+
+[node name="ConvexFloor" type="StaticBody" parent="Floors"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10 )
+collision_layer = 2
+collision_mask = 3
+
+[node name="MeshInstance" type="MeshInstance" parent="Floors/ConvexFloor"]
+visible = false
+mesh = SubResource( 23 )
+material/0 = null
+
+[node name="BoxShape" type="CollisionShape" parent="Floors/ConvexFloor"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.25, 0 )
+shape = SubResource( 25 )
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.604, 22.124 )
 script = ExtResource( 4 )
 
 [node name="OmniLight" type="OmniLight" parent="Camera"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 14.6965, -5.95932 )
 omni_range = 50.0

--- a/3d/physics_tests/tests/functional/test_rigidbody_impact.tscn
+++ b/3d/physics_tests/tests/functional/test_rigidbody_impact.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://utils/rigidbody_pick.gd" type="Script" id=1]
 [ext_resource path="res://test.gd" type="Script" id=2]
@@ -16,6 +16,8 @@ points = PoolVector3Array( -0.7, 0, -0.7, -0.3, 0, 0.8, 0.8, 0, -0.3, 0, -1, 0 )
 
 [sub_resource type="SphereShape" id=5]
 
+[sub_resource type="RayShape" id=6]
+
 [node name="Test" type="Spatial"]
 script = ExtResource( 2 )
 
@@ -23,7 +25,7 @@ script = ExtResource( 2 )
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 9.35591, 0 )
 
 [node name="RigidBodyBox" type="RigidBody" parent="DynamicShapes"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 1.0034, 0 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -34,7 +36,7 @@ transform = Transform( 0.6, 0, 0, 0, 1, 0, 0, 0, 0.6, 0, 0, 0 )
 shape = SubResource( 1 )
 
 [node name="RigidBodyCapsule" type="RigidBody" parent="DynamicShapes"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 0, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 1.0034, 0 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -45,6 +47,7 @@ transform = Transform( 0.8, 0, 0, 0, -3.49691e-08, -0.8, 0, 0.8, -3.49691e-08, 0
 shape = SubResource( 2 )
 
 [node name="RigidBodyCylinder" type="RigidBody" parent="DynamicShapes"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.0034, 0 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -55,7 +58,7 @@ transform = Transform( 0.8, 0, 0, 0, 1, 0, 0, 0, 0.8, 0, 0, 0 )
 shape = SubResource( 3 )
 
 [node name="RigidBodyConvex" type="RigidBody" parent="DynamicShapes"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0.974548, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 1.97795, 0 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -66,7 +69,7 @@ transform = Transform( 1.5, 0, 0, 0, 2, 0, 0, 0, 1.5, 0, 0, 0 )
 shape = SubResource( 4 )
 
 [node name="RigidBodySphere" type="RigidBody" parent="DynamicShapes"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 0, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 1.0034, 0 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -75,6 +78,17 @@ script = ExtResource( 1 )
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodySphere"]
 transform = Transform( 0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0, 0 )
 shape = SubResource( 5 )
+
+[node name="RigidBodyRay" type="RigidBody" parent="DynamicShapes"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 1.0034, 0 )
+axis_lock_angular_x = true
+axis_lock_angular_y = true
+axis_lock_angular_z = true
+script = ExtResource( 1 )
+
+[node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyRay"]
+transform = Transform( 0.8, 0, 0, 0, -3.49691e-08, -0.8, 0, 0.8, -3.49691e-08, 0, 0, 0 )
+shape = SubResource( 6 )
 
 [node name="StaticBodyPlane" parent="." instance=ExtResource( 3 )]
 

--- a/3d/physics_tests/tests/functional/test_rigidbody_impact.tscn
+++ b/3d/physics_tests/tests/functional/test_rigidbody_impact.tscn
@@ -25,7 +25,7 @@ script = ExtResource( 2 )
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 9.35591, 0 )
 
 [node name="RigidBodyBox" type="RigidBody" parent="DynamicShapes"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 1.0034, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 1, 0 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -69,7 +69,7 @@ transform = Transform( 1.5, 0, 0, 0, 2, 0, 0, 0, 1.5, 0, 0, 0 )
 shape = SubResource( 4 )
 
 [node name="RigidBodySphere" type="RigidBody" parent="DynamicShapes"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 1.0034, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 1, 0 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -80,14 +80,14 @@ transform = Transform( 0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0, 0 )
 shape = SubResource( 5 )
 
 [node name="RigidBodyRay" type="RigidBody" parent="DynamicShapes"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 1.0034, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 1, 0 )
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
 script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="DynamicShapes/RigidBodyRay"]
-transform = Transform( 0.8, 0, 0, 0, -3.49691e-08, -0.8, 0, 0.8, -3.49691e-08, 0, 0, 0 )
+transform = Transform( 0.8, 0, 0, 0, 0, -0.8, 0, 0.8, 0, 0, 0, 0 )
 shape = SubResource( 6 )
 
 [node name="StaticBodyPlane" parent="." instance=ExtResource( 3 )]


### PR DESCRIPTION
Added Ray collision shape to these tests.
RigidBody ground check has added floor segment with convex shape, previously only original concave. I noticed that on the original concave floor in Bullet sphere and ray didn't lose ground but on concave they started to flicker. Also added floor segmentation should give extra test points.
The moving platform now has a movement up and down. It will be needed to test the ground connection (Bullet KinematicBody connection is unstable on vertical movement).
