### PR TITLE
opensimplexnoise: Fix persistence, tweak documentation URL and layout

### DIFF
--- a/misc/opensimplexnoise/OpenSimplexNoise_Viewer.gd
+++ b/misc/opensimplexnoise/OpenSimplexNoise_Viewer.gd
@@ -31,7 +31,7 @@ func _refresh_shader_params():
 
 func _on_DocumentationButton_pressed():
 	#warning-ignore:return_value_discarded
-	OS.shell_open("https://docs.godotengine.org/en/latest/classes/class_opensimplexnoise.html")
+	OS.shell_open("https://docs.godotengine.org/en/3.6/classes/class_opensimplexnoise.html")
 
 
 func _on_RandomSeedButton_pressed():

--- a/misc/opensimplexnoise/OpenSimplexNoise_Viewer.tscn
+++ b/misc/opensimplexnoise/OpenSimplexNoise_Viewer.tscn
@@ -16,9 +16,6 @@ margin_top = 24.0
 margin_right = -24.0
 margin_bottom = -24.0
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="SeamlessNoiseTexture" type="TextureRect" parent="."]
 material = ExtResource( 2 )
@@ -26,39 +23,34 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = -196.0
+margin_left = -256.0
 margin_top = -256.0
-margin_right = 316.0
+margin_right = 256.0
 margin_bottom = 256.0
 grow_horizontal = 2
 grow_vertical = 2
 texture = SubResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ButtonsContainer" type="VBoxContainer" parent="."]
 anchor_left = 1.0
 anchor_right = 1.0
-margin_left = -137.0
-margin_bottom = 44.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
+margin_left = -200.0
+margin_bottom = 48.0
+custom_constants/separation = 8
 
 [node name="DocumentationButton" type="Button" parent="ButtonsContainer"]
-margin_right = 137.0
+margin_right = 200.0
 margin_bottom = 20.0
 grow_horizontal = 0
-text = "API Documentation"
+text = "API Documentation 3.6"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="RandomSeedButton" type="Button" parent="ButtonsContainer"]
-margin_top = 24.0
-margin_right = 137.0
-margin_bottom = 44.0
+margin_top = 28.0
+margin_right = 200.0
+margin_bottom = 48.0
 grow_horizontal = 0
 text = "Random Seed"
 __meta__ = {
@@ -66,14 +58,12 @@ __meta__ = {
 }
 
 [node name="ParameterContainer" type="VBoxContainer" parent="."]
-margin_right = 280.0
-margin_bottom = 136.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
+margin_right = 200.0
+margin_bottom = 152.0
+custom_constants/separation = 8
 
 [node name="SeedSpinBox" type="SpinBox" parent="ParameterContainer"]
-margin_right = 280.0
+margin_right = 200.0
 margin_bottom = 24.0
 min_value = -2.14748e+09
 max_value = 2.14748e+09
@@ -82,34 +72,35 @@ allow_lesser = true
 prefix = "Seed:"
 
 [node name="LacunaritySpinBox" type="SpinBox" parent="ParameterContainer"]
-margin_top = 28.0
-margin_right = 280.0
-margin_bottom = 52.0
+margin_top = 32.0
+margin_right = 200.0
+margin_bottom = 56.0
 step = 0.1
 allow_greater = true
 prefix = "Lacunarity:"
 
 [node name="PeriodSpinBox" type="SpinBox" parent="ParameterContainer"]
-margin_top = 56.0
-margin_right = 280.0
-margin_bottom = 80.0
+margin_top = 64.0
+margin_right = 200.0
+margin_bottom = 88.0
 min_value = -100000.0
 max_value = 100000.0
 allow_greater = true
 prefix = "Period:"
 
 [node name="PersistenceSpinBox" type="SpinBox" parent="ParameterContainer"]
-margin_top = 84.0
-margin_right = 280.0
-margin_bottom = 108.0
+margin_top = 96.0
+margin_right = 200.0
+margin_bottom = 120.0
 max_value = 1000.0
+step = 0.05
 allow_greater = true
-prefix = "Persistance:"
+prefix = "Persistence:"
 
 [node name="OctavesSpinBox" type="SpinBox" parent="ParameterContainer"]
-margin_top = 112.0
-margin_right = 280.0
-margin_bottom = 136.0
+margin_top = 128.0
+margin_right = 200.0
+margin_bottom = 152.0
 min_value = 1.0
 max_value = 9.0
 value = 1.0
@@ -118,15 +109,13 @@ prefix = "Octaves:"
 [node name="ClipContainer" type="VBoxContainer" parent="."]
 anchor_top = 1.0
 anchor_bottom = 1.0
-margin_top = -52.0
-margin_right = 280.0
+margin_top = -56.0
+margin_right = 200.0
 grow_vertical = 0
-__meta__ = {
-"_edit_use_anchors_": false
-}
+custom_constants/separation = 8
 
 [node name="MinClipSpinBox" type="SpinBox" parent="ClipContainer"]
-margin_right = 280.0
+margin_right = 200.0
 margin_bottom = 24.0
 min_value = -1.0
 max_value = 1.0
@@ -135,9 +124,9 @@ value = -1.0
 prefix = "Min:"
 
 [node name="MaxClipSpinBox" type="SpinBox" parent="ClipContainer"]
-margin_top = 28.0
-margin_right = 280.0
-margin_bottom = 52.0
+margin_top = 32.0
+margin_right = 200.0
+margin_bottom = 56.0
 min_value = -1.0
 max_value = 1.0
 step = 0.01

--- a/misc/opensimplexnoise/project.godot
+++ b/misc/opensimplexnoise/project.godot
@@ -18,7 +18,6 @@ config/icon="res://icon.png"
 
 [display]
 
-window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 

--- a/misc/opensimplexnoise/project.godot
+++ b/misc/opensimplexnoise/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.png"
 
 [display]
 
+window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
 window/stretch/aspect="expand"
 


### PR DESCRIPTION
persistence's spinbox step size was set to 1, breaking the default of 0.5.

changed step size to 0.05 because small changes in this value make a big different (only values 0 to ~2 are relevant).

other fixes I did:

- typo persistance -> persistence
- documentation button led to 404, changed to permanent 3.6 url (I think this is fair since the demo is made with this version and future godot versions might work differently)
- decreased spinbox widths
- increased button sizes to include "3.6" in the doc button name
- increased vbox separation
- centered texture
- ~disabled high dpi since it doesn't actually properly scale on high dpi~

before
<img width="624" alt="Bildschirmfoto 2022-11-18 um 10 58 55" src="https://user-images.githubusercontent.com/431162/202677276-7f3880e6-3ff8-4ecb-9da8-d639834ef4df.png">

after
<img width="1136" alt="Bildschirmfoto 2022-11-18 um 10 59 36" src="https://user-images.githubusercontent.com/431162/202677294-24e78612-6ae9-4973-9a5c-64dd365fc37f.png">

ps: how is the release on the website handled?