### PR TITLE
Check for obstacle before teleporting player in Grid-based Pathfinding with Astar

### DIFF
--- a/2d/navigation_astar/character.gd
+++ b/2d/navigation_astar/character.gd
@@ -33,7 +33,7 @@ func _process(_delta):
 func _unhandled_input(event):
 	if event.is_action_pressed("click"):
 		var global_mouse_pos = get_global_mouse_position()
-		if Input.is_key_pressed(KEY_SHIFT):
+		if Input.is_key_pressed(KEY_SHIFT) and get_parent().get_node("TileMap").check_start_position(global_mouse_pos):
 			global_position = global_mouse_pos
 		else:
 			_target_position = global_mouse_pos

--- a/2d/navigation_astar/pathfind_astar.gd
+++ b/2d/navigation_astar/pathfind_astar.gd
@@ -130,6 +130,7 @@ func check_start_position(world_start):
 	var start_point = world_to_map(world_start)
 	if start_point in obstacles:
 		return false
+
 	return true
 
 

--- a/2d/navigation_astar/pathfind_astar.gd
+++ b/2d/navigation_astar/pathfind_astar.gd
@@ -126,6 +126,13 @@ func is_outside_map_bounds(point):
 	return point.x < 0 or point.y < 0 or point.x >= map_size.x or point.y >= map_size.y
 
 
+func check_start_position(world_start):
+	var start_point = world_to_map(world_start)
+	if start_point in obstacles:
+		return false
+	return true
+
+
 func get_astar_path(world_start, world_end):
 	self.path_start_position = world_to_map(world_start)
 	self.path_end_position = world_to_map(world_end)


### PR DESCRIPTION
Checks for obstacles before moving character when shift-clicking. Better matches normal clicking behavior for clicking on obstacles.

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest Godot version of the branch you're submitting to.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
