### PR TITLE
Don't export global illumination demo to HTML5

### DIFF
--- a/.github/dist/footer.html
+++ b/.github/dist/footer.html
@@ -2,15 +2,16 @@
     </ul>
     <h2>Unavailable demos</h2>
     <ul>
-        <li><code>2d/hdr/</code>: Not supported on HTML5 yet.
-        <li><code>3d/voxel/</code>: Not supported on HTML5 yet.
-        <li><code>audio/device_changer/</code>: Not supported on HTML5 due to browser limitations.
-        <li><code>loading/background_load/</code>: Not supported on HTML5 yet.
-        <li><code>loading/multiple_threads_loading/</code>: Not supported on HTML5 yet.
-        <li><code>loading/threads/</code>: Not supported on HTML5 yet.
-        <li><code>misc/matrix_transform/</code>: Results are only visible in the editor.
-        <li><code>mobile/android_iap/</code>: Only relevant on native Android.
-        <li><code>mobile/sensors/</code>: Not supported on HTML5 yet.
+        <li><code>2d/hdr/</code>: Not supported on HTML5 yet.</li>
+        <li><code>3d/global_illumination/</code>: Not supported on HTML5 yet (freezes the browser).</li>
+        <li><code>3d/voxel/</code>: Not supported on HTML5 yet.</li>
+        <li><code>audio/device_changer/</code>: Not supported on HTML5 due to browser limitations.</li>
+        <li><code>loading/background_load/</code>: Not supported on HTML5 yet.</li>
+        <li><code>loading/multiple_threads_loading/</code>: Not supported on HTML5 yet.</li>
+        <li><code>loading/threads/</code>: Not supported on HTML5 yet.</li>
+        <li><code>misc/matrix_transform/</code>: Results are only visible in the editor.</li>
+        <li><code>mobile/android_iap/</code>: Only relevant on native Android.</li>
+        <li><code>mobile/sensors/</code>: Not supported on HTML5 yet.</li>
         <li><code>mono/*/</code>: Not available yet (requires Mono-enabled HTML5 build).</li>
         <li><code>networking/*/</code>: Doesn't make sense to be hosted on a static host, as the server must be hosted on the same origin due to the browser's same-origin policy.</li>
         <li><code>plugins/*/</code>: Only effective within the editor.</li>

--- a/.github/workflows/export_html5.yml
+++ b/.github/workflows/export_html5.yml
@@ -31,6 +31,7 @@ jobs:
           # Remember to update `.github/dist/footer.html` when updating the list of excluded demos.
           rm -rf \
             2d/hdr/ \
+            3d/global_illumination/ \
             3d/voxel/ \
             audio/device_changer/ \
             loading/background_load/ \


### PR DESCRIPTION
It freezes Firefox when I open it.

This PR also fixes the list items not ending in `</li>`