### PR TITLE
Docs: 2D Platformer - Update Pause Mode Comments

### DIFF
--- a/2d/platformer/src/Main/Game.gd
+++ b/2d/platformer/src/Main/Game.gd
@@ -25,10 +25,18 @@ func _unhandled_input(event):
 	if event.is_action_pressed("toggle_fullscreen"):
 		OS.window_fullscreen = not OS.window_fullscreen
 		get_tree().set_input_as_handled()
-	# The GlobalControls node, in the Stage scene, is set to process even
-	# when the game is paused, so this code keeps running.
-	# To see that, select GlobalControls, and scroll down to the Pause category
-	# in the inspector.
+	# The desired behavior is when pausing is to pause the gamplay,
+	# but the Pause Menu should continue to process.
+	# To achieve this, the "Pause Mode" field is used on nodes in the Game scene:
+	# 1. The root node in the Game scene is set to process even when the game is paused
+	#   (via Pause Mode = Process), so this Game script keeps running in order to open/close
+	#   the Pause Menu when the player presses the "toggle_pause" action.
+	# 2. The Level scene has Pause Mode = Stop (and its child Player scene has Pause Mode = Inherit),
+	#   so the gameplay will stop.
+	# 3. The InterfaceLayer node has Pause Mode = Inherit, with its child PauseMenu scene having
+	#   Pause Mode = Process, so it will continue to process even when the game is paused.
+	# To see the Pause Mode of any node, select the node and you'll see "Pause Mode" near the bottom
+	# of the Inspector under "Node" fields.
 	elif event.is_action_pressed("toggle_pause"):
 		var tree = get_tree()
 		tree.paused = not tree.paused


### PR DESCRIPTION
I believe this comment got out-of-date (based on the fact that the `Stage` scene seems like something that was in an older version of the demo: https://github.com/godotengine/godot-demo-projects/blob/81441c42b79e38e54c2bc38acee3205f22431738/2d/platformer/Stage.tscn), so updated the comment to reflect the current state of the demo, along with some other information that I thought a developer might find helpful.