### PR TITLE
Pause demo: Showcase new pause features in Godot 4.0

### DIFF
--- a/misc/pause/process_mode.gd
+++ b/misc/pause/process_mode.gd
@@ -1,0 +1,7 @@
+extends OptionButton
+
+@onready var cube_animation = $"../../AnimationPlayer"
+
+
+func _on_option_button_item_selected(index):
+	cube_animation.process_mode = index

--- a/misc/pause/project.godot
+++ b/misc/pause/project.godot
@@ -28,6 +28,7 @@ singletons=[]
 [rendering]
 
 vulkan/rendering/back_end=1
+environment/defaults/default_clear_color=Color(0.133333, 0.133333, 0.133333, 1)
 quality/intended_usage/framebuffer_allocation=3
 vram_compression/import_etc=true
 vram_compression/import_etc2=false

--- a/misc/pause/spinpause.tscn
+++ b/misc/pause/spinpause.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://cwa8rglnrg4yb"]
+[gd_scene load_steps=5 format=3 uid="uid://cwa8rglnrg4yb"]
 
 [ext_resource type="Script" path="res://pause_button.gd" id="1"]
+[ext_resource type="Script" path="res://process_mode.gd" id="2_0dpmq"]
 
 [sub_resource type="BoxMesh" id="1"]
 
@@ -50,3 +51,44 @@ offset_bottom = 200.0
 toggle_mode = true
 text = "Pause"
 script = ExtResource( "1" )
+
+[node name="ProcessMode" type="HBoxContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -185.502
+offset_top = -250.0
+offset_right = 185.503
+offset_bottom = -210.0
+theme_override_constants/separation = 12
+
+[node name="Label" type="Label" parent="ProcessMode"]
+offset_top = 7.0
+offset_right = 151.0
+offset_bottom = 33.0
+text = "Cube Process Mode"
+
+[node name="OptionButton" type="OptionButton" parent="ProcessMode"]
+minimum_size = Vector2(200, 0)
+offset_left = 163.0
+offset_right = 363.0
+offset_bottom = 40.0
+item_count = 5
+selected = 0
+popup/item_0/text = "Inherit"
+popup/item_0/id = 0
+popup/item_1/text = "Pausable"
+popup/item_1/id = 1
+popup/item_2/text = "When Paused"
+popup/item_2/id = 2
+popup/item_3/text = "Always"
+popup/item_3/id = 3
+popup/item_4/text = "Disabled (Never)"
+popup/item_4/id = 4
+script = ExtResource( "2_0dpmq" )
+__meta__ = {
+"_edit_use_custom_anchors": false
+}
+
+[connection signal="item_selected" from="ProcessMode/OptionButton" to="ProcessMode/OptionButton" method="_on_option_button_item_selected"]


### PR DESCRIPTION
This adds an OptionButton to change the ProcessMode of the cube's AnimationPlayer to showcase new pause features in 4.0.