### PR TITLE
Update start button shortcut to not use ui_* events

### DIFF
--- a/2d/dodge_the_creeps/HUD.tscn
+++ b/2d/dodge_the_creeps/HUD.tscn
@@ -12,7 +12,7 @@ size = 64
 font_data = ExtResource( 2 )
 
 [sub_resource type="InputEventAction" id=3]
-action = "ui_select"
+action = "start_game"
 
 [sub_resource type="ShortCut" id=4]
 shortcut = SubResource( 3 )
@@ -50,6 +50,9 @@ margin_bottom = -100.0
 custom_fonts/font = SubResource( 2 )
 shortcut = SubResource( 4 )
 text = "Start"
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="MessageTimer" type="Timer" parent="."]
 one_shot = true

--- a/2d/dodge_the_creeps/Player.tscn
+++ b/2d/dodge_the_creeps/Player.tscn
@@ -8,14 +8,14 @@
 
 [sub_resource type="SpriteFrames" id=1]
 animations = [ {
-"frames": [ ExtResource( 2 ), ExtResource( 3 ) ],
-"loop": true,
-"name": "right",
-"speed": 5.0
-}, {
 "frames": [ ExtResource( 4 ), ExtResource( 5 ) ],
 "loop": true,
 "name": "up",
+"speed": 5.0
+}, {
+"frames": [ ExtResource( 2 ), ExtResource( 3 ) ],
+"loop": true,
+"name": "right",
 "speed": 5.0
 } ]
 

--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -61,3 +61,8 @@ move_down={
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
  ]
 }
+start_game={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}


### PR DESCRIPTION
Update the Dodge the Creeps demo to not use the `ui_select` action for the start button shortcut.  Replace with a custom action called `start_game`.

See also https://github.com/godotengine/godot-docs/pull/5383 for corresponding docs change.