### PR TITLE
Improve 3D global illumination demo (3.x)

### DIFF
--- a/3d/global_illumination/default_env.tres
+++ b/3d/global_illumination/default_env.tres
@@ -9,5 +9,6 @@ background_mode = 2
 background_sky = SubResource( 1 )
 fog_sun_amount = 1.0
 fog_depth_begin = 0.0
-tonemap_mode = 2
+tonemap_mode = 4
 tonemap_white = 6.0
+ssao_intensity = 0.5

--- a/3d/global_illumination/project.godot
+++ b/3d/global_illumination/project.godot
@@ -27,9 +27,9 @@ cycle_gi_mode={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
-toggle_reflection_probe={
+cycle_reflection_probe_mode={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":82,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":82,"unicode":0,"echo":false,"script":null)
  ]
 }
 move_forward={
@@ -62,6 +62,11 @@ toggle_mouse_capture={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":16777217,"unicode":0,"echo":false,"script":null)
  ]
 }
+toggle_ssao={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":70,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [physics]
 
@@ -70,4 +75,7 @@ common/enable_pause_aware_picking=true
 [rendering]
 
 quality/shadows/filter_mode=2
+quality/filters/use_fxaa=true
+quality/filters/use_debanding=true
 environment/default_environment="res://default_env.tres"
+quality/filters/use_debanding.mobile=false


### PR DESCRIPTION
3.x version of https://github.com/godotengine/godot-demo-projects/pull/758.

- Add reflection probe mode toggle to use Always update mode (slower, but updates in real-time).
- Add SSAO toggle (with halved SSAO intensity to look better in the test scene).
- Tweak DirectionalLight shadow bias parameters to reduce shadow peter panning.
- Enable FXAA and debanding for a better appearance. Debanding is disabled on mobile due to known issues.