### PR TITLE
[4.0] [WebSocket] Fix peers handling in multiplayer example.

### DIFF
--- a/networking/websocket_multiplayer/script/game.gd
+++ b/networking/websocket_multiplayer/script/game.gd
@@ -64,7 +64,7 @@ func do_action(action):
 	var pos = _players.find(id)
 	if pos == -1:
 		return
-	_players.erase(pos)
+	_players.remove_at(pos)
 	_list.remove_item(pos)
 	if _turn > pos:
 		_turn -= 1


### PR DESCRIPTION
Disconnected peers were not properly removed from the local peers list.