### PR TITLE
Use `remotesync` instead of the deprecated `sync` in networking demos

### DIFF
--- a/networking/multiplayer_bomber/player.gd
+++ b/networking/multiplayer_bomber/player.gd
@@ -8,7 +8,7 @@ puppet var puppet_motion = Vector2()
 export var stunned = false
 
 # Use sync because it will be called everywhere
-sync func setup_bomb(bomb_name, pos, by_who):
+remotesync func setup_bomb(bomb_name, pos, by_who):
 	var bomb = preload("res://bomb.tscn").instance()
 	bomb.set_name(bomb_name) # Ensure unique name for the bomb
 	bomb.position = pos

--- a/networking/multiplayer_bomber/score.gd
+++ b/networking/multiplayer_bomber/score.gd
@@ -16,7 +16,7 @@ func _process(_delta):
 		$"../Winner".show()
 
 
-sync func increase_score(for_who):
+remotesync func increase_score(for_who):
 	assert(for_who in player_labels)
 	var pl = player_labels[for_who]
 	pl.score += 1

--- a/networking/multiplayer_pong/logic/ball.gd
+++ b/networking/multiplayer_pong/logic/ball.gd
@@ -41,7 +41,7 @@ func _process(delta):
 			rpc("_reset_ball", true)
 
 
-sync func bounce(left, random):
+remotesync func bounce(left, random):
 	# Using sync because both players can make it bounce.
 	if left:
 		direction.x = abs(direction.x)
@@ -53,11 +53,11 @@ sync func bounce(left, random):
 	direction = direction.normalized()
 
 
-sync func stop():
+remotesync func stop():
 	stopped = true
 
 
-sync func _reset_ball(for_left):
+remotesync func _reset_ball(for_left):
 	position = _screen_size / 2
 	if for_left:
 		direction = Vector2.LEFT

--- a/networking/multiplayer_pong/logic/pong.gd
+++ b/networking/multiplayer_pong/logic/pong.gd
@@ -27,7 +27,7 @@ func _ready():
 	print("Unique id: ", get_tree().get_network_unique_id())
 
 
-sync func update_score(add_to_left):
+remotesync func update_score(add_to_left):
 	if add_to_left:
 		score_left += 1
 		score_left_node.set_text(str(score_left))

--- a/networking/websocket_multiplayer/script/game.gd
+++ b/networking/websocket_multiplayer/script/game.gd
@@ -13,7 +13,7 @@ master func set_player_name(name):
 	rpc("update_player_name", sender, name)
 
 
-sync func update_player_name(player, name):
+remotesync func update_player_name(player, name):
 	var pos = _players.find(player)
 	if pos != -1:
 		_list.set_item_text(pos, name)
@@ -28,13 +28,13 @@ master func request_action(action):
 	next_turn()
 
 
-sync func do_action(action):
+remotesync func do_action(action):
 	var name = _list.get_item_text(_turn)
 	var val = randi() % 100
 	rpc("_log", "%s: %ss %d" % [name, action, val])
 
 
-sync func set_turn(turn):
+remotesync func set_turn(turn):
 	_turn = turn
 	if turn >= _players.size():
 		return
@@ -46,7 +46,7 @@ sync func set_turn(turn):
 	_action.disabled = _players[turn] != get_tree().get_network_unique_id()
 
 
-sync func del_player(id):
+remotesync func del_player(id):
 	var pos = _players.find(id)
 	if pos == -1:
 		return
@@ -58,7 +58,7 @@ sync func del_player(id):
 		rpc("set_turn", _turn)
 
 
-sync func add_player(id, name=""):
+remotesync func add_player(id, name=""):
 	_players.append(id)
 	if name == "":
 		_list.add_item("... connecting ...", null, false)
@@ -106,7 +106,7 @@ func on_peer_del(id):
 	rpc("del_player", id)
 
 
-sync func _log(what):
+remotesync func _log(what):
 	$HBoxContainer/RichTextLabel.add_text(what + "\n")
 
 


### PR DESCRIPTION
The `sync` keyword has been deprecated since Godot 3.1.