### PR TITLE
Fix leaked object - Label

### DIFF
--- a/gui/theming_override/test.gd
+++ b/gui/theming_override/test.gd
@@ -9,7 +9,7 @@ onready var label = $VBoxContainer/Label
 onready var button = $VBoxContainer/Button
 onready var button2 = $VBoxContainer/Button2
 onready var reset_all_button = $VBoxContainer/ResetAllButton
-# Save the label color so it can be resetted
+# Save the label color so it can be reset.
 onready var default_label_color = label.get_color("font_color")
 
 func _ready():

--- a/gui/theming_override/test.gd
+++ b/gui/theming_override/test.gd
@@ -16,6 +16,7 @@ func _ready():
 	# Focus the first button automatically for keyboard/controller-friendly navigation.
 	button.grab_focus()
 
+
 func _on_button_pressed():
 	# We have to modify the normal, hover and pressed styleboxes all at once
 	# to get a correct appearance when the button is hovered or pressed.
@@ -64,4 +65,3 @@ func _on_reset_all_button_pressed():
 	button2.add_stylebox_override("pressed", null)
 
 	label.add_color_override("font_color", default_label_color)
-

--- a/gui/theming_override/test.gd
+++ b/gui/theming_override/test.gd
@@ -9,12 +9,12 @@ onready var label = $VBoxContainer/Label
 onready var button = $VBoxContainer/Button
 onready var button2 = $VBoxContainer/Button2
 onready var reset_all_button = $VBoxContainer/ResetAllButton
-
+# Save the label color so it can be resetted
+onready var default_label_color = label.get_color("font_color")
 
 func _ready():
 	# Focus the first button automatically for keyboard/controller-friendly navigation.
 	button.grab_focus()
-
 
 func _on_button_pressed():
 	# We have to modify the normal, hover and pressed styleboxes all at once
@@ -63,7 +63,5 @@ func _on_reset_all_button_pressed():
 	button2.add_stylebox_override("hover", null)
 	button2.add_stylebox_override("pressed", null)
 
-	# If you don't have any references to the previous color value,
-	# you can instance a node at runtime to get this value.
-	var default_label_color = Label.new().get_color("font_color")
 	label.add_color_override("font_color", default_label_color)
+


### PR DESCRIPTION
This fixes a warning of leaked instances.

"WARNING: cleanup: ObjectDB instances leaked at exit (run with --verbose for details).
   At: core/object.cpp:2132."

seems to be the Label.new() that was leaked.
