### PR TITLE
Fixed Script Errors for GUI Input Mapping Demo - 4.0-dev

### DIFF
--- a/gui/input_mapping/ActionRemapButton.gd
+++ b/gui/input_mapping/ActionRemapButton.gd
@@ -8,9 +8,9 @@ func _ready():
 	display_current_key()
 
 
-func _toggled(button_pressed):
-	set_process_unhandled_key_input(button_pressed)
-	if button_pressed:
+func _toggled(is_button_pressed):
+	set_process_unhandled_key_input(is_button_pressed)
+	if is_button_pressed:
 		text = "... Key"
 		release_focus()
 	else:
@@ -21,7 +21,7 @@ func _unhandled_key_input(event):
 	# Note that you can use the _input callback instead, especially if
 	# you want to work with gamepads.
 	remap_action_to(event)
-	pressed = false
+	button_pressed = false
 
 
 func remap_action_to(event):
@@ -31,5 +31,5 @@ func remap_action_to(event):
 
 
 func display_current_key():
-	var current_key = InputMap.get_action_list(action)[0].as_text()
+	var current_key = InputMap.action_get_events(action)[0].as_text()
 	text = "%s Key" % current_key

--- a/gui/input_mapping/InputRemapMenu.tscn
+++ b/gui/input_mapping/InputRemapMenu.tscn
@@ -1,8 +1,6 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=3 uid="uid://bjdgwg23lm1d4"]
 
-[ext_resource path="res://ActionRemapButton.tscn" type="PackedScene" id=1]
-
-[sub_resource type="ButtonGroup" id=1]
+[ext_resource type="PackedScene" path="res://ActionRemapButton.tscn" id="1"]
 
 [node name="InputRemapMenu" type="Control"]
 anchor_right = 1.0
@@ -13,8 +11,6 @@ anchor_right = 1.0
 offset_top = 24.0
 offset_bottom = 55.0
 text = "Click on a button to reassign its action key."
-align = 1
-autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -29,7 +25,6 @@ offset_top = -144.0
 offset_right = 160.0
 offset_bottom = 144.0
 disabled = true
-group = SubResource( 1 )
 flat = true
 __meta__ = {
 "_edit_use_anchors_": false
@@ -60,16 +55,13 @@ offset_bottom = 52.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Move Left"
-align = 1
-valign = 1
 
-[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow" instance=ExtResource( 1 )]
+[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow" instance=ExtResource( "1" )]
 offset_left = 162.0
 offset_right = 320.0
 offset_bottom = 52.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-group = SubResource( 1 )
 action = "move_left"
 
 [node name="ActionRemapRow2" type="HBoxContainer" parent="RemapButtonGroup/ActionsList"]
@@ -85,16 +77,13 @@ offset_bottom = 53.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Move Right"
-align = 1
-valign = 1
 
-[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow2" instance=ExtResource( 1 )]
+[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow2" instance=ExtResource( "1" )]
 offset_left = 162.0
 offset_right = 320.0
 offset_bottom = 53.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-group = SubResource( 1 )
 action = "move_right"
 
 [node name="ActionRemapRow3" type="HBoxContainer" parent="RemapButtonGroup/ActionsList"]
@@ -110,16 +99,13 @@ offset_bottom = 53.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Look Up"
-align = 1
-valign = 1
 
-[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow3" instance=ExtResource( 1 )]
+[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow3" instance=ExtResource( "1" )]
 offset_left = 162.0
 offset_right = 320.0
 offset_bottom = 53.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-group = SubResource( 1 )
 action = "look_up"
 
 [node name="ActionRemapRow4" type="HBoxContainer" parent="RemapButtonGroup/ActionsList"]
@@ -135,16 +121,13 @@ offset_bottom = 53.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Crouch"
-align = 1
-valign = 1
 
-[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow4" instance=ExtResource( 1 )]
+[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow4" instance=ExtResource( "1" )]
 offset_left = 162.0
 offset_right = 320.0
 offset_bottom = 53.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-group = SubResource( 1 )
 action = "crouch"
 
 [node name="ActionRemapRow5" type="HBoxContainer" parent="RemapButtonGroup/ActionsList"]
@@ -160,14 +143,11 @@ offset_bottom = 53.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Dash"
-align = 1
-valign = 1
 
-[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow5" instance=ExtResource( 1 )]
+[node name="RemapButton" parent="RemapButtonGroup/ActionsList/ActionRemapRow5" instance=ExtResource( "1" )]
 offset_left = 162.0
 offset_right = 320.0
 offset_bottom = 53.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-group = SubResource( 1 )
 action = "dash"

--- a/gui/input_mapping/README.md
+++ b/gui/input_mapping/README.md
@@ -8,7 +8,7 @@ A demo showing how to build an input key remapping screen.
 
 Language: GDScript
 
-Renderer: GLES 2
+Renderer: Vulkan Mobile
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/131
 

--- a/gui/input_mapping/icon.png.import
+++ b/gui/input_mapping/icon.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture2D"
-path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+type="CompressedTexture2D"
+uid="uid://bn2conid84pie"
+path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,23 @@ metadata={
 [deps]
 
 source_file="res://icon.png"
-dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/gui/input_mapping/project.godot
+++ b/gui/input_mapping/project.godot
@@ -6,7 +6,7 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
+config_version=5
 
 [application]
 
@@ -18,13 +18,13 @@ config/description="A demo showing how to build an input key remapping screen.
   after the project is restarted."
 run/main_scene="res://InputRemapMenu.tscn"
 config/icon="res://icon.png"
+config/features=PackedStringArray("4.0")
 
 [display]
 
-window/size/width=640
-window/size/height=480
-window/dpi/allow_hidpi=true
-window/stretch/mode="2d"
+window/size/viewport_width=640
+window/size/viewport_height=480
+window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 
 [gdnative]
@@ -61,6 +61,4 @@ dash={
 
 [rendering]
 
-quality/driver/driver_name="GLES2"
-vram_compression/import_etc=true
-vram_compression/import_etc2=false
+vulkan/rendering/back_end=1


### PR DESCRIPTION
Edited the project settings to match the new Godot 4 standard and fixed
the script errors which were making it impossible to run this demo.

Now everything works properly for the 4.0-dev version.
Another check that can be added for #697.

I really hope that I'm doing a good job helping to make all these demo's run properly on Godot 4,
if I'm doing anything wrong, please say so I can improve myself.