### PR TITLE
[3.x] [WebSocket] Fix peer disconnection not closing the network layer.

### DIFF
--- a/networking/websocket_multiplayer/script/main.gd
+++ b/networking/websocket_multiplayer/script/main.gd
@@ -79,6 +79,10 @@ func _on_Host_pressed():
 
 
 func _on_Disconnect_pressed():
+	if peer is WebSocketServer:
+		peer.stop()
+	elif peer is WebSocketClient:
+		peer.disconnect_from_host()
 	_close_network()
 
 


### PR DESCRIPTION
We were removing it from the MultiplayerAPI but not immediately destroying it (to avoid tricky in-signal de-referencing). We still need to properly close the connection in this case if we want the remote peer to be notified immediately.

Fixes #793