### PR TITLE
Update loading in a thread demo for 4.0

### DIFF
--- a/loading/threads/README.md
+++ b/loading/threads/README.md
@@ -4,7 +4,7 @@ An example using a thread to load an image.
 
 Language: GDScript
 
-Renderer: GLES 2
+Renderer: Vulkan Mobile
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/144
 

--- a/loading/threads/mona.png.import
+++ b/loading/threads/mona.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture2D"
-path="res://.godot/imported/mona.png-a5ce9963ac8c7ef765aeb0f5428366a9.stex"
+type="CompressedTexture2D"
+uid="uid://bcy2b4hw0bvj2"
+path="res://.godot/imported/mona.png-a5ce9963ac8c7ef765aeb0f5428366a9.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,24 @@ metadata={
 [deps]
 
 source_file="res://mona.png"
-dest_files=["res://.godot/imported/mona.png-a5ce9963ac8c7ef765aeb0f5428366a9.stex"]
+dest_files=["res://.godot/imported/mona.png-a5ce9963ac8c7ef765aeb0f5428366a9.ctex"]
 
 [params]
 
 compress/mode=0
 compress/lossy_quality=0.7
-compress/hdr_mode=0
+compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/loading/threads/project.godot
+++ b/loading/threads/project.godot
@@ -6,30 +6,15 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
+config_version=5
 
 [application]
 
 config/name="Loading in a Thread"
 config/description="An example using a thread to load an image."
 run/main_scene="res://thread.tscn"
-
-[display]
-
-window/dpi/allow_hidpi=true
-window/stretch/mode="2d"
-window/stretch/aspect="expand"
-
-[gdnative]
-
-singletons=[]
-
-[memory]
-
-multithread/thread_rid_pool_prealloc=60
+config/features=PackedStringArray("4.0")
 
 [rendering]
 
-quality/driver/driver_name="GLES2"
-vram_compression/import_etc=true
-vram_compression/import_etc2=false
+vulkan/rendering/back_end=1

--- a/loading/threads/thread.gd
+++ b/loading/threads/thread.gd
@@ -1,28 +1,39 @@
 extends Node2D
 
-var thread = Thread.new()
+var thread: Thread
 
-# This function runs in a thread!
-# Threads always take one userdata argument
-func _bg_load(path):
+func _on_load_pressed():
+	if is_instance_valid(thread) and thread.is_started():
+		# If a thread is already running, let it finish before we start another.
+		thread.wait_to_finish()
+	thread = Thread.new()
+	print("START THREAD!")
+	# Our method needs an argument, so we pass it using bind().
+	thread.start(_bg_load.bind("res://mona.png"))
+
+
+func _bg_load(path: String):
 	print("THREAD FUNC!")
-	# Load the resource
-	var tex = ResourceLoader.load(path)
-	# Call _bg_load_done on main thread
-	call_deferred("_bg_load_done")
-	return tex # return it
+	var tex = load(path)
+	# call_deferred() tells the main thread to call a method during idle time.
+	# Our method operates on nodes currently in the tree, so it isn't safe to
+	# call directly from another thread.
+	_bg_load_done.call_deferred()
+	return tex
 
 
 func _bg_load_done():
-	# Wait for the thread to complete, get the returned value
+	# Wait for the thread to complete, and get the returned value.
 	var tex = thread.wait_to_finish()
-	# Set to the sprite
-	get_node(^"Sprite2D").set_texture(tex)
+	print("THREAD FINISHED!")
+	$Sprite2D.set_texture(tex)
+	# We're done with the thread now, so we can free it.
+	thread = null # Threads are reference counted, so this is how we free it.
 
 
-func _on_load_pressed():
-	if thread.is_active():
-		# Already working
-		return
-	print("START THREAD!")
-	thread.start(self, "_bg_load", "res://mona.png")
+func _exit_tree():
+	# You should always wait for a thread to finish before letting it get freed!
+	# It might not clean up correctly if you don't.
+	if is_instance_valid(thread) and thread.is_started():
+		thread.wait_to_finish()
+		thread = null

--- a/loading/threads/thread.tscn
+++ b/loading/threads/thread.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=2 format=3 uid="uid://df1dmjx4ny0gd"]
 
-[ext_resource path="res://thread.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://thread.gd" id="1"]
 
 [node name="Thread" type="Node2D"]
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="Load" type="Button" parent="."]
 offset_left = 432.0
@@ -13,9 +13,6 @@ offset_bottom = 114.0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 text = "Load in Thread"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(494, 336)


### PR DESCRIPTION
This updates and improves the simple background loading demo (the one that doesn't use `load_interactive`). On the list in #697.
In addition to updating for 4.0, I made the following additional changes:

- Make the comments more clear and informative. I removed a few that I thought were just stating the obvious (like one after `return tex` that just says it returns something, or the one that says `ResourceLoader.load` loads a resource). Most of them I kept and just edited for clarity.
- Don't reuse `Thread` objects. According to the documentation, you shouldn't do this, so the demo now waits for the previous thread to finish (if there is one) and makes a new one.
- Add an `_exit_tree` method that makes sure the thread is finished, then frees it.
- Change the order of the methods in the script to match the order they are called, to make it easier to follow. They are now ordered as `_on_load_pressed`, `_bg_load`, `_bg_load_done`, `_exit_tree`.

Some of these changes are subjective, so let me know what you think. The last one is technically in violation of the GDScript style guide, since it puts a built-in virtual method after the private methods, but I think it improves readability enough to be worth it. I'm also not sure why the documentation says not to reuse thread objects, since doing so seems to work just fine.