### PR TITLE
Fix jumps in scale and rotation when pinching

### DIFF
--- a/mobile/multitouch_cubes/GestureArea.gd
+++ b/mobile/multitouch_cubes/GestureArea.gd
@@ -78,12 +78,8 @@ func _gui_input(event):
 			if not event.pressed and base_state.has(event.index):
 				# Some known touching finger released.
 
-				# Remove released finger from the base state.
-				base_state.erase(event.index)
-				# Reset the base state to the now only toyching finger.
-				base_state = {
-					curr_state.keys()[0]: curr_state.values()[0],
-				}
+				# Clear the base state
+				base_state.clear()
 
 		elif event is InputEventScreenDrag:
 			if curr_state.has(event.index):


### PR DESCRIPTION
When pressing with two fingers at once and pinching,  an old coordinate contained in the curr_state dictionary gets added to the base_state dictionary, which causes unintended jumps in both scale and rotation. By clearing base_state the script functions as intended.

Behavior before:
https://user-images.githubusercontent.com/40431794/126072155-e75fa0d4-b3ab-460d-9c53-7336dd864285.mp4

Behavior after:
https://user-images.githubusercontent.com/40431794/126072151-c880ea0a-4fd8-47aa-b303-651db64d0705.mp4