### PR TITLE
Making Demo Dodge the Creeps ready for 4.0-dev

### DIFF
--- a/2d/dodge_the_creeps/README.md
+++ b/2d/dodge_the_creeps/README.md
@@ -10,7 +10,7 @@ consider following the tutorial in the documentation.
 
 Language: GDScript
 
-Renderer: GLES 3 (particles are not available in GLES 2)
+Renderer: Vulkan Mobile
 
 Note: There is a C# version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/mono/dodge_the_creeps).
 

--- a/2d/dodge_the_creeps/art/enemyFlyingAlt_1.png.import
+++ b/2d/dodge_the_creeps/art/enemyFlyingAlt_1.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/art/enemyFlyingAlt_2.png.import
+++ b/2d/dodge_the_creeps/art/enemyFlyingAlt_2.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/art/enemySwimming_1.png.import
+++ b/2d/dodge_the_creeps/art/enemySwimming_1.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/art/enemySwimming_2.png.import
+++ b/2d/dodge_the_creeps/art/enemySwimming_2.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/art/enemyWalking_1.png.import
+++ b/2d/dodge_the_creeps/art/enemyWalking_1.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/art/enemyWalking_2.png.import
+++ b/2d/dodge_the_creeps/art/enemyWalking_2.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/art/playerGrey_up1.png.import
+++ b/2d/dodge_the_creeps/art/playerGrey_up1.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/art/playerGrey_up2.png.import
+++ b/2d/dodge_the_creeps/art/playerGrey_up2.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/art/playerGrey_walk1.png.import
+++ b/2d/dodge_the_creeps/art/playerGrey_walk1.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/art/playerGrey_walk2.png.import
+++ b/2d/dodge_the_creeps/art/playerGrey_walk2.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/fonts/Xolonium-Regular.ttf.import
+++ b/2d/dodge_the_creeps/fonts/Xolonium-Regular.ttf.import
@@ -13,6 +13,7 @@ dest_files=["res://.godot/imported/Xolonium-Regular.ttf-bc2981e3069cff4c34dd7c8e
 [params]
 
 antialiased=true
+generate_mipmaps=false
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/2d/dodge_the_creeps/icon.png.import
+++ b/2d/dodge_the_creeps/icon.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -21,13 +21,17 @@ run/main_scene="res://Main.tscn"
 config/icon="res://icon.png"
 config/features=PackedStringArray("4.0")
 
+[debug]
+
+gdscript/warnings/redundant_await=false
+
 [display]
 
 window/size/viewport_width=480
 window/size/viewport_height=720
-window/stretch/mode="2d"
-window/size/width=480
-window/size/height=720
+window/size/window_width_override=480
+window/size/window_height_override=720
+window/stretch/mode="canvas_items"
 
 [input]
 
@@ -68,3 +72,7 @@ start_game={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":16777221,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+
+[rendering]
+
+vulkan/rendering/back_end=1


### PR DESCRIPTION
Going through the demo's mentioned at: #697
to fix and prepare them for 4.0.
It was mentioned that there were minor bugs (errors printing in console), found non of that, only some logs about awaits not being needed (they were needed). Everything works again now and stretch_mode set to canvas_items.