### PR TITLE
[3.x] GUI Input Mapping Demo Persistent Key Mapping- Fixes #629

### DIFF
--- a/gui/input_mapping/ActionRemapButton.gd
+++ b/gui/input_mapping/ActionRemapButton.gd
@@ -25,8 +25,12 @@ func _unhandled_key_input(event):
 
 
 func remap_action_to(event):
+	# We first change the event in this game instance.
 	InputMap.action_erase_events(action)
 	InputMap.action_add_event(action, event)
+	# And then save it to the keymaps file
+	KeyPersistence.keymaps[action] = event
+	KeyPersistence.save_keymap()
 	text = "%s Key" % event.as_text()
 
 

--- a/gui/input_mapping/KeyPersistence.gd
+++ b/gui/input_mapping/KeyPersistence.gd
@@ -1,0 +1,45 @@
+# This is an autoload (singleton) which will save
+# the key maps in a simple way through a dictionary.
+extends Node
+
+const keymaps_path = "user://keymaps.dat"
+var keymaps: Dictionary
+
+
+func _ready() -> void:
+	# First we create the keymap dictionary on startup with all
+	# the keymap actions we have.
+	for action in InputMap.get_actions():
+		keymaps[action] = InputMap.get_action_list(action)[0]
+	load_keymap()
+
+
+func load_keymap() -> void:
+	var file := File.new()
+	if not file.file_exists(keymaps_path):
+		save_keymap() # There is no save file yet, so let's create one.
+		return
+	#warning-ignore:return_value_discarded
+	file.open(keymaps_path, File.READ)
+	var temp_keymap: Dictionary = file.get_var(true)
+	file.close()
+	# We don't just replace the keymaps dictionary, because if you
+	# updated your game and removed/added keymaps, the data of this
+	# save file may have invalid actions. So we check one by one to
+	# make sure that the keymap dictionary really has all current actions.
+	for action in keymaps.keys():
+		if temp_keymap.has(action):
+			keymaps[action] = temp_keymap[action]
+			# Whilst setting the keymap dictionary, we also set the
+			# correct InputMap event
+			InputMap.action_erase_events(action)
+			InputMap.action_add_event(action, keymaps[action])
+
+
+func save_keymap() -> void:
+	# For saving the keymap, we just save the entire dictionary as a var.
+	var file := File.new()
+	#warning-ignore:return_value_discarded
+	file.open(keymaps_path, File.WRITE)
+	file.store_var(keymaps, true)
+	file.close()

--- a/gui/input_mapping/project.godot
+++ b/gui/input_mapping/project.godot
@@ -19,6 +19,10 @@ config/description="A demo showing how to build an input key remapping screen.
 run/main_scene="res://InputRemapMenu.tscn"
 config/icon="res://icon.png"
 
+[autoload]
+
+KeyPersistence="*res://KeyPersistence.gd"
+
 [display]
 
 window/size/width=640


### PR DESCRIPTION
This pull request fixes https://github.com/godotengine/godot-demo-projects/issues/629 . Now this demo saves the input keys through saving a dictionary. I hope the comments which I made make sense and that they are helpful.

I could not fix the wrong rebase on #731 so I closed that one.