### PR TITLE
[3.x] Calling RPC functions in the webrtc signaling demo

### DIFF
--- a/networking/webrtc_signaling/demo/client_ui.gd
+++ b/networking/webrtc_signaling/demo/client_ui.gd
@@ -28,6 +28,7 @@ func _disconnected():
 
 
 func _lobby_joined(lobby):
+	get_tree().network_peer = client.rtc_mp
 	_log("Joined lobby %s" % lobby)
 
 
@@ -77,3 +78,9 @@ func _on_Seal_pressed():
 
 func stop():
 	client.stop()
+
+func _on_RPC_pressed():
+	rpc("update_color", Color(rand_range(0, 1), rand_range(0, 1), rand_range(0, 1), 1))
+
+remotesync func update_color(color: Color):
+	$VBoxContainer/HBoxContainer/Label.modulate = color

--- a/networking/webrtc_signaling/demo/client_ui.tscn
+++ b/networking/webrtc_signaling/demo/client_ui.tscn
@@ -39,7 +39,7 @@ margin_left = 77.0
 margin_right = 921.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
-text = "ws://localhost:9080"
+text = "ws://127.0.0.1:9080"
 
 [node name="Room" type="Label" parent="VBoxContainer/Connect"]
 margin_left = 925.0
@@ -93,6 +93,20 @@ margin_right = 280.0
 margin_bottom = 20.0
 text = "Print peers"
 
+[node name="RPC" type="Button" parent="VBoxContainer/HBoxContainer"]
+margin_left = 290.0
+margin_right = 385.0
+margin_bottom = 20.0
+text = "Change Color"
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
+margin_left = 395.0
+margin_top = 3.0
+margin_right = 1024.0
+margin_bottom = 17.0
+size_flags_horizontal = 3
+text = "Random Color"
+
 [node name="TextEdit" type="TextEdit" parent="VBoxContainer"]
 margin_top = 60.0
 margin_right = 1024.0
@@ -105,3 +119,4 @@ readonly = true
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/Seal" to="." method="_on_Seal_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/Ping" to="." method="ping"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/Peers" to="." method="_on_Peers_pressed"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/RPC" to="." method="_on_RPC_pressed"]


### PR DESCRIPTION
I am working with an application similar to the webrtc_signaling demo. I was experiencing issues where RPC calls are just dropped without warning. I was able to reproduce it using the signaling demo.

In this PR I setup the `network_peer` in order to get RPC working. I added a new label and and RPC function that randomly updates the color of that label. The function is marked `remotesync` and should update all clients whenever the button is cicked. In this demo though, there are some cases where clicking the button does not update the other client. This occurs even in a small network mesh.

Below is an example of running the application. You chose host in one and connect 1 peer in each client. When they are connected clicking the "Random Color" button should update the color in the other peers. Sometimes this will fail. See the below of an example where the color gets desync.

My best guess is that somehow the signaling server is interfering with the RTC calls.

*Make sure to download the WebRTC libraries in order to test this*

<img width="1028" alt="signaling-rpc-bug" src="https://user-images.githubusercontent.com/1059099/144729093-ea473341-d416-43a4-9f87-c0ddf4fef10b.png">
