### PR TITLE
Fix broken links for the your first 2D game tutorial

### DIFF
--- a/2d/dodge_the_creeps/README.md
+++ b/2d/dodge_the_creeps/README.md
@@ -4,7 +4,7 @@ This is a simple game where your character must move
 and avoid the enemies for as long as possible.
 
 This is a finished version of the game featured in the
-["Your first game"](https://docs.godotengine.org/en/latest/getting_started/step_by_step/your_first_game.html)
+["Your first 2D game"](https://docs.godotengine.org/en/latest/getting_started/first_2d_game/index.html)
 tutorial in the documentation. For more details,
 consider following the tutorial in the documentation.
 

--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -14,7 +14,7 @@ config/name="Dodge the Creeps"
 config/description="This is a simple game where your character must move
 and avoid the enemies for as long as possible.
 
-This is a finished version of the game featured in the 'Your first game'
+This is a finished version of the game featured in the 'Your first 2D game'
 tutorial in the documentation. For more details, consider
 following the tutorial in the documentation."
 run/main_scene="res://Main.tscn"

--- a/mono/dodge_the_creeps/README.md
+++ b/mono/dodge_the_creeps/README.md
@@ -4,7 +4,7 @@ This is a simple game where your character must move
 and avoid the enemies for as long as possible.
 
 This is a finished version of the game featured in the
-["Your first game"](https://docs.godotengine.org/en/latest/getting_started/step_by_step/your_first_game.html)
+["Your first 2D game"](https://docs.godotengine.org/en/latest/getting_started/first_2d_game/index.html)
 tutorial in the documentation, but ported to C#. For more details,
 consider following the tutorial in the documentation.
 

--- a/mono/dodge_the_creeps/project.godot
+++ b/mono/dodge_the_creeps/project.godot
@@ -14,7 +14,7 @@ config/name="Dodge the Creeps with C#"
 config/description="This is a simple game where your character must move
 and avoid the enemies for as long as possible.
 
-This is a finished version of the game featured in the 'Your first game'
+This is a finished version of the game featured in the 'Your first 2D game'
 tutorial in the documentation, but ported to C#. For more details,
 consider following the tutorial in the documentation."
 run/main_scene="res://Main.tscn"


### PR DESCRIPTION
The link was sending to a not found page because the `Your first game` tutorial was moved to the `Your first 2D game` one. Also fix the tutorial name in the Dodge the Creeps project config file.

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest stable Godot version. Do not submit a
  pull request if it only works with alpha/beta builds.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
