### PR TITLE
Fix bomber demo in godot 4.0 beta 1

### DIFF
--- a/networking/multiplayer_bomber/brickfloor.png.import
+++ b/networking/multiplayer_bomber/brickfloor.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/networking/multiplayer_bomber/charwalk.png.import
+++ b/networking/multiplayer_bomber/charwalk.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/networking/multiplayer_bomber/explosion.png.import
+++ b/networking/multiplayer_bomber/explosion.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/networking/multiplayer_bomber/icon.png.import
+++ b/networking/multiplayer_bomber/icon.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/networking/multiplayer_bomber/lobby.tscn
+++ b/networking/multiplayer_bomber/lobby.tscn
@@ -3,14 +3,20 @@
 [ext_resource type="Script" path="res://lobby.gd" id="1"]
 
 [node name="Lobby" type="Control"]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 2
 size_flags_vertical = 2
-script = ExtResource( "1" )
+script = ExtResource("1")
 
 [node name="Players" type="Panel" parent="."]
 visible = false
+layout_mode = 1
+anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -19,10 +25,13 @@ offset_left = -126.0
 offset_top = -177.5
 offset_right = 126.0
 offset_bottom = 177.5
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 2
 size_flags_vertical = 2
 
 [node name="Label" type="Label" parent="Players"]
+layout_mode = 0
 offset_left = 26.0
 offset_top = 18.0
 offset_right = 142.0
@@ -32,6 +41,7 @@ size_flags_vertical = 0
 text = "Awaiting Players..."
 
 [node name="Start" type="Button" parent="Players"]
+layout_mode = 0
 offset_left = 68.0
 offset_top = 307.0
 offset_right = 193.0
@@ -41,6 +51,7 @@ size_flags_vertical = 2
 text = "START!"
 
 [node name="List" type="ItemList" parent="Players"]
+layout_mode = 0
 offset_left = 25.0
 offset_top = 37.0
 offset_right = 229.0
@@ -49,6 +60,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 2
 
 [node name="PortForward" type="Label" parent="Players"]
+layout_mode = 0
 offset_left = -124.0
 offset_top = 375.0
 offset_right = 128.0
@@ -59,6 +71,7 @@ make sure the port 10567 in UDP
 is forwarded on your router."
 
 [node name="FindPublicIP" type="LinkButton" parent="Players"]
+layout_mode = 0
 offset_left = 168.0
 offset_top = 393.5
 offset_right = 341.0
@@ -66,6 +79,8 @@ offset_bottom = 407.5
 text = "Find your public IP address"
 
 [node name="Connect" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -74,10 +89,13 @@ offset_left = -138.5
 offset_top = -83.5
 offset_right = 138.5
 offset_bottom = 83.5
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 2
 size_flags_vertical = 2
 
 [node name="NameLabel" type="Label" parent="Connect"]
+layout_mode = 0
 offset_left = 14.0
 offset_top = 11.0
 offset_right = 56.0
@@ -87,6 +105,7 @@ size_flags_vertical = 0
 text = "Name:"
 
 [node name="Name" type="LineEdit" parent="Connect"]
+layout_mode = 0
 offset_left = 17.0
 offset_top = 30.0
 offset_right = 173.0
@@ -96,6 +115,7 @@ size_flags_vertical = 2
 text = "The Warrior"
 
 [node name="IPLabel" type="Label" parent="Connect"]
+layout_mode = 0
 offset_left = 15.0
 offset_top = 66.0
 offset_right = 57.0
@@ -106,6 +126,7 @@ theme_override_font_sizes/font_size = 16
 text = "IP:"
 
 [node name="IPAddress" type="LineEdit" parent="Connect"]
+layout_mode = 0
 offset_left = 17.0
 offset_top = 85.0
 offset_right = 173.0
@@ -115,6 +136,7 @@ size_flags_vertical = 2
 text = "127.0.0.1"
 
 [node name="Host" type="Button" parent="Connect"]
+layout_mode = 0
 offset_left = 181.0
 offset_top = 31.0
 offset_right = 246.0
@@ -124,6 +146,7 @@ size_flags_vertical = 2
 text = "Host"
 
 [node name="Join" type="Button" parent="Connect"]
+layout_mode = 0
 offset_left = 181.0
 offset_top = 87.0
 offset_right = 246.0
@@ -133,6 +156,7 @@ size_flags_vertical = 2
 text = "Join"
 
 [node name="ErrorLabel" type="Label" parent="Connect"]
+layout_mode = 0
 offset_left = 15.0
 offset_top = 125.0
 offset_right = 257.0

--- a/networking/multiplayer_bomber/montserrat.otf.import
+++ b/networking/multiplayer_bomber/montserrat.otf.import
@@ -1,7 +1,7 @@
 [remap]
 
 importer="font_data_dynamic"
-type="FontData"
+type="FontFile"
 uid="uid://dksjmw4cy83s4"
 path="res://.godot/imported/montserrat.otf-0d875bde8933edfaf65407b0d9da84e5.fontdata"
 
@@ -12,22 +12,21 @@ dest_files=["res://.godot/imported/montserrat.otf-0d875bde8933edfaf65407b0d9da84
 
 [params]
 
-antialiased=true
+Rendering=null
+antialiasing=1
+generate_mipmaps=false
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
-embolden=0.0
-transform=Transform2D(1, 0, 0, 1, 0, 0)
 oversampling=0.0
+Fallbacks=null
+fallbacks=[]
+Compress=null
 compress=true
-opentype_feature_overrides={}
-preload/char_ranges=PackedStringArray()
-preload/glyph_ranges=PackedStringArray()
-preload/configurations=PackedStringArray()
-support_overrides/language_enabled=PackedStringArray()
-support_overrides/language_disabled=PackedStringArray()
-support_overrides/script_enabled=PackedStringArray()
-support_overrides/script_disabled=PackedStringArray()
+preload=[]
+language_support={}
+script_support={}
+opentype_features={}

--- a/networking/multiplayer_bomber/player.tscn
+++ b/networking/multiplayer_bomber/player.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://player.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://bsqovikudjr0q" path="res://charwalk.png" id="2"]
-[ext_resource type="FontData" uid="uid://dksjmw4cy83s4" path="res://montserrat.otf" id="3"]
+[ext_resource type="FontFile" uid="uid://dksjmw4cy83s4" path="res://montserrat.otf" id="3_snwca"]
 [ext_resource type="Script" path="res://player_controls.gd" id="4_k1vfr"]
 
 [sub_resource type="CircleShape2D" id="1"]
@@ -132,10 +132,17 @@ tracks/0/keys = {
 "values": [2, 6, 10, 14]
 }
 
-[sub_resource type="Font" id="8"]
-data/0 = ExtResource( "3" )
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_2o4y4"]
+_data = {
+"standing": SubResource("2"),
+"stunned": SubResource("3"),
+"walk_down": SubResource("4"),
+"walk_left": SubResource("5"),
+"walk_right": SubResource("6"),
+"walk_up": SubResource("7")
+}
 
-[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_xm6wv"]
+[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_sj3oc"]
 properties/0/path = NodePath(".:synced_position")
 properties/0/spawn = true
 properties/0/sync = true
@@ -143,7 +150,7 @@ properties/1/path = NodePath("label:text")
 properties/1/spawn = true
 properties/1/sync = false
 
-[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_kkxsa"]
+[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_e4xr0"]
 properties/0/path = NodePath(".:motion")
 properties/0/spawn = true
 properties/0/sync = true
@@ -153,26 +160,23 @@ properties/1/sync = true
 
 [node name="player" type="CharacterBody2D"]
 motion_mode = 1
-script = ExtResource( "1" )
+script = ExtResource("1")
 
 [node name="sprite" type="Sprite2D" parent="."]
 position = Vector2(0.0750351, 6.23615)
 rotation = -6.28319
-texture = ExtResource( "2" )
+texture = ExtResource("2")
 offset = Vector2(-0.0750351, -6.23615)
 hframes = 4
 vframes = 4
 
 [node name="shape" type="CollisionShape2D" parent="."]
-shape = SubResource( "1" )
+shape = SubResource("1")
 
 [node name="anim" type="AnimationPlayer" parent="."]
-anims/standing = SubResource( "2" )
-anims/stunned = SubResource( "3" )
-anims/walk_down = SubResource( "4" )
-anims/walk_left = SubResource( "5" )
-anims/walk_right = SubResource( "6" )
-anims/walk_up = SubResource( "7" )
+libraries = {
+"": SubResource("AnimationLibrary_2o4y4")
+}
 
 [node name="label" type="Label" parent="."]
 offset_left = -82.0
@@ -181,18 +185,16 @@ offset_right = 85.0
 offset_bottom = -14.0
 size_flags_horizontal = 2
 size_flags_vertical = 0
-theme_override_fonts/font = SubResource( "8" )
+theme_override_fonts/font = ExtResource("3_snwca")
 theme_override_font_sizes/font_size = 16
 text = "Player 1"
 horizontal_alignment = 1
 
 [node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="."]
-root_path = NodePath("..")
-resource = SubResource( "SceneReplicationConfig_xm6wv" )
+replication_config = SubResource("SceneReplicationConfig_sj3oc")
 
 [node name="Inputs" type="Node" parent="."]
-script = ExtResource( "4_k1vfr" )
+script = ExtResource("4_k1vfr")
 
 [node name="InputsSync" type="MultiplayerSynchronizer" parent="Inputs"]
-root_path = NodePath("..")
-resource = SubResource( "SceneReplicationConfig_kkxsa" )
+replication_config = SubResource("SceneReplicationConfig_e4xr0")

--- a/networking/multiplayer_bomber/project.godot
+++ b/networking/multiplayer_bomber/project.godot
@@ -15,8 +15,8 @@ config/description="A multiplayer implementation of the classical bomberman game
 One of the players should press 'host', while the other
 should type in his address and press 'play'."
 run/main_scene="res://lobby.tscn"
-config/icon="res://icon.png"
 config/features=PackedStringArray("4.0")
+config/icon="res://icon.png"
 
 [autoload]
 
@@ -49,42 +49,42 @@ gen_mipmaps=false
 
 move_down={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":83,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":16777234,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":83,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":16777234,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 move_left={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":65,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":16777231,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":65,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":16777231,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 move_right={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":68,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":16777233,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":68,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":16777233,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 move_up={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":87,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":16777232,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":87,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":16777232,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 set_bomb={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":1,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"pressed":false,"double_click":false,"script":null)
+, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"pressed":false,"double_click":false,"script":null)
 ]
 }
 

--- a/networking/multiplayer_bomber/rock_bit.png.import
+++ b/networking/multiplayer_bomber/rock_bit.png.import
@@ -29,5 +29,6 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
 process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1

--- a/networking/multiplayer_bomber/score.gd
+++ b/networking/multiplayer_bomber/score.gd
@@ -28,9 +28,7 @@ func add_player(id, new_player_name):
 	l.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	l.set_text(new_player_name + "\n" + "0")
 	l.set_h_size_flags(SIZE_EXPAND_FILL)
-	var font = Font.new()
-	font.add_data(preload("res://montserrat.otf"))
-	l.set("custom_fonts/font", font)
+	l.set("custom_fonts/font", preload("res://montserrat.otf"))
 	l.set("custom_font_size/font_size", 18)
 	add_child(l)
 

--- a/networking/multiplayer_bomber/tileset.tres
+++ b/networking/multiplayer_bomber/tileset.tres
@@ -3,7 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://bdomqql6y50po" path="res://brickfloor.png" id="1"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_qhkfp"]
-texture = ExtResource( "1" )
+texture = ExtResource("1")
 texture_region_size = Vector2i(48, 48)
 0:0/0 = 0
 0:0/0/physics_layer_0/linear_velocity = Vector2(0, 0)
@@ -16,4 +16,4 @@ texture_region_size = Vector2i(48, 48)
 [resource]
 tile_size = Vector2i(48, 48)
 physics_layer_0/collision_layer = 1
-sources/0 = SubResource( "TileSetAtlasSource_qhkfp" )
+sources/0 = SubResource("TileSetAtlasSource_qhkfp")

--- a/networking/multiplayer_bomber/world.tscn
+++ b/networking/multiplayer_bomber/world.tscn
@@ -1,271 +1,267 @@
-[gd_scene load_steps=8 format=3 uid="uid://by3f5o7dyoqx4"]
+[gd_scene load_steps=6 format=3 uid="uid://by3f5o7dyoqx4"]
 
 [ext_resource type="TileSet" uid="uid://do2l6lpuotti8" path="res://tileset.tres" id="1"]
 [ext_resource type="PackedScene" uid="uid://bao3yernlglws" path="res://rock.tscn" id="2"]
 [ext_resource type="Script" path="res://score.gd" id="3"]
-[ext_resource type="FontData" uid="uid://dksjmw4cy83s4" path="res://montserrat.otf" id="4"]
-[ext_resource type="PackedScene" uid="uid://dviwgv2ty8v6u" path="res://player.tscn" id="5_yef4r"]
+[ext_resource type="FontFile" uid="uid://dksjmw4cy83s4" path="res://montserrat.otf" id="4_e2flb"]
 [ext_resource type="Script" path="res://bomb_spawner.gd" id="6_ac5ja"]
-
-[sub_resource type="Font" id="1"]
-data/0 = ExtResource( "4" )
 
 [node name="World" type="Node2D"]
 
 [node name="TileMap" type="TileMap" parent="."]
-tile_set = ExtResource( "1" )
+tile_set = ExtResource("1")
 cell_quadrant_size = 48
 format = 2
 layer_0/tile_data = PackedInt32Array(196598, 0, 0, 0, 0, 0, 65536, 0, 0, 131072, 0, 0, 196608, 0, 0, 262144, 0, 0, 327680, 0, 0, 393216, 0, 0, 458752, 0, 0, 524288, 0, 0, 589824, 0, 0, 655360, 0, 0, 720896, 0, 0, 786432, 0, 0, 1, 0, 0, 65537, 65536, 0, 131073, 65536, 0, 196609, 65536, 0, 262145, 65536, 0, 327681, 65536, 0, 393217, 65536, 0, 458753, 65536, 0, 524289, 65536, 0, 589825, 65536, 0, 655361, 65536, 0, 720897, 65536, 0, 786433, 0, 0, 2, 0, 0, 65538, 65536, 0, 131074, 0, 0, 196610, 65536, 0, 262146, 0, 0, 327682, 65536, 0, 393218, 0, 0, 458754, 65536, 0, 524290, 0, 0, 589826, 65536, 0, 655362, 0, 0, 720898, 65536, 0, 786434, 0, 0, 3, 0, 0, 65539, 65536, 0, 131075, 65536, 0, 196611, 65536, 0, 262147, 65536, 0, 327683, 65536, 0, 393219, 65536, 0, 458755, 65536, 0, 524291, 0, 0, 589827, 65536, 0, 655363, 65536, 0, 720899, 65536, 0, 786435, 0, 0, 4, 0, 0, 65540, 65536, 0, 131076, 0, 0, 196612, 0, 0, 262148, 0, 0, 327684, 65536, 0, 393220, 0, 0, 458756, 65536, 0, 524292, 0, 0, 589828, 65536, 0, 655364, 0, 0, 720900, 65536, 0, 786436, 0, 0, 5, 0, 0, 65541, 65536, 0, 131077, 65536, 0, 196613, 65536, 0, 262149, 65536, 0, 327685, 65536, 0, 393221, 65536, 0, 458757, 65536, 0, 524293, 65536, 0, 589829, 65536, 0, 655365, 65536, 0, 720901, 65536, 0, 786437, 0, 0, 6, 0, 0, 65542, 65536, 0, 131078, 0, 0, 196614, 65536, 0, 262150, 0, 0, 327686, 0, 0, 393222, 0, 0, 458758, 65536, 0, 524294, 0, 0, 589830, 65536, 0, 655366, 0, 0, 720902, 65536, 0, 786438, 0, 0, 7, 0, 0, 65543, 65536, 0, 131079, 65536, 0, 196615, 65536, 0, 262151, 65536, 0, 327687, 65536, 0, 393223, 65536, 0, 458759, 65536, 0, 524295, 65536, 0, 589831, 65536, 0, 655367, 65536, 0, 720903, 65536, 0, 786439, 0, 0, 8, 0, 0, 65544, 65536, 0, 131080, 0, 0, 196616, 65536, 0, 262152, 0, 0, 327688, 65536, 0, 393224, 0, 0, 458760, 65536, 0, 524296, 0, 0, 589832, 65536, 0, 655368, 0, 0, 720904, 65536, 0, 786440, 0, 0, 9, 0, 0, 65545, 65536, 0, 131081, 65536, 0, 196617, 65536, 0, 262153, 65536, 0, 327689, 65536, 0, 393225, 65536, 0, 458761, 65536, 0, 524297, 65536, 0, 589833, 65536, 0, 655369, 65536, 0, 720905, 65536, 0, 786441, 0, 0, 10, 0, 0, 65546, 65536, 0, 131082, 0, 0, 196618, 0, 0, 262154, 0, 0, 327690, 65536, 0, 393226, 0, 0, 458762, 65536, 0, 524298, 0, 0, 589834, 65536, 0, 655370, 0, 0, 720906, 65536, 0, 786442, 0, 0, 11, 0, 0, 65547, 65536, 0, 131083, 0, 0, 196619, 65536, 0, 262155, 65536, 0, 327691, 65536, 0, 393227, 65536, 0, 458763, 65536, 0, 524299, 65536, 0, 589835, 65536, 0, 655371, 65536, 0, 720907, 65536, 0, 786443, 0, 0, 12, 0, 0, 65548, 65536, 0, 131084, 0, 0, 196620, 65536, 0, 262156, 0, 0, 327692, 65536, 0, 393228, 0, 0, 458764, 65536, 0, 524300, 0, 0, 589836, 65536, 0, 655372, 0, 0, 720908, 65536, 0, 786444, 0, 0, 13, 0, 0, 65549, 65536, 0, 131085, 0, 0, 196621, 65536, 0, 262157, 65536, 0, 327693, 65536, 0, 393229, 0, 0, 458765, 65536, 0, 524301, 0, 0, 589837, 65536, 0, 655373, 65536, 0, 720909, 65536, 0, 786445, 0, 0, 14, 0, 0, 65550, 65536, 0, 131086, 0, 0, 196622, 65536, 0, 262158, 0, 0, 327694, 65536, 0, 393230, 0, 0, 458766, 65536, 0, 524302, 0, 0, 589838, 65536, 0, 655374, 0, 0, 720910, 65536, 0, 786446, 0, 0, 15, 0, 0, 65551, 65536, 0, 131087, 65536, 0, 196623, 65536, 0, 262159, 65536, 0, 327695, 65536, 0, 393231, 0, 0, 458767, 65536, 0, 524303, 65536, 0, 589839, 65536, 0, 655375, 65536, 0, 720911, 65536, 0, 786447, 0, 0, 16, 0, 0, 65552, 65536, 0, 131088, 0, 0, 196624, 65536, 0, 262160, 0, 0, 327696, 65536, 0, 393232, 0, 0, 458768, 65536, 0, 524304, 0, 0, 589840, 65536, 0, 655376, 0, 0, 720912, 65536, 0, 786448, 0, 0, 17, 0, 0, 65553, 65536, 0, 131089, 65536, 0, 196625, 65536, 0, 262161, 65536, 0, 327697, 65536, 0, 393233, 65536, 0, 458769, 65536, 0, 524305, 65536, 0, 589841, 65536, 0, 655377, 65536, 0, 720913, 65536, 0, 786449, 0, 0, 18, 0, 0, 65554, 65536, 0, 131090, 0, 0, 196626, 65536, 0, 262162, 0, 0, 327698, 0, 0, 393234, 0, 0, 458770, 65536, 0, 524306, 0, 0, 589842, 65536, 0, 655378, 0, 0, 720914, 65536, 0, 786450, 0, 0, 19, 0, 0, 65555, 65536, 0, 131091, 65536, 0, 196627, 65536, 0, 262163, 65536, 0, 327699, 65536, 0, 393235, 65536, 0, 458771, 65536, 0, 524307, 65536, 0, 589843, 65536, 0, 655379, 65536, 0, 720915, 65536, 0, 786451, 0, 0, 20, 0, 0, 65556, 0, 0, 131092, 0, 0, 196628, 0, 0, 262164, 0, 0, 327700, 0, 0, 393236, 0, 0, 458772, 0, 0, 524308, 0, 0, 589844, 0, 0, 655380, 0, 0, 720916, 0, 0, 786452, 0, 0, 21, 0, 0, 65557, 0, 0, 131093, 0, 0, 196629, 0, 0, 262165, 0, 0, 327701, 0, 0, 393237, 0, 0, 458773, 0, 0, 524309, 0, 0, 589845, 0, 0, 655381, 0, 0, 720917, 0, 0, 786453, 0, 0)
 
 [node name="SpawnPoints" type="Node2D" parent="."]
 
-[node name="0" type="Position2D" parent="SpawnPoints"]
+[node name="0" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(72, 72)
 
-[node name="1" type="Position2D" parent="SpawnPoints"]
+[node name="1" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(264, 216)
 
-[node name="2" type="Position2D" parent="SpawnPoints"]
+[node name="2" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(72, 456)
 
-[node name="3" type="Position2D" parent="SpawnPoints"]
+[node name="3" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(360, 552)
 
-[node name="4" type="Position2D" parent="SpawnPoints"]
+[node name="4" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(840, 360)
 
-[node name="5" type="Position2D" parent="SpawnPoints"]
+[node name="5" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(456, 264)
 
-[node name="6" type="Position2D" parent="SpawnPoints"]
+[node name="6" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(696, 264)
 
-[node name="7" type="Position2D" parent="SpawnPoints"]
+[node name="7" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(744, 456)
 
-[node name="8" type="Position2D" parent="SpawnPoints"]
+[node name="8" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(312, 456)
 
-[node name="9" type="Position2D" parent="SpawnPoints"]
+[node name="9" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(696, 72)
 
-[node name="10" type="Position2D" parent="SpawnPoints"]
+[node name="10" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(504, 72)
 
-[node name="11" type="Position2D" parent="SpawnPoints"]
+[node name="11" type="Marker2D" parent="SpawnPoints"]
 position = Vector2(936, 72)
 
 [node name="Rocks" type="Node2D" parent="."]
 
-[node name="Rock0" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock0" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(120, 72)
 
-[node name="Rock1" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock1" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(264, 168)
 
-[node name="Rock2" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock2" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(264, 120)
 
-[node name="Rock3" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock3" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(216, 72)
 
-[node name="Rock4" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock4" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(264, 72)
 
-[node name="Rock5" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock5" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(312, 72)
 
-[node name="Rock6" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock6" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(552, 168)
 
-[node name="Rock7" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock7" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(600, 168)
 
-[node name="Rock8" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock8" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(552, 216)
 
-[node name="Rock9" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock9" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(264, 312)
 
-[node name="Rock10" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock10" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(120, 360)
 
-[node name="Rock11" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock11" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(168, 360)
 
-[node name="Rock12" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock12" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(216, 360)
 
-[node name="Rock13" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock13" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(120, 264)
 
-[node name="Rock14" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock14" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(168, 216)
 
-[node name="Rock15" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock15" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(72, 360)
 
-[node name="Rock16" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock16" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(72, 312)
 
-[node name="Rock17" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock17" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(72, 264)
 
-[node name="Rock18" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock18" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(360, 360)
 
-[node name="Rock19" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock19" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(408, 360)
 
-[node name="Rock20" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock20" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(504, 360)
 
-[node name="Rock21" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock21" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(600, 360)
 
-[node name="Rock22" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock22" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(648, 360)
 
-[node name="Rock23" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock23" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(504, 456)
 
-[node name="Rock24" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock24" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(552, 456)
 
-[node name="Rock25" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock25" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(552, 408)
 
-[node name="Rock26" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock26" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(360, 456)
 
-[node name="Rock27" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock27" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(360, 504)
 
-[node name="Rock28" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock28" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(264, 504)
 
-[node name="Rock29" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock29" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(264, 552)
 
-[node name="Rock30" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock30" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(168, 456)
 
-[node name="Rock31" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock31" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(168, 504)
 
-[node name="Rock32" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock32" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(72, 552)
 
-[node name="Rock33" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock33" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(120, 552)
 
-[node name="Rock34" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock34" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(504, 552)
 
-[node name="Rock35" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock35" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(600, 552)
 
-[node name="Rock36" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock36" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(648, 552)
 
-[node name="Rock37" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock37" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(648, 504)
 
-[node name="Rock38" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock38" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(456, 216)
 
-[node name="Rock39" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock39" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(360, 216)
 
-[node name="Rock40" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock40" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(360, 168)
 
-[node name="Rock41" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock41" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(456, 120)
 
-[node name="Rock42" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock42" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(456, 408)
 
-[node name="Rock43" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock43" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(456, 456)
 
-[node name="Rock44" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock44" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(456, 504)
 
-[node name="Rock45" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock45" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(600, 264)
 
-[node name="Rock46" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock46" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(600, 72)
 
-[node name="Rock47" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock47" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(408, 72)
 
-[node name="Rock48" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock48" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(792, 168)
 
-[node name="Rock49" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock49" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(744, 168)
 
-[node name="Rock50" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock50" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(744, 264)
 
-[node name="Rock51" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock51" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(792, 264)
 
-[node name="Rock52" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock52" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(744, 360)
 
-[node name="Rock53" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock53" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(744, 408)
 
-[node name="Rock54" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock54" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(792, 552)
 
-[node name="Rock55" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock55" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(840, 552)
 
-[node name="Rock56" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock56" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(840, 504)
 
-[node name="Rock57" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock57" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(840, 312)
 
-[node name="Rock58" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock58" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(840, 264)
 
-[node name="Rock59" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock59" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(840, 216)
 
-[node name="Rock60" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock60" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(840, 120)
 
-[node name="Rock61" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock61" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(792, 72)
 
-[node name="Rock62" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock62" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(840, 72)
 
-[node name="Rock63" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock63" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(936, 216)
 
-[node name="Rock64" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock64" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(936, 264)
 
-[node name="Rock65" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock65" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(936, 408)
 
-[node name="Rock66" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock66" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(888, 456)
 
-[node name="Rock67" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock67" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(936, 456)
 
-[node name="Rock68" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock68" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(792, 456)
 
-[node name="Rock69" parent="Rocks" instance=ExtResource( "2" )]
+[node name="Rock69" parent="Rocks" instance=ExtResource("2")]
 position = Vector2(840, 456)
 
 [node name="Players" type="Node2D" parent="."]
@@ -275,7 +271,7 @@ offset_right = 1024.0
 offset_bottom = 40.0
 size_flags_horizontal = 2
 size_flags_vertical = 2
-script = ExtResource( "3" )
+script = ExtResource("3")
 
 [node name="Winner" type="Label" parent="."]
 visible = false
@@ -285,18 +281,19 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 theme_override_constants/shadow_offset_x = 2
 theme_override_constants/shadow_offset_y = 2
-theme_override_fonts/font = SubResource( "1" )
+theme_override_fonts/font = ExtResource("4_e2flb")
 text = "THE WINNER IS:
 YOU"
 
 [node name="ExitGame" type="Button" parent="Winner"]
+layout_mode = 0
 offset_left = 384.0
 offset_top = 408.0
 offset_right = 649.0
 offset_bottom = 469.0
 size_flags_horizontal = 2
 size_flags_vertical = 2
-theme_override_fonts/font = SubResource( "1" )
+theme_override_fonts/font = ExtResource("4_e2flb")
 text = "EXIT GAME"
 
 [node name="Camera2D" type="Camera2D" parent="."]
@@ -304,12 +301,11 @@ offset = Vector2(512, 300)
 current = true
 
 [node name="PlayerSpawner" type="MultiplayerSpawner" parent="."]
-replication = [ExtResource( "5_yef4r" )]
+_spawnable_scenes = PackedStringArray("res://player.tscn")
 spawn_path = NodePath("../Players")
-auto_spawn = true
 
 [node name="BombSpawner" type="MultiplayerSpawner" parent="."]
 spawn_path = NodePath("..")
-script = ExtResource( "6_ac5ja" )
+script = ExtResource("6_ac5ja")
 
 [connection signal="pressed" from="Winner/ExitGame" to="Score" method="_on_exit_game_pressed"]


### PR DESCRIPTION
Fix networking/multiplayer_bomber to work with godot 4.0 beta 1. Two major things seem to have changed:
1. Fonts objects no longer exist, and setting the override font should use the data from preload directly. See the code snippet at the end of the description here https://docs.godotengine.org/en/latest/classes/class_fontfile.html?highlight=font#description
2. The field names for the MultiplayerSpawner and MultiplayerSynchronizer nodes seem to have changed. 

In addition to those changes, the 4.0 beta 1 editor has lots of whitespace changes, and additional default fields. Also it automatically converted Position2D to Marker2D.