### PR TITLE
Switch 2D Platformer and Multiplayer Bomber demos to GLES2

### DIFF
--- a/2d/README.md
+++ b/2d/README.md
@@ -5,4 +5,4 @@ These demos are all 2D, but otherwise do not have a common theme.
 Languages: Most have GDScript, some have
 [GDSL](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shading_language.html)
 
-Renderers: 6 of them are GLES 3, but most are GLES 2
+Renderers: 4 of them are GLES 3, but most are GLES 2

--- a/2d/physics_platformer/README.md
+++ b/2d/physics_platformer/README.md
@@ -9,7 +9,7 @@ manual modification of the RigidBody velocity.
 
 Language: GDScript
 
-Renderer: GLES 3 (particles are not available in GLES 2)
+Renderer: GLES 2
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/119
 

--- a/2d/physics_platformer/coin/Coin.tscn
+++ b/2d/physics_platformer/coin/Coin.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://coin/coin.gd" type="Script" id=1]
 [ext_resource path="res://coin/coin.png" type="Texture" id=2]
@@ -97,21 +97,6 @@ blend_mode = 1
 
 [sub_resource type="Curve" id=5]
 
-[sub_resource type="CurveTexture" id=6]
-curve = SubResource( 5 )
-
-[sub_resource type="ParticlesMaterial" id=7]
-emission_shape = 1
-emission_sphere_radius = 20.0
-flag_disable_z = true
-gravity = Vector3( 0, 0, 0 )
-initial_velocity = 1.0
-angular_velocity = 0.0191222
-orbit_velocity = 0.0
-orbit_velocity_random = 0.0
-scale = 0.3
-scale_curve = SubResource( 6 )
-
 [node name="Coin" type="Area2D"]
 script = ExtResource( 1 )
 
@@ -130,14 +115,20 @@ shape = SubResource( 3 )
 [node name="Sound" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 3 )
 
-[node name="Particles" type="Particles2D" parent="."]
+[node name="Particles" type="CPUParticles2D" parent="."]
 modulate = Color( 0.596863, 0.638745, 1, 1 )
 material = SubResource( 4 )
 emitting = false
 one_shot = true
 explosiveness = 0.7
-process_material = SubResource( 7 )
 texture = ExtResource( 4 )
+emission_shape = 1
+emission_sphere_radius = 20.0
+gravity = Vector2( 0, 0 )
+initial_velocity = 1.0
+angular_velocity = 0.0191222
+scale_amount = 0.3
+scale_amount_curve = SubResource( 5 )
 
 [node name="Enabler" type="VisibilityEnabler2D" parent="."]
 rect = Rect2( -5, -5, 10, 10 )

--- a/2d/physics_platformer/enemy/Enemy.tscn
+++ b/2d/physics_platformer/enemy/Enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://enemy/enemy.gd" type="Script" id=1]
 [ext_resource path="res://enemy/enemy.png" type="Texture" id=2]
@@ -106,23 +106,6 @@ radius = 7.0
 offsets = PoolRealArray( 0.5, 1 )
 colors = PoolColorArray( 1, 1, 1, 0.501961, 0, 0, 0, 0 )
 
-[sub_resource type="GradientTexture" id=7]
-gradient = SubResource( 6 )
-
-[sub_resource type="ParticlesMaterial" id=8]
-emission_shape = 1
-emission_sphere_radius = 8.0
-flag_disable_z = true
-spread = 180.0
-gravity = Vector3( 0, 0, 0 )
-initial_velocity = 120.0
-initial_velocity_random = 0.5
-orbit_velocity = 0.0
-orbit_velocity_random = 0.0
-angle_random = 1.0
-scale_random = 1.0
-color_ramp = SubResource( 7 )
-
 [node name="Enemy" type="RigidBody2D"]
 mode = 2
 physics_material_override = SubResource( 1 )
@@ -166,7 +149,7 @@ position = Vector2( 11, -4.672 )
 enabled = true
 cast_to = Vector2( 0, 22.5 )
 
-[node name="Explosion" type="Particles2D" parent="."]
+[node name="Explosion" type="CPUParticles2D" parent="."]
 modulate = Color( 1, 1, 1, 0.685843 )
 emitting = false
 amount = 32
@@ -174,8 +157,16 @@ lifetime = 0.5
 one_shot = true
 speed_scale = 1.2
 explosiveness = 0.76
-process_material = SubResource( 8 )
 texture = ExtResource( 3 )
+emission_shape = 1
+emission_sphere_radius = 8.0
+spread = 180.0
+gravity = Vector2( 0, 0 )
+initial_velocity = 120.0
+initial_velocity_random = 0.5
+angle_random = 1.0
+scale_amount_random = 1.0
+color_ramp = SubResource( 6 )
 
 [node name="SoundHit" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 4 )

--- a/2d/physics_platformer/player/Bullet.tscn
+++ b/2d/physics_platformer/player/Bullet.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://player/bullet.gd" type="Script" id=1]
 [ext_resource path="res://player/bullet.png" type="Texture" id=2]
@@ -6,20 +6,10 @@
 [sub_resource type="CanvasItemMaterial" id=1]
 blend_mode = 1
 
-[sub_resource type="ParticlesMaterial" id=2]
-flag_disable_z = true
-spread = 0.0
-gravity = Vector3( 0, 0, 0 )
-initial_velocity = 1.0
-angular_velocity = 38.0
-orbit_velocity = 0.0
-orbit_velocity_random = 0.0
-scale = 0.8
-
-[sub_resource type="CircleShape2D" id=3]
+[sub_resource type="CircleShape2D" id=2]
 radius = 4.5
 
-[sub_resource type="Animation" id=4]
+[sub_resource type="Animation" id=3]
 length = 1.5
 tracks/0/type = "method"
 tracks/0/path = NodePath(".")
@@ -64,24 +54,29 @@ tracks/2/keys = {
 continuous_cd = 2
 script = ExtResource( 1 )
 
-[node name="Particles2D" type="Particles2D" parent="."]
+[node name="Particles2D" type="CPUParticles2D" parent="."]
 material = SubResource( 1 )
+emitting = false
 lifetime = 0.3
 speed_scale = 3.0
 local_coords = false
-process_material = SubResource( 2 )
 texture = ExtResource( 2 )
+spread = 0.0
+gravity = Vector2( 0, 0 )
+initial_velocity = 1.0
+angular_velocity = 38.0
+scale_amount = 0.8
 
 [node name="Sprite" type="Sprite" parent="."]
 texture = ExtResource( 2 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource( 3 )
+shape = SubResource( 2 )
 
 [node name="Timer" type="Timer" parent="."]
 one_shot = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-anims/shutdown = SubResource( 4 )
+anims/shutdown = SubResource( 3 )
 
 [connection signal="timeout" from="Timer" to="." method="disable"]

--- a/2d/physics_platformer/player/Player.tscn
+++ b/2d/physics_platformer/player/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://player/player.gd" type="Script" id=1]
 [ext_resource path="res://player/robot_demo.png" type="Texture" id=2]
@@ -16,22 +16,7 @@ friction = 0.0
 [sub_resource type="Gradient" id=2]
 colors = PoolColorArray( 0.708353, 0.72498, 1, 1, 1, 1, 1, 0 )
 
-[sub_resource type="GradientTexture" id=3]
-gradient = SubResource( 2 )
-
-[sub_resource type="ParticlesMaterial" id=4]
-flag_disable_z = true
-spread = 65.84
-gravity = Vector3( 0, -15, 0 )
-initial_velocity = 10.14
-angular_velocity = 200.0
-angular_velocity_random = 1.0
-orbit_velocity = 0.0
-orbit_velocity_random = 0.0
-linear_accel = 100.0
-color_ramp = SubResource( 3 )
-
-[sub_resource type="Animation" id=5]
+[sub_resource type="Animation" id=3]
 length = 0.01
 loop = true
 step = 0.25
@@ -48,7 +33,7 @@ tracks/0/keys = {
 "values": [ 22 ]
 }
 
-[sub_resource type="Animation" id=6]
+[sub_resource type="Animation" id=4]
 length = 0.01
 loop = true
 step = 0.25
@@ -65,7 +50,7 @@ tracks/0/keys = {
 "values": [ 21 ]
 }
 
-[sub_resource type="Animation" id=7]
+[sub_resource type="Animation" id=5]
 length = 0.5
 loop = true
 step = 0.25
@@ -82,7 +67,7 @@ tracks/0/keys = {
 "values": [ 26 ]
 }
 
-[sub_resource type="Animation" id=8]
+[sub_resource type="Animation" id=6]
 length = 7.0
 loop = true
 step = 0.25
@@ -99,7 +84,7 @@ tracks/0/keys = {
 "values": [ 16, 17, 18, 16, 19, 20, 19, 16 ]
 }
 
-[sub_resource type="Animation" id=9]
+[sub_resource type="Animation" id=7]
 length = 0.5
 loop = true
 step = 0.25
@@ -116,7 +101,7 @@ tracks/0/keys = {
 "values": [ 25 ]
 }
 
-[sub_resource type="Animation" id=10]
+[sub_resource type="Animation" id=8]
 length = 0.5
 loop = true
 step = 0.25
@@ -133,7 +118,7 @@ tracks/0/keys = {
 "values": [ 23, 24, 23 ]
 }
 
-[sub_resource type="Animation" id=11]
+[sub_resource type="Animation" id=9]
 length = 0.5
 loop = true
 step = 0.25
@@ -150,7 +135,7 @@ tracks/0/keys = {
 "values": [ 26 ]
 }
 
-[sub_resource type="Animation" id=12]
+[sub_resource type="Animation" id=10]
 length = 1.25
 loop = true
 step = 0.25
@@ -167,7 +152,7 @@ tracks/0/keys = {
 "values": [ 0, 1, 2, 3, 4, 0 ]
 }
 
-[sub_resource type="Animation" id=13]
+[sub_resource type="Animation" id=11]
 length = 1.25
 loop = true
 step = 0.25
@@ -184,7 +169,7 @@ tracks/0/keys = {
 "values": [ 5, 6, 7, 8, 9, 5 ]
 }
 
-[sub_resource type="Animation" id=14]
+[sub_resource type="Animation" id=12]
 length = 1.25
 loop = true
 step = 0.25
@@ -201,7 +186,7 @@ tracks/0/keys = {
 "values": [ 10, 11, 12, 13, 14, 5 ]
 }
 
-[sub_resource type="RayShape2D" id=15]
+[sub_resource type="RayShape2D" id=13]
 custom_solver_bias = 0.5
 length = 18.0
 
@@ -218,7 +203,7 @@ texture = ExtResource( 2 )
 hframes = 16
 vframes = 2
 
-[node name="Smoke" type="Particles2D" parent="Sprite"]
+[node name="Smoke" type="CPUParticles2D" parent="Sprite"]
 self_modulate = Color( 1, 1, 1, 0.26702 )
 position = Vector2( 10, 1.5 )
 rotation = -1.45648
@@ -227,20 +212,26 @@ lifetime = 0.3
 one_shot = true
 explosiveness = 1.0
 local_coords = false
-process_material = SubResource( 4 )
 texture = ExtResource( 3 )
+spread = 65.84
+gravity = Vector2( 0, -15 )
+initial_velocity = 10.14
+angular_velocity = 200.0
+angular_velocity_random = 1.0
+linear_accel = 100.0
+color_ramp = SubResource( 2 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-anims/crouch = SubResource( 5 )
-anims/falling = SubResource( 6 )
-anims/falling_weapon = SubResource( 7 )
-anims/idle = SubResource( 8 )
-anims/idle_weapon = SubResource( 9 )
-anims/jumping = SubResource( 10 )
-anims/jumping_weapon = SubResource( 11 )
-anims/run = SubResource( 12 )
-anims/run_weapon = SubResource( 13 )
-anims/standing_weapon_ready = SubResource( 14 )
+anims/crouch = SubResource( 3 )
+anims/falling = SubResource( 4 )
+anims/falling_weapon = SubResource( 5 )
+anims/idle = SubResource( 6 )
+anims/idle_weapon = SubResource( 7 )
+anims/jumping = SubResource( 8 )
+anims/jumping_weapon = SubResource( 9 )
+anims/run = SubResource( 10 )
+anims/run_weapon = SubResource( 11 )
+anims/standing_weapon_ready = SubResource( 12 )
 
 [node name="Camera" type="Camera2D" parent="."]
 current = true
@@ -253,7 +244,7 @@ position = Vector2( 15, 2 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2( 0.15, -6 )
-shape = SubResource( 15 )
+shape = SubResource( 13 )
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
 polygon = PoolVector2Array( -0.138, 8.25, -10, -12, 11, -12 )

--- a/2d/physics_platformer/project.godot
+++ b/2d/physics_platformer/project.godot
@@ -66,7 +66,7 @@ window/size/width=800
 window/size/height=480
 window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
-window/stretch/aspect="keep"
+window/stretch/aspect="keep_height"
 
 [gdnative]
 
@@ -154,6 +154,7 @@ mipmap_policy=1
 
 [rendering]
 
+quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=0
 quality/intended_usage/framebuffer_allocation.mobile=1
 2d/snapping/use_gpu_pixel_snap=true

--- a/2d/platformer/README.md
+++ b/2d/platformer/README.md
@@ -17,7 +17,7 @@ they contain a lot of comments that explain how each class works.
 
 Language: GDScript
 
-Renderer: GLES 3 (particles are not available in GLES 2)
+Renderer: GLES 2
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/120
 

--- a/2d/platformer/project.godot
+++ b/2d/platformer/project.godot
@@ -240,6 +240,7 @@ mipmap_policy=1
 
 [rendering]
 
+quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=0
 quality/intended_usage/framebuffer_allocation.mobile=1
 2d/snapping/use_gpu_pixel_snap=true

--- a/2d/platformer/src/Actors/Enemy.tscn
+++ b/2d/platformer/src/Actors/Enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://assets/art/player/bullet/bullet.png" type="Texture" id=1]
 [ext_resource path="res://assets/audio/sfx/explode.wav" type="AudioStream" id=2]
@@ -179,26 +179,6 @@ blend_mode = 1
 offsets = PoolRealArray( 0.5, 1 )
 colors = PoolColorArray( 1, 1, 1, 1, 0, 0, 0, 1 )
 
-[sub_resource type="GradientTexture" id=8]
-gradient = SubResource( 7 )
-width = 256
-
-[sub_resource type="ParticlesMaterial" id=9]
-emission_shape = 1
-emission_sphere_radius = 8.0
-flag_disable_z = true
-spread = 180.0
-gravity = Vector3( 0, 250, 0 )
-initial_velocity = 120.0
-initial_velocity_random = 0.5
-orbit_velocity = 0.0
-orbit_velocity_random = 0.0
-angle_random = 1.0
-scale_random = 1.0
-color_ramp = SubResource( 8 )
-hue_variation = 0.05
-hue_variation_random = 0.46
-
 [node name="Enemy" type="KinematicBody2D"]
 collision_layer = 2
 collision_mask = 24
@@ -239,7 +219,7 @@ anims/walk = SubResource( 4 )
 rotation = -1.5708
 shape = SubResource( 5 )
 
-[node name="Explosion" type="Particles2D" parent="."]
+[node name="Explosion" type="CPUParticles2D" parent="."]
 self_modulate = Color( 1, 1, 1, 0.12 )
 material = SubResource( 6 )
 emitting = false
@@ -249,8 +229,18 @@ one_shot = true
 speed_scale = 1.2
 explosiveness = 0.76
 draw_order = 215832976
-process_material = SubResource( 9 )
 texture = ExtResource( 1 )
+emission_shape = 1
+emission_sphere_radius = 8.0
+spread = 180.0
+gravity = Vector2( 0, 250 )
+initial_velocity = 120.0
+initial_velocity_random = 0.5
+angle_random = 1.0
+scale_amount_random = 1.0
+color_ramp = SubResource( 7 )
+hue_variation = 0.05
+hue_variation_random = 0.46
 
 [node name="Hit" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 3 )

--- a/2d/platformer/src/Objects/Bullet.tscn
+++ b/2d/platformer/src/Objects/Bullet.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://assets/art/player/bullet/bullet.png" type="Texture" id=1]
 [ext_resource path="res://src/Objects/Bullet.gd" type="Script" id=2]
@@ -8,21 +8,12 @@
 [sub_resource type="CanvasItemMaterial" id=2]
 blend_mode = 1
 
-[sub_resource type="ParticlesMaterial" id=3]
-flag_disable_z = true
-spread = 0.0
-gravity = Vector3( 0, 0, 0 )
-orbit_velocity = 0.0
-orbit_velocity_random = 0.0
-scale = 0.8
-color = Color( 1, 1, 1, 0.705882 )
+[sub_resource type="CanvasItemMaterial" id=3]
 
-[sub_resource type="CanvasItemMaterial" id=4]
-
-[sub_resource type="CircleShape2D" id=5]
+[sub_resource type="CircleShape2D" id=4]
 radius = 4.5
 
-[sub_resource type="Animation" id=6]
+[sub_resource type="Animation" id=5]
 resource_name = "destroy"
 length = 0.3
 tracks/0/type = "method"
@@ -73,27 +64,31 @@ contacts_reported = 1
 contact_monitor = true
 script = ExtResource( 2 )
 
-[node name="Particles2D" type="Particles2D" parent="."]
+[node name="Particles2D" type="CPUParticles2D" parent="."]
 material = SubResource( 2 )
+emitting = false
 lifetime = 0.3
 speed_scale = 3.0
 local_coords = false
-process_material = SubResource( 3 )
 texture = ExtResource( 1 )
+spread = 0.0
+gravity = Vector2( 0, 0 )
+scale_amount = 0.8
+color = Color( 1, 1, 1, 0.705882 )
 
 [node name="Sprite" type="Sprite" parent="."]
-material = SubResource( 4 )
+material = SubResource( 3 )
 texture = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource( 5 )
+shape = SubResource( 4 )
 
 [node name="Timer" type="Timer" parent="."]
 one_shot = true
 autostart = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-anims/destroy = SubResource( 6 )
+anims/destroy = SubResource( 5 )
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]
 [connection signal="timeout" from="Timer" to="." method="destroy"]

--- a/networking/README.md
+++ b/networking/README.md
@@ -4,4 +4,4 @@ These demos showcase networking and/or multiplayer features.
 
 Languages: All have GDScript, WebRTC uses some GDNative
 
-Renderers: Multiplayer Bomber is GLES 3, rest are GLES 2
+Renderer: All are GLES 2

--- a/networking/multiplayer_bomber/README.md
+++ b/networking/multiplayer_bomber/README.md
@@ -6,7 +6,7 @@ should type in his address and press "play".
 
 Language: GDScript
 
-Renderer: GLES 3
+Renderer: GLES 2
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/139
 

--- a/networking/multiplayer_bomber/bomb.tscn
+++ b/networking/multiplayer_bomber/bomb.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://bomb.gd" type="Script" id=1]
 [ext_resource path="res://brickfloor.png" type="Texture" id=2]
@@ -14,22 +14,7 @@ extents = Vector2( 96, 8 )
 max_value = 2.0
 _data = [ Vector2( 0.00150494, 0.398437 ), 0.0, 0.0, 0, 0, Vector2( 0.0152287, 1.42969 ), 0.0, 0.0, 0, 0, Vector2( 0.478607, 1.30078 ), 0.0, 0.0, 0, 0, Vector2( 1, 0.291016 ), 0.0, 0.0, 0, 0 ]
 
-[sub_resource type="CurveTexture" id=4]
-curve = SubResource( 3 )
-
-[sub_resource type="ParticlesMaterial" id=5]
-emission_shape = 2
-emission_box_extents = Vector3( 80, 1, 1 )
-flag_disable_z = true
-gravity = Vector3( 0, 0, 0 )
-initial_velocity = 1.0
-angular_velocity = 187.85
-angular_velocity_random = 1.0
-orbit_velocity = 0.0
-orbit_velocity_random = 0.0
-scale_curve = SubResource( 4 )
-
-[sub_resource type="Animation" id=6]
+[sub_resource type="Animation" id=4]
 length = 4.0
 tracks/0/type = "value"
 tracks/0/path = NodePath("Sprite:self_modulate")
@@ -100,25 +85,38 @@ shape = SubResource( 1 )
 [node name="Shape2" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )
 
-[node name="Explosion1" type="Particles2D" parent="."]
+[node name="Explosion1" type="CPUParticles2D" parent="."]
 emitting = false
 lifetime = 0.5
 one_shot = true
 explosiveness = 0.95
-process_material = SubResource( 5 )
 texture = ExtResource( 3 )
+emission_shape = 2
+emission_rect_extents = Vector2( 80, 1 )
+gravity = Vector2( 0, 0 )
+initial_velocity = 1.0
+angular_velocity = 187.85
+angular_velocity_random = 1.0
+scale_amount_curve = SubResource( 3 )
 
-[node name="Explosion2" type="Particles2D" parent="."]
+[node name="Explosion2" type="CPUParticles2D" parent="."]
 rotation = 1.57162
+scale = Vector2( 1, 1 )
 emitting = false
 one_shot = true
 explosiveness = 0.95
-process_material = SubResource( 5 )
 texture = ExtResource( 3 )
+emission_shape = 2
+emission_rect_extents = Vector2( 80, 1 )
+gravity = Vector2( 0, 0 )
+initial_velocity = 1.0
+angular_velocity = 187.85
+angular_velocity_random = 1.0
+scale_amount_curve = SubResource( 3 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 autoplay = "anim"
-anims/anim = SubResource( 6 )
+anims/anim = SubResource( 4 )
 
 [connection signal="body_entered" from="." to="." method="_on_bomb_body_enter"]
 [connection signal="body_exited" from="." to="." method="_on_bomb_body_exit"]

--- a/networking/multiplayer_bomber/project.godot
+++ b/networking/multiplayer_bomber/project.godot
@@ -83,3 +83,7 @@ set_bomb={
 , Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
  ]
 }
+
+[rendering]
+
+quality/driver/driver_name="GLES2"


### PR DESCRIPTION
This allows those demos to run on a greater range of devices.

Particles2D nodes were converted to CPUParticles2D for compatibility with GLES2.

Physics-Based 2D Platformer demo now uses the same stretch mode as 2D Platformer for consistency.