### PR TITLE
[3.x] Adds a deadzone control with indicator sprite

### DIFF
--- a/misc/joypads/deadzone.gd
+++ b/misc/joypads/deadzone.gd
@@ -1,0 +1,18 @@
+extends HBoxContainer
+
+const MAX_DEADZONE_SPRITE_SCALE:float = 1.5
+const PATH_TO_MASK:String = "Axis_Sprite/Mask"
+const PATH_TO_ROOT:String = "../../"
+
+var deadzone_sprite:Sprite = null
+var root_node:Node = null
+
+func _ready():
+	self.deadzone_sprite = self.get_node(self.PATH_TO_MASK)
+	self.root_node = self.get_node(self.PATH_TO_ROOT)
+
+func _on_SpinBox_value_changed(value):
+	var percentage_value:float = value * 0.01
+	self.deadzone_sprite.scale.y = self.MAX_DEADZONE_SPRITE_SCALE * percentage_value
+	self.deadzone_sprite.scale.x = self.deadzone_sprite.scale.y
+	self.root_node.deadzone = percentage_value

--- a/misc/joypads/joypads.gd
+++ b/misc/joypads/joypads.gd
@@ -7,10 +7,10 @@ extends Control
 #
 # Licensed under the MIT license
 
-const DEADZONE = 0.2
 const FONT_COLOR_DEFAULT = Color(1.0, 1.0, 1.0, 0.5)
 const FONT_COLOR_ACTIVE = Color.white
 
+export(float) var deadzone = 0.2
 var joy_num
 var cur_joy = -1
 var axis_value
@@ -44,10 +44,12 @@ func _process(_delta):
 		axes.get_node("Axis" + str(axis) + "/ProgressBar").set_value(100 * axis_value)
 		axes.get_node("Axis" + str(axis) + "/ProgressBar/Value").set_text(str(axis_value))
 		# Scaled value used for alpha channel using valid range rather than including unusable deadzone values.
-		var scaled_alpha_value = (abs(axis_value) - DEADZONE) / (1.0 - DEADZONE)
+		var scaled_alpha_value = 0.0
+		if(deadzone < 1.0):
+			scaled_alpha_value = (abs(axis_value) - deadzone) / (1.0 - deadzone)
 		# Show joypad direction indicators
 		if axis <= JOY_ANALOG_RY:
-			if abs(axis_value) < DEADZONE:
+			if abs(axis_value) < deadzone:
 				joypad_axes.get_node(str(axis) + "+").hide()
 				joypad_axes.get_node(str(axis) + "-").hide()
 			elif axis_value > 0:
@@ -61,14 +63,14 @@ func _process(_delta):
 				# Transparent white modulate, non-alpha color channels are not changed here.
 				joypad_axes.get_node(str(axis) + "-").self_modulate.a = scaled_alpha_value
 		elif axis == JOY_ANALOG_L2:
-			if axis_value <= DEADZONE:
+			if axis_value <= deadzone:
 				joypad_buttons.get_child(JOY_ANALOG_L2).hide()
 			else:
 				joypad_buttons.get_child(JOY_ANALOG_L2).show()
 				# Transparent white modulate, non-alpha color channels are not changed here.
 				joypad_buttons.get_child(JOY_ANALOG_L2).self_modulate.a = scaled_alpha_value
 		elif axis == JOY_ANALOG_R2:
-			if axis_value <= DEADZONE:
+			if axis_value <= deadzone:
 				joypad_buttons.get_child(JOY_ANALOG_R2).hide()
 			else:
 				joypad_buttons.get_child(JOY_ANALOG_R2).show()
@@ -77,7 +79,7 @@ func _process(_delta):
 
 		# Highlight axis labels that are within the "active" value range. Simular to the button highlighting for loop below.
 		axes.get_node("Axis" + str(axis) + "/Label").add_color_override("font_color", FONT_COLOR_DEFAULT)
-		if abs(axis_value) >= DEADZONE:
+		if abs(axis_value) >= deadzone:
 			axes.get_node("Axis" + str(axis) + "/Label").add_color_override("font_color", FONT_COLOR_ACTIVE)
 
 	# Loop through the buttons and highlight the ones that are pressed.

--- a/misc/joypads/joypads.tscn
+++ b/misc/joypads/joypads.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://joypads.gd" type="Script" id=1]
 [ext_resource path="res://joypad_diagram.tscn" type="PackedScene" id=2]
 [ext_resource path="res://remap/remap_wizard.tscn" type="PackedScene" id=3]
+[ext_resource path="res://indicators.png" type="Texture" id=4]
+[ext_resource path="res://diagram.png" type="Texture" id=5]
+[ext_resource path="res://deadzone.gd" type="Script" id=6]
 
 [node name="joypads" type="Control"]
 anchor_left = 0.5
@@ -74,9 +77,45 @@ margin_top = 50.0
 margin_right = 255.0
 margin_bottom = 310.0
 
-[node name="Axis0" type="HBoxContainer" parent="Axes"]
+[node name="Deadzone" type="HBoxContainer" parent="Axes"]
 margin_right = 260.0
-margin_bottom = 20.0
+margin_bottom = 24.0
+script = ExtResource( 6 )
+
+[node name="Label" type="Label" parent="Axes/Deadzone"]
+margin_top = 5.0
+margin_right = 182.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Axis Deadzone"
+
+[node name="Axis_Sprite" type="Sprite" parent="Axes/Deadzone"]
+position = Vector2( 140, 11 )
+scale = Vector2( 0.5, 0.5 )
+texture = ExtResource( 5 )
+offset = Vector2( -1, 0 )
+region_enabled = true
+region_rect = Rect2( 144, 404, 70, 70 )
+region_filter_clip = true
+
+[node name="Mask" type="Sprite" parent="Axes/Deadzone/Axis_Sprite"]
+modulate = Color( 0, 0.0392157, 1, 1 )
+scale = Vector2( 0.3, 0.3 )
+texture = ExtResource( 4 )
+region_enabled = true
+region_rect = Rect2( 0, 0, 46, 46 )
+
+[node name="SpinBox" type="SpinBox" parent="Axes/Deadzone"]
+margin_left = 186.0
+margin_right = 260.0
+margin_bottom = 24.0
+value = 20.0
+suffix = "%"
+
+[node name="Axis0" type="HBoxContainer" parent="Axes"]
+margin_top = 28.0
+margin_right = 260.0
+margin_bottom = 48.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -119,9 +158,9 @@ __meta__ = {
 }
 
 [node name="Axis1" type="HBoxContainer" parent="Axes"]
-margin_top = 24.0
+margin_top = 52.0
 margin_right = 260.0
-margin_bottom = 44.0
+margin_bottom = 72.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -164,9 +203,9 @@ __meta__ = {
 }
 
 [node name="Axis2" type="HBoxContainer" parent="Axes"]
-margin_top = 48.0
+margin_top = 76.0
 margin_right = 260.0
-margin_bottom = 68.0
+margin_bottom = 96.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -209,9 +248,9 @@ __meta__ = {
 }
 
 [node name="Axis3" type="HBoxContainer" parent="Axes"]
-margin_top = 72.0
+margin_top = 100.0
 margin_right = 260.0
-margin_bottom = 92.0
+margin_bottom = 120.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -254,9 +293,9 @@ __meta__ = {
 }
 
 [node name="Axis4" type="HBoxContainer" parent="Axes"]
-margin_top = 96.0
+margin_top = 124.0
 margin_right = 260.0
-margin_bottom = 116.0
+margin_bottom = 144.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -299,9 +338,9 @@ __meta__ = {
 }
 
 [node name="Axis5" type="HBoxContainer" parent="Axes"]
-margin_top = 120.0
+margin_top = 148.0
 margin_right = 260.0
-margin_bottom = 140.0
+margin_bottom = 168.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -344,9 +383,9 @@ __meta__ = {
 }
 
 [node name="Axis6" type="HBoxContainer" parent="Axes"]
-margin_top = 144.0
+margin_top = 172.0
 margin_right = 260.0
-margin_bottom = 164.0
+margin_bottom = 192.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -389,9 +428,9 @@ __meta__ = {
 }
 
 [node name="Axis7" type="HBoxContainer" parent="Axes"]
-margin_top = 168.0
+margin_top = 196.0
 margin_right = 260.0
-margin_bottom = 188.0
+margin_bottom = 216.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -434,9 +473,9 @@ __meta__ = {
 }
 
 [node name="Axis8" type="HBoxContainer" parent="Axes"]
-margin_top = 192.0
+margin_top = 220.0
 margin_right = 260.0
-margin_bottom = 212.0
+margin_bottom = 240.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -479,9 +518,9 @@ __meta__ = {
 }
 
 [node name="Axis9" type="HBoxContainer" parent="Axes"]
-margin_top = 216.0
+margin_top = 244.0
 margin_right = 260.0
-margin_bottom = 236.0
+margin_bottom = 264.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -524,9 +563,9 @@ __meta__ = {
 }
 
 [node name="Axis10" type="HBoxContainer" parent="Axes"]
-margin_top = 240.0
+margin_top = 268.0
 margin_right = 260.0
-margin_bottom = 260.0
+margin_bottom = 288.0
 rect_min_size = Vector2( 260, 20 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -1161,6 +1200,7 @@ text = "Show"
 
 [node name="RemapWizard" parent="." instance=ExtResource( 3 )]
 
+[connection signal="value_changed" from="Axes/Deadzone/SpinBox" to="Axes/Deadzone" method="_on_SpinBox_value_changed"]
 [connection signal="pressed" from="Vibration/Buttons/Start" to="." method="_on_start_vibration_pressed"]
 [connection signal="pressed" from="Vibration/Buttons/Stop" to="." method="_on_stop_vibration_pressed"]
 [connection signal="pressed" from="VBoxContainer/Clear" to="." method="_on_Clear_pressed"]


### PR DESCRIPTION
Adds a deadzone spinbox to control the percentage strength on the axis deadzone as well as adding two sprites and a label for representing the deadzone value.

Thought it maybe a useful feature to allow people to change the deadzone value to see what it would look like at different values. I'd prefer to be able to do a "by device" dictionary lookup so that the demo or a game using the demo as reference could have a specific deadzone for each of their controllers remembered by a unique ID. This may already exist and I just don't know about it, but I figured a simple control shared for all joypad devices would suffice.

As always if this is an undesired addition or I messed up something please do let me know. Hope everyone is having a good day out there. o/

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest stable Godot version. Do not submit a
  pull request if it only works with alpha/beta builds.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
