### PR TITLE
Change start button shortcut to use custom action

### DIFF
--- a/2d/dodge_the_creeps/HUD.tscn
+++ b/2d/dodge_the_creeps/HUD.tscn
@@ -12,7 +12,7 @@ size = 64
 font_data = ExtResource( 2 )
 
 [sub_resource type="InputEventAction" id=3]
-action = "ui_select"
+action = "start_game"
 
 [sub_resource type="ShortCut" id=4]
 shortcut = SubResource( 3 )
@@ -50,6 +50,9 @@ margin_bottom = -100.0
 custom_fonts/font = SubResource( 2 )
 shortcut = SubResource( 4 )
 text = "Start"
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="MessageTimer" type="Timer" parent="."]
 one_shot = true

--- a/2d/dodge_the_creeps/Main.tscn
+++ b/2d/dodge_the_creeps/Main.tscn
@@ -20,6 +20,9 @@ mob_scene = ExtResource( 2 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color( 0.219608, 0.372549, 0.380392, 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="Player" parent="." instance=ExtResource( 3 )]
 

--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -61,3 +61,8 @@ move_down={
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
  ]
 }
+start_game={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}


### PR DESCRIPTION
Change to make the start button shortcut in the 2D Dodge the Creeps demo to be `start_game`, per the update to the tutorial text in https://github.com/godotengine/godot-docs/pull/5383.

This PR should be committed **after** the other one.