### PR TITLE
Revert accidental change in camera script in Global illumination demo

### DIFF
--- a/3d/global_illumination/camera.gd
+++ b/3d/global_illumination/camera.gd
@@ -29,9 +29,9 @@ func _input(event):
 
 func _process(delta):
 	var motion = Vector3(
-			Input.get_action_strength("move_right") - Input.get_action_strength("move_left"),
+			Input.get_axis(&"move_left", &"move_right"),
 			0,
-			Input.get_action_strength("move_back") - Input.get_action_strength("move_forward")
+			Input.get_axis(&"move_forward", &"move_back")
 	)
 
 	# Normalize motion to prevent diagonal movement from being

--- a/3d/global_illumination/test.tscn
+++ b/3d/global_illumination/test.tscn
@@ -121,6 +121,8 @@ offset_top = 16.0
 offset_right = 263.0
 offset_bottom = 42.0
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_x = 1
+theme_override_constants/shadow_offset_y = 1
 text = "Global illumination: None (Fastest)"
 
 [node name="ReflectionProbeMode" type="Label" parent="."]
@@ -129,6 +131,8 @@ offset_top = 48.0
 offset_right = 148.0
 offset_bottom = 74.0
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_x = 1
+theme_override_constants/shadow_offset_y = 1
 text = "Reflection probe: Disabled - Using environment, VoxelGI or SDFGI reflections (Fast)"
 
 [node name="SSILMode" type="Label" parent="."]
@@ -137,6 +141,8 @@ offset_top = 80.0
 offset_right = 365.0
 offset_bottom = 106.0
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_x = 1
+theme_override_constants/shadow_offset_y = 1
 text = "Screen-space lighting effects: Disabled (Fast)"
 
 [node name="Label" type="Label" parent="."]
@@ -147,6 +153,8 @@ offset_top = -120.0
 offset_right = 537.0
 offset_bottom = -16.0
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_x = 1
+theme_override_constants/shadow_offset_y = 1
 text = "Space: Cycle between GI modes
 R: Toggle reflection probe
 F: Cycle between screen-space lighting effect modes


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-demo-projects/pull/718.

This also tweaks the font shadow appearance for better visibility.