### PR TITLE
Fix scaling not working after resizing the window

### DIFF
--- a/viewport/3d_scaling/hud.gd
+++ b/viewport/3d_scaling/hud.gd
@@ -16,7 +16,7 @@ func _ready():
 
 	# Required to change the 3D viewport's size when the window is resized.
 	# warning-ignore:return_value_discarded
-	viewport.connect("size_changed" ,self._root_viewport_size_changed)
+	viewport.connect(&"size_changed", self._root_viewport_size_changed)
 
 
 func _unhandled_input(event):
@@ -41,4 +41,3 @@ func _root_viewport_size_changed():
 	# The viewport is resized depending on the window height.
 	# To compensate for the larger resolution, the viewport sprite is scaled down.
 	viewport.size = get_viewport().size * scale_factor
-	

--- a/viewport/3d_scaling/hud.gd
+++ b/viewport/3d_scaling/hud.gd
@@ -16,7 +16,7 @@ func _ready():
 
 	# Required to change the 3D viewport's size when the window is resized.
 	# warning-ignore:return_value_discarded
-	get_viewport().connect(&"size_changed", self._root_viewport_size_changed)
+	viewport.connect("size_changed" ,self._root_viewport_size_changed)
 
 
 func _unhandled_input(event):
@@ -41,3 +41,4 @@ func _root_viewport_size_changed():
 	# The viewport is resized depending on the window height.
 	# To compensate for the larger resolution, the viewport sprite is scaled down.
 	viewport.size = get_viewport().size * scale_factor
+	

--- a/viewport/3d_scaling/project.godot
+++ b/viewport/3d_scaling/project.godot
@@ -22,7 +22,7 @@ config/features=PackedStringArray("4.0")
 
 [display]
 
-window/stretch/mode="2d"
+window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 
 [input]


### PR DESCRIPTION
Scaling didn't work after resizing the window. In Godot 4, the
SubViewport also has a size changed signal which should be used instead.
This fixes the issue I was having: #698 
Tested this in the demo project and my personal project, everything seems to work find again.

The main changes were switching the stretch mode to the new Godot 4 mode Canvas_items like @Calinou suggested. And the viewport change should happen on the SubViewport _size_changed as that one updates later compared to the root viewport, which had more control over the size of the SubViewport for some reason. 

Ps.: This is my first pull request ever so I'm not sure if I did a good job explaining everything.

