### PR TITLE
Google play billing method signature mismatch in demo with Godot's android billing plugin method

### DIFF
--- a/mono/android_iap/GodotGooglePlayBilling/GooglePlayBilling.cs
+++ b/mono/android_iap/GodotGooglePlayBilling/GooglePlayBilling.cs
@@ -15,7 +15,7 @@ namespace AndroidInAppPurchasesWithCSharp.GodotGooglePlayBilling
         [Signal] public delegate void Disconnected();
         [Signal] public delegate void ConnectError(int code, string message);
         [Signal] public delegate void SkuDetailsQueryCompleted(Array skuDetails);
-        [Signal] public delegate void SkuDetailsQueryError(int code, string message);
+        [Signal] public delegate void SkuDetailsQueryError(int code, string message, string[] querySkuDetails);
         [Signal] public delegate void PurchasesUpdated(Array purchases);
         [Signal] public delegate void PurchaseError(int code, string message);
         [Signal] public delegate void PurchaseAcknowledged(string purchaseToken);
@@ -96,7 +96,7 @@ namespace AndroidInAppPurchasesWithCSharp.GodotGooglePlayBilling
 
         private void OnGodotGooglePlayBilling_sku_details_query_completed(Array skuDetails) => EmitSignal(nameof(SkuDetailsQueryCompleted), skuDetails);
 
-        private void OnGodotGooglePlayBilling_sku_details_query_error(int code, string message) => EmitSignal(nameof(SkuDetailsQueryError), code, message);
+        private void OnGodotGooglePlayBilling_sku_details_query_error(int code, string message, string[] querySkuDetails) => EmitSignal(nameof(SkuDetailsQueryError), code, message, querySkuDetails);
 
         private void OnGodotGooglePlayBilling_purchases_updated(Array purchases) => EmitSignal(nameof(PurchasesUpdated), purchases);
 

--- a/mono/android_iap/Main.cs
+++ b/mono/android_iap/Main.cs
@@ -93,7 +93,7 @@ namespace AndroidInAppPurchasesWithCSharp
             _payment.StartConnection();
         }
 
-        private void OnConnectError()
+        private void OnConnectError(int code, string message)
         {
             ShowAlert("PurchaseManager connect error");
         }
@@ -136,7 +136,7 @@ namespace AndroidInAppPurchasesWithCSharp
             }
         }
 
-        private void OnSkuDetailsQueryError(int code, string message)
+        private void OnSkuDetailsQueryError(int code, string message, string[] querySkuDetails)
         {
             ShowAlert($"SKU details query error {code}: {message}");
         }


### PR DESCRIPTION
Fixes following issues:

1. Google play billing method(OnGodotGooglePlayBilling_sku_details_query_error) signature in GooglePlayBilling class doesn't match with Godot's android library exposed method
Check: https://github.com/godotengine/godot-google-play-billing/blob/master/godot-google-play-billing/src/main/java/org/godotengine/godot/plugin/googleplaybilling/GodotGooglePlayBilling.java
Line: 236.

2. "OnConnectError" method signature mismatch

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest stable Godot version. Do not submit a
  pull request if it only works with alpha/beta builds.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
