### PR TITLE
Added Alpha effect to joystick indicators

### DIFF
--- a/misc/joypads/joypads.gd
+++ b/misc/joypads/joypads.gd
@@ -41,6 +41,8 @@ func _process(_delta):
 		axis_value = Input.get_joy_axis(joy_num, axis)
 		axes.get_node("Axis" + str(axis) + "/ProgressBar").set_value(100 * axis_value)
 		axes.get_node("Axis" + str(axis) + "/ProgressBar/Value").set_text(str(axis_value))
+		# Scaled value used for alpha channel using valid range rather than including unusable deadzone values.
+		var scaled_alpha_value = (abs(axis_value) - DEADZONE) / (1.0 - DEADZONE)
 		# Show joypad direction indicators
 		if axis <= JOY_ANALOG_RY:
 			if abs(axis_value) < DEADZONE:
@@ -49,19 +51,37 @@ func _process(_delta):
 			elif axis_value > 0:
 				joypad_axes.get_node(str(axis) + "+").show()
 				joypad_axes.get_node(str(axis) + "-").hide()
+				# Transparent white modulate, non-alpha color channels are not changed here.
+				joypad_axes.get_node(str(axis) + "+").self_modulate.a = scaled_alpha_value
 			else:
 				joypad_axes.get_node(str(axis) + "+").hide()
 				joypad_axes.get_node(str(axis) + "-").show()
+				# Transparent white modulate, non-alpha color channels are not changed here.
+				joypad_axes.get_node(str(axis) + "-").self_modulate.a = scaled_alpha_value
+		elif axis == JOY_ANALOG_L2:
+			if axis_value <= DEADZONE:
+				joypad_buttons.get_child(JOY_ANALOG_L2).hide()
+			else:
+				joypad_buttons.get_child(JOY_ANALOG_L2).show()
+				# Transparent white modulate, non-alpha color channels are not changed here.
+				joypad_buttons.get_child(JOY_ANALOG_L2).self_modulate.a = scaled_alpha_value
+		elif axis == JOY_ANALOG_R2:
+			if axis_value <= DEADZONE:
+				joypad_buttons.get_child(JOY_ANALOG_R2).hide()
+			else:
+				joypad_buttons.get_child(JOY_ANALOG_R2).show()
+				# Transparent white modulate, non-alpha color channels are not changed here.
+				joypad_buttons.get_child(JOY_ANALOG_R2).self_modulate.a = scaled_alpha_value
 
 	# Loop through the buttons and highlight the ones that are pressed.
 	for btn in range(JOY_BUTTON_0, int(min(JOY_BUTTON_MAX, 24))):
 		if Input.is_joy_button_pressed(joy_num, btn):
 			button_grid.get_child(btn).add_color_override("font_color", Color.white)
-			if btn < 17:
+			if btn < 17 and btn != JOY_ANALOG_L2 and btn != JOY_ANALOG_R2:
 				joypad_buttons.get_child(btn).show()
 		else:
 			button_grid.get_child(btn).add_color_override("font_color", Color(0.2, 0.1, 0.3, 1))
-			if btn < 17:
+			if btn < 17 and btn != JOY_ANALOG_L2 and btn != JOY_ANALOG_R2:
 				joypad_buttons.get_child(btn).hide()
 
 


### PR DESCRIPTION
Added alpha effect to joystick sprites via selfmodulator color on the canvasitem.

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest stable Godot version. Do not submit a
  pull request if it only works with alpha/beta builds.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
