### PR TITLE
Fix Physics tests for Godot 4 beta 6

### DIFF
--- a/2d/physics_tests/assets/tileset/tileset.tres
+++ b/2d/physics_tests/assets/tileset/tileset.tres
@@ -3,7 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://1nmxl2dgdqro" path="res://assets/tileset/tiles_demo.png" id="1"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_4jjf0"]
-texture = ExtResource( "1" )
+texture = ExtResource("1")
 0:0/next_alternative_id = 8
 0:0/0 = 0
 0:0/0/modulate = Color(0, 0, 1, 1)
@@ -18,4 +18,4 @@ texture = ExtResource( "1" )
 
 [resource]
 physics_layer_0/collision_layer = 1
-sources/0 = SubResource( "TileSetAtlasSource_4jjf0" )
+sources/0 = SubResource("TileSetAtlasSource_4jjf0")

--- a/2d/physics_tests/main.tscn
+++ b/2d/physics_tests/main.tscn
@@ -14,13 +14,12 @@
 bg_color = Color(0, 0, 0, 0.176471)
 
 [node name="Main" type="Control"]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-script = ExtResource( "12" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("12")
 
 [node name="TestsMenu" type="MenuButton" parent="."]
 offset_left = 10.0
@@ -29,10 +28,7 @@ offset_right = 125.0
 offset_bottom = 30.0
 text = "TESTS"
 flat = false
-script = ExtResource( "4" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("4")
 
 [node name="LabelControls" type="Label" parent="."]
 offset_left = 157.0
@@ -40,11 +36,9 @@ offset_top = 13.0
 offset_right = 646.0
 offset_bottom = 27.0
 text = "P - TOGGLE PAUSE / R - RESTART / C - TOGGLE COLLISION / F - TOGGLE FULL SCREEN / ESC - QUIT"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LabelFPS" type="Label" parent="."]
+anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 10.0
@@ -52,12 +46,10 @@ offset_top = -19.0
 offset_right = 50.0
 offset_bottom = -5.0
 text = "FPS: 0"
-script = ExtResource( "1" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("1")
 
 [node name="LabelEngine" type="Label" parent="."]
+anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 10.0
@@ -65,12 +57,10 @@ offset_top = -39.0
 offset_right = 50.0
 offset_bottom = -25.0
 text = "Physics engine:"
-script = ExtResource( "3" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("3")
 
 [node name="LabelVersion" type="Label" parent="."]
+anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 10.0
@@ -78,12 +68,10 @@ offset_top = -59.0
 offset_right = 50.0
 offset_bottom = -45.0
 text = "Godot Version:"
-script = ExtResource( "2" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("2")
 
 [node name="LabelTest" type="Label" parent="."]
+anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 10.0
@@ -91,12 +79,10 @@ offset_top = -79.0
 offset_right = 50.0
 offset_bottom = -65.0
 text = "Test:"
-script = ExtResource( "5" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("5")
 
 [node name="LabelPause" type="Label" parent="."]
+anchors_preset = 7
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
@@ -106,24 +92,20 @@ offset_top = -40.9695
 offset_right = 31.0
 offset_bottom = -26.9695
 text = "PAUSED"
-script = ExtResource( "6" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("6")
 
 [node name="PanelLog" type="Panel" parent="."]
+anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -428.0
 offset_top = -125.0
-theme_override_styles/panel = SubResource( "1" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+theme_override_styles/panel = SubResource("1")
 
 [node name="ButtonClear" type="Button" parent="PanelLog"]
+anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -134,11 +116,9 @@ offset_right = -5.0
 offset_bottom = -5.0
 focus_mode = 0
 text = "clear"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="CheckBoxScroll" type="CheckBox" parent="PanelLog"]
+anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -149,19 +129,13 @@ offset_right = -54.0
 offset_bottom = -3.0
 focus_mode = 0
 text = "auto-scroll"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ScrollLog" type="ScrollContainer" parent="PanelLog"]
 offset_left = 10.0
 offset_top = 5.0
 offset_right = 418.0
 offset_bottom = 94.0
-script = ExtResource( "11" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("11")
 auto_scroll = true
 
 [node name="VBoxLog" type="VBoxContainer" parent="PanelLog/ScrollLog"]
@@ -170,7 +144,7 @@ offset_bottom = 89.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 alignment = 2
-script = ExtResource( "10" )
+script = ExtResource("10")
 
 [node name="LabelLog" type="Label" parent="PanelLog/ScrollLog/VBoxLog"]
 offset_top = 63.0
@@ -178,9 +152,6 @@ offset_right = 408.0
 offset_bottom = 89.0
 text = "Log start"
 max_lines_visible = 5
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [connection signal="pressed" from="PanelLog/ButtonClear" to="PanelLog/ScrollLog/VBoxLog" method="clear"]
 [connection signal="toggled" from="PanelLog/CheckBoxScroll" to="PanelLog/ScrollLog" method="set_auto_scroll"]

--- a/2d/physics_tests/project.godot
+++ b/2d/physics_tests/project.godot
@@ -34,8 +34,8 @@ _global_script_class_icons={
 
 config/name="2D Physics Tests"
 run/main_scene="res://main.tscn"
-config/icon="res://icon.png"
 config/features=PackedStringArray("4.0")
+config/icon="res://icon.png"
 
 [autoload]
 
@@ -50,6 +50,10 @@ gdscript/warnings/return_value_discarded=false
 
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
+
+[dotnet]
+
+project/assembly_name="2D Physics Tests"
 
 [input]
 
@@ -71,45 +75,45 @@ ui_down={
 }
 toggle_full_screen={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":70,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":70,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 exit={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":16777217,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":16777217,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 toggle_debug_collision={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":67,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":67,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 restart_test={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":82,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":82,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 toggle_pause={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":80,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":80,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 character_left={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":16777231,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":65,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":16777231,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":65,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 character_right={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":16777233,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":68,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":16777233,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":68,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 character_jump={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":16777232,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"store_command":true,"alt_pressed":false,"shift_pressed":false,"meta_pressed":false,"command_pressed":false,"pressed":false,"keycode":87,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":16777232,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":87,"physical_keycode":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 

--- a/2d/physics_tests/test.gd
+++ b/2d/physics_tests/test.gd
@@ -73,7 +73,7 @@ func create_rigidbody(shape, pickable = false, shape_transform = Transform2D.IDE
 	collision.shape = shape
 	collision.transform = shape_transform
 
-	var body = RigidDynamicBody2D.new()
+	var body = RigidBody2D.new()
 	body.add_child(collision)
 
 	if pickable:
@@ -97,14 +97,6 @@ func create_rigidbody_box(size, pickable = false, use_icon = false, shape_transf
 		body.add_child(icon)
 
 	return body
-
-
-func find_node(node_name):
-	var nodes = find_nodes(node_name)
-	if nodes.size() > 0:
-		return nodes[0]
-	return null
-
 
 func start_timer(timeout):
 	if _timer == null:

--- a/2d/physics_tests/tests/dynamic_box.tscn
+++ b/2d/physics_tests/tests/dynamic_box.tscn
@@ -3,7 +3,7 @@
 [sub_resource type="RectangleShape2D" id="1"]
 size = Vector2(40, 40)
 
-[node name="StackBox" type="RigidDynamicBody2D"]
+[node name="StackBox" type="RigidBody2D"]
 position = Vector2(-180, -20)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/2d/physics_tests/tests/functional/test_character.gd
+++ b/2d/physics_tests/tests/functional/test_character.gd
@@ -47,28 +47,28 @@ func _ready():
 	options.connect(&"option_selected", Callable(self, "_on_option_selected"))
 	options.connect(&"option_changed", Callable(self, "_on_option_changed"))
 
-	_character_body_template = find_node("CharacterBody2D")
+	_character_body_template = find_child("CharacterBody2D")
 	if _character_body_template:
 		_body_parent = _character_body_template.get_parent()
 		_body_parent.remove_child(_character_body_template)
 		var enabled = _body_type == E_BodyType.CHARACTER_BODY
 		options.add_menu_item(OPTION_OBJECT_TYPE_CHARACTER, true, enabled, true)
 
-	_character_body_ray_template = find_node("CharacterBodyRay2D")
+	_character_body_ray_template = find_child("CharacterBodyRay2D")
 	if _character_body_ray_template:
 		_body_parent = _character_body_ray_template.get_parent()
 		_body_parent.remove_child(_character_body_ray_template)
 		var enabled = _body_type == E_BodyType.CHARACTER_BODY_RAY
 		options.add_menu_item(OPTION_OBJECT_TYPE_CHARACTER_RAY, true, enabled, true)
 
-	_rigid_body_template = find_node("RigidDynamicBody2D")
+	_rigid_body_template = find_child("RigidBody2D")
 	if _rigid_body_template:
 		_body_parent = _rigid_body_template.get_parent()
 		_body_parent.remove_child(_rigid_body_template)
 		var enabled = _body_type == E_BodyType.RIGID_BODY
 		options.add_menu_item(OPTION_OBJECT_TYPE_RIGID_BODY, true, enabled, true)
 
-	_rigid_body_ray_template = find_node("RigidBodyRay2D")
+	_rigid_body_ray_template = find_child("RigidBodyRay2D")
 	if _rigid_body_ray_template:
 		_body_parent = _rigid_body_ray_template.get_parent()
 		_body_parent.remove_child(_rigid_body_ray_template)
@@ -80,7 +80,7 @@ func _ready():
 	options.add_menu_item(OPTION_MOVE_CHARACTER_FLOOR_ONLY, true, _use_floor_only)
 	options.add_menu_item(OPTION_MOVE_CHARACTER_CONSTANT_SPEED, true, _use_constant_speed)
 
-	var floor_slider = find_node("FloorMaxAngle")
+	var floor_slider = find_child("FloorMaxAngle")
 	if floor_slider:
 		floor_slider.get_node("HSlider").value = _floor_max_angle
 

--- a/2d/physics_tests/tests/functional/test_character_pixels.tscn
+++ b/2d/physics_tests/tests/functional/test_character_pixels.tscn
@@ -25,13 +25,14 @@ size = Vector2(6, 10)
 size = Vector2(20, 4)
 
 [node name="Test" type="Node2D"]
-script = ExtResource( "1" )
+script = ExtResource("1")
 _motion_speed = 30.0
 _gravity_force = 2.0
 _jump_force = 50.0
 _snap_distance = 1.0
 
 [node name="ViewportContainer" type="SubViewportContainer" parent="."]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_right = 1024.0
@@ -39,9 +40,6 @@ offset_bottom = 600.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 stretch = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Viewport" type="SubViewport" parent="ViewportContainer"]
 handle_input_locally = false
@@ -50,85 +48,75 @@ size_2d_override = Vector2i(128, 75)
 size_2d_override_stretch = true
 render_target_update_mode = 4
 
-[node name="StaticSceneFlat" parent="ViewportContainer/Viewport" instance=ExtResource( "4" )]
+[node name="StaticSceneFlat" parent="ViewportContainer/Viewport" instance=ExtResource("4")]
 position = Vector2(0, -450)
 
 [node name="CharacterBody2D" type="CharacterBody2D" parent="ViewportContainer/Viewport"]
 position = Vector2(30, 40)
 collision_mask = 2147483649
-script = ExtResource( "7" )
+script = ExtResource("7")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ViewportContainer/Viewport/CharacterBody2D"]
-shape = SubResource( "3" )
+shape = SubResource("3")
 
 [node name="CharacterBodyRay2D" type="CharacterBody2D" parent="ViewportContainer/Viewport"]
 position = Vector2(30, 40)
 collision_mask = 2147483649
-script = ExtResource( "7" )
+script = ExtResource("7")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ViewportContainer/Viewport/CharacterBodyRay2D"]
 position = Vector2(0, -2.5)
-shape = SubResource( "RectangleShape2D_scs3g" )
+shape = SubResource("RectangleShape2D_scs3g")
 
 [node name="CollisionShapeRay2D" type="CollisionShape2D" parent="ViewportContainer/Viewport/CharacterBodyRay2D"]
 position = Vector2(0, -2)
-shape = SubResource( "SeparationRayShape2D_vby12" )
+shape = SubResource("SeparationRayShape2D_vby12")
 
-[node name="RigidDynamicBody2D" type="RigidDynamicBody2D" parent="ViewportContainer/Viewport"]
+[node name="RigidBody2D" type="RigidBody2D" parent="ViewportContainer/Viewport"]
 position = Vector2(30, 40)
 collision_mask = 2147483649
-physics_material_override = SubResource( "1" )
-contacts_reported = 4
+physics_material_override = SubResource("1")
 contact_monitor = true
 lock_rotation = true
-script = ExtResource( "2" )
+script = ExtResource("2")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="ViewportContainer/Viewport/RigidDynamicBody2D"]
-shape = SubResource( "2" )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="ViewportContainer/Viewport/RigidBody2D"]
+shape = SubResource("2")
 
-[node name="RigidBodyRay2D" type="RigidDynamicBody2D" parent="ViewportContainer/Viewport"]
+[node name="RigidBodyRay2D" type="RigidBody2D" parent="ViewportContainer/Viewport"]
 position = Vector2(30, 40)
 collision_mask = 2147483649
-physics_material_override = SubResource( "1" )
-contacts_reported = 4
+physics_material_override = SubResource("1")
 contact_monitor = true
 lock_rotation = true
-script = ExtResource( "2" )
+script = ExtResource("2")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ViewportContainer/Viewport/RigidBodyRay2D"]
 position = Vector2(0, -2.5)
-shape = SubResource( "RectangleShape2D_scs3g" )
+shape = SubResource("RectangleShape2D_scs3g")
 
 [node name="CollisionShapeRay2D" type="CollisionShape2D" parent="ViewportContainer/Viewport/RigidBodyRay2D"]
 position = Vector2(0, -2)
-shape = SubResource( "SeparationRayShape2D_vby12" )
+shape = SubResource("SeparationRayShape2D_vby12")
 
 [node name="Wall1" type="StaticBody2D" parent="ViewportContainer/Viewport"]
 position = Vector2(20, 40)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="SubViewportContainer/SubViewport/Wall1"]
-rotation = 1.5708
-shape = SubResource( "6" )
-
 [node name="Wall2" type="StaticBody2D" parent="ViewportContainer/Viewport"]
 position = Vector2(122, 40)
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="SubViewportContainer/SubViewport/Wall2"]
-rotation = 1.5708
-shape = SubResource( "6" )
 
 [node name="Platform1" type="StaticBody2D" parent="ViewportContainer/Viewport"]
 position = Vector2(50, 44)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ViewportContainer/Viewport/Platform1"]
-shape = SubResource( "6" )
+shape = SubResource("6")
 one_way_collision = true
 
 [node name="Platform2" type="StaticBody2D" parent="ViewportContainer/Viewport"]
 position = Vector2(80, 38)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="ViewportContainer/Viewport/Platform2"]
-shape = SubResource( "6" )
+shape = SubResource("6")
 
 [node name="Slope" type="StaticBody2D" parent="ViewportContainer/Viewport"]
 position = Vector2(85, 36)
@@ -136,17 +124,22 @@ position = Vector2(85, 36)
 [node name="CollisionShape2D" type="CollisionPolygon2D" parent="ViewportContainer/Viewport/Slope"]
 polygon = PackedVector2Array(0, 0, 6, 0, 22, 16, 16, 16)
 
+[node name="SubViewportContainer@SubViewport@Wall1@CollisionShape2D" type="CollisionShape2D" parent="."]
+rotation = 1.5708
+shape = SubResource("6")
+
+[node name="SubViewportContainer@SubViewport@Wall2@CollisionShape2D" type="CollisionShape2D" parent="."]
+rotation = 1.5708
+shape = SubResource("6")
+
 [node name="LabelTestType" type="Label" parent="."]
 offset_left = 14.0
 offset_top = 79.0
 offset_right = 145.0
 offset_bottom = 93.0
 text = "Testing: "
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Options" parent="." instance=ExtResource( "3" )]
+[node name="Options" parent="." instance=ExtResource("3")]
 
 [node name="LabelFloor" type="Label" parent="."]
 offset_left = 14.0
@@ -154,9 +147,6 @@ offset_top = 237.929
 offset_right = 145.0
 offset_bottom = 251.929
 text = "ON FLOOR"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LabelControls" type="Label" parent="."]
 offset_left = 14.0
@@ -165,6 +155,3 @@ offset_right = 145.0
 offset_bottom = 294.291
 text = "LEFT/RIGHT - MOVE
 UP - JUMP"
-__meta__ = {
-"_edit_use_anchors_": false
-}

--- a/2d/physics_tests/tests/functional/test_character_slopes.tscn
+++ b/2d/physics_tests/tests/functional/test_character_slopes.tscn
@@ -32,7 +32,7 @@ radius = 32.0
 length = 64.0
 
 [node name="Test" type="Node2D"]
-script = ExtResource( "1" )
+script = ExtResource("1")
 _snap_distance = 32.0
 _floor_max_angle = 60.0
 
@@ -42,11 +42,8 @@ offset_top = 79.0
 offset_right = 145.0
 offset_bottom = 93.0
 text = "Testing: "
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Options" parent="." instance=ExtResource( "3" )]
+[node name="Options" parent="." instance=ExtResource("3")]
 
 [node name="LabelFloor" type="Label" parent="."]
 offset_left = 14.0
@@ -54,9 +51,6 @@ offset_top = 237.929
 offset_right = 145.0
 offset_bottom = 251.929
 text = "ON FLOOR"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LabelControls" type="Label" parent="."]
 offset_left = 14.0
@@ -65,9 +59,6 @@ offset_right = 145.0
 offset_bottom = 294.291
 text = "LEFT/RIGHT - MOVE
 UP - JUMP"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="FloorMaxAngle" type="HBoxContainer" parent="."]
 offset_left = 14.0
@@ -76,83 +67,78 @@ offset_right = 476.0
 offset_bottom = 186.0
 theme_override_constants/separation = 20
 alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label" type="Label" parent="FloorMaxAngle"]
-offset_right = 122.0
+offset_left = 176.0
+offset_right = 299.0
 offset_bottom = 26.0
 text = "Floor Max angle"
 
 [node name="HSlider" type="HSlider" parent="FloorMaxAngle"]
-offset_left = 142.0
-offset_right = 342.0
+custom_minimum_size = Vector2(100, 0)
+offset_left = 319.0
+offset_right = 419.0
 offset_bottom = 16.0
-rect_min_size = Vector2(200, 0)
 max_value = 180.0
-script = ExtResource( "3_cd5g0" )
+script = ExtResource("3_cd5g0")
 snap_step = 5.0
 
 [node name="LabelValue" type="Label" parent="FloorMaxAngle"]
-offset_left = 362.0
+offset_left = 439.0
 offset_right = 462.0
 offset_bottom = 26.0
-rect_min_size = Vector2(100, 0)
 text = "0.0"
-script = ExtResource( "4_eoplu" )
+script = ExtResource("4_eoplu")
 
 [node name="CharacterBody2D" type="CharacterBody2D" parent="."]
 position = Vector2(100, 450)
 collision_mask = 2147483649
-script = ExtResource( "7" )
+script = ExtResource("7")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBody2D"]
-shape = SubResource( "3" )
+shape = SubResource("3")
 
 [node name="CharacterBodyRay2D" type="CharacterBody2D" parent="."]
 position = Vector2(100, 450)
 collision_mask = 2147483649
-script = ExtResource( "7" )
+script = ExtResource("7")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBodyRay2D"]
 position = Vector2(0, -16)
-shape = SubResource( "CircleShape2D_llvur" )
+shape = SubResource("CircleShape2D_llvur")
 
 [node name="CollisionShapeRay2D" type="CollisionShape2D" parent="CharacterBodyRay2D"]
 position = Vector2(0, -16)
-shape = SubResource( "RayShape2D_3lv1w" )
+shape = SubResource("RayShape2D_3lv1w")
 
-[node name="RigidDynamicBody2D" type="RigidDynamicBody2D" parent="."]
+[node name="RigidBody2D" type="RigidBody2D" parent="."]
 position = Vector2(100, 450)
 collision_mask = 2147483649
-physics_material_override = SubResource( "1" )
-contacts_reported = 4
+physics_material_override = SubResource("1")
 contact_monitor = true
 lock_rotation = true
-script = ExtResource( "6" )
+script = ExtResource("6")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="RigidDynamicBody2D"]
-shape = SubResource( "2" )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="RigidBody2D"]
+shape = SubResource("2")
 
-[node name="RigidBodyRay2D" type="RigidDynamicBody2D" parent="."]
+[node name="RigidBodyRay2D" type="RigidBody2D" parent="."]
 position = Vector2(100, 450)
 collision_mask = 2147483649
-physics_material_override = SubResource( "1" )
-contacts_reported = 4
+physics_material_override = SubResource("1")
 contact_monitor = true
 lock_rotation = true
-script = ExtResource( "6" )
+script = ExtResource("6")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="RigidBodyRay2D"]
 position = Vector2(-7.62939e-06, -16)
-shape = SubResource( "CircleShape2D_dr08f" )
+shape = SubResource("CircleShape2D_dr08f")
 
 [node name="CollisionShapeRay2D" type="CollisionShape2D" parent="RigidBodyRay2D"]
 position = Vector2(-7.62939e-06, -16)
-shape = SubResource( "RayShape2D_w83f0" )
+shape = SubResource("RayShape2D_w83f0")
 
-[node name="StaticSceneFlat" parent="." instance=ExtResource( "4" )]
+[node name="StaticSceneFlat" parent="." instance=ExtResource("4")]
 position = Vector2(0, 12)
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]

--- a/2d/physics_tests/tests/functional/test_character_tilemap.tscn
+++ b/2d/physics_tests/tests/functional/test_character_tilemap.tscn
@@ -23,7 +23,7 @@ friction = 0.0
 radius = 16.0
 
 [node name="Test" type="Node2D"]
-script = ExtResource( "1" )
+script = ExtResource("1")
 
 [node name="LabelTestType" type="Label" parent="."]
 offset_left = 14.0
@@ -31,11 +31,8 @@ offset_top = 79.0
 offset_right = 145.0
 offset_bottom = 93.0
 text = "Testing: "
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Options" parent="." instance=ExtResource( "3" )]
+[node name="Options" parent="." instance=ExtResource("3")]
 
 [node name="LabelFloor" type="Label" parent="."]
 offset_left = 14.0
@@ -43,9 +40,6 @@ offset_top = 237.929
 offset_right = 145.0
 offset_bottom = 251.929
 text = "ON FLOOR"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LabelControls" type="Label" parent="."]
 offset_left = 14.0
@@ -54,82 +48,77 @@ offset_right = 145.0
 offset_bottom = 277.291
 text = "LEFT/RIGHT - MOVE
 UP - JUMP"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="CharacterBody2D" type="CharacterBody2D" parent="."]
 position = Vector2(250, 460)
 collision_mask = 2147483649
-script = ExtResource( "7" )
+script = ExtResource("7")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBody2D"]
-shape = SubResource( "2" )
+shape = SubResource("2")
 
 [node name="CharacterBodyRay2D" type="CharacterBody2D" parent="."]
 position = Vector2(250, 460)
 collision_mask = 2147483649
-script = ExtResource( "7" )
+script = ExtResource("7")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBodyRay2D"]
 position = Vector2(0, -8)
-shape = SubResource( "RectangleShape2D_jx2e1" )
+shape = SubResource("RectangleShape2D_jx2e1")
 
 [node name="CollisionShapeRay2D" type="CollisionShape2D" parent="CharacterBodyRay2D"]
 position = Vector2(0, 8)
-shape = SubResource( "RayShape2D_206f5" )
+shape = SubResource("RayShape2D_206f5")
 
 [node name="CollisionShapeRay2DLeft" type="CollisionShape2D" parent="CharacterBodyRay2D"]
 position = Vector2(-12, 8)
-shape = SubResource( "RayShape2D_206f5" )
+shape = SubResource("RayShape2D_206f5")
 
 [node name="CollisionShapeRay2DRight" type="CollisionShape2D" parent="CharacterBodyRay2D"]
 position = Vector2(12, 8)
-shape = SubResource( "RayShape2D_206f5" )
+shape = SubResource("RayShape2D_206f5")
 
-[node name="RigidDynamicBody2D" type="RigidDynamicBody2D" parent="."]
+[node name="RigidBody2D" type="RigidBody2D" parent="."]
 position = Vector2(250, 460)
 collision_mask = 2147483649
-physics_material_override = SubResource( "1" )
-contacts_reported = 4
+physics_material_override = SubResource("1")
 contact_monitor = true
 lock_rotation = true
-script = ExtResource( "6" )
+script = ExtResource("6")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="RigidDynamicBody2D"]
-shape = SubResource( "2" )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="RigidBody2D"]
+shape = SubResource("2")
 
-[node name="RigidBodyRay2D" type="RigidDynamicBody2D" parent="."]
+[node name="RigidBodyRay2D" type="RigidBody2D" parent="."]
 position = Vector2(250, 460)
 collision_mask = 2147483649
-physics_material_override = SubResource( "1" )
-contacts_reported = 4
+physics_material_override = SubResource("1")
 contact_monitor = true
 lock_rotation = true
-script = ExtResource( "6" )
+script = ExtResource("6")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="RigidBodyRay2D"]
 position = Vector2(0, -8)
-shape = SubResource( "RectangleShape2D_jx2e1" )
+shape = SubResource("RectangleShape2D_jx2e1")
 
 [node name="CollisionShapeRay2D" type="CollisionShape2D" parent="RigidBodyRay2D"]
 position = Vector2(0, 8)
-shape = SubResource( "RayShape2D_206f5" )
+shape = SubResource("RayShape2D_206f5")
 
 [node name="CollisionShapeRay2DLeft" type="CollisionShape2D" parent="RigidBodyRay2D"]
 position = Vector2(-12, 8)
-shape = SubResource( "RayShape2D_206f5" )
+shape = SubResource("RayShape2D_206f5")
 
 [node name="CollisionShapeRay2DRight" type="CollisionShape2D" parent="RigidBodyRay2D"]
 position = Vector2(12, 8)
-shape = SubResource( "RayShape2D_206f5" )
+shape = SubResource("RayShape2D_206f5")
 
 [node name="JumpTargetArea2D" type="Area2D" parent="."]
 visible = false
 position = Vector2(810, 390)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="JumpTargetArea2D"]
-shape = SubResource( "5" )
+shape = SubResource("5")
 disabled = true
 
 [node name="FallTargetArea2D" type="Area2D" parent="."]
@@ -137,15 +126,15 @@ visible = false
 position = Vector2(250, 480)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="FallTargetArea2D"]
-shape = SubResource( "5" )
+shape = SubResource("5")
 disabled = true
 
-[node name="StaticSceneFlat" parent="." instance=ExtResource( "4" )]
+[node name="StaticSceneFlat" parent="." instance=ExtResource("4")]
 position = Vector2(0, 12)
 
 [node name="TileMap" type="TileMap" parent="."]
 scale = Vector2(2, 2)
-tile_set = ExtResource( "5" )
+tile_set = ExtResource("5")
 collision_visibility_mode = 1
 format = 2
 layer_0/tile_data = PackedInt32Array(786438, 65536, 0, 786439, 65536, 0, 786440, 65536, 0, 786441, 65536, 0, 458764, 65536, 0, 524300, 65536, 0, 589836, 65536, 0, 655372, 65536, 0, 720908, 65536, 0, 786444, 65536, 0, 851980, 65536, 0, 917516, 65536, 0, 983052, 65536, 0, 458765, 65536, 0, 524301, 65536, 0, 589837, 65536, 0, 655373, 65536, 0, 720909, 65536, 0, 786445, 65536, 0, 851981, 65536, 0, 917517, 65536, 0, 983053, 65536, 0, 458766, 65536, 0, 524302, 65536, 0, 589838, 65536, 0, 655374, 65536, 0, 720910, 65536, 0, 786446, 65536, 0, 851982, 65536, 0, 917518, 65536, 0, 983054, 65536, 0, 458767, 65536, 0, 524303, 65536, 0, 589839, 65536, 0, 655375, 65536, 0, 720911, 65536, 0, 786447, 65536, 0, 851983, 65536, 0, 917519, 65536, 0, 983055, 65536, 0, 458768, 65536, 0, 524304, 65536, 0, 589840, 65536, 0, 655376, 65536, 0, 720912, 65536, 0, 786448, 65536, 0, 851984, 65536, 0, 917520, 65536, 0, 983056, 65536, 0, 458769, 65536, 0, 524305, 65536, 0, 589841, 65536, 0, 655377, 65536, 0, 720913, 65536, 0, 786449, 65536, 0, 851985, 65536, 0, 917521, 65536, 0, 983057, 65536, 0, 458770, 65536, 0, 524306, 65536, 0, 589842, 65536, 0, 655378, 65536, 0, 720914, 65536, 0, 786450, 65536, 0, 851986, 65536, 0, 917522, 65536, 0, 983058, 65536, 0, 458771, 65536, 0, 524307, 65536, 0, 589843, 65536, 0, 655379, 65536, 0, 720915, 65536, 0, 786451, 65536, 0, 851987, 65536, 0, 917523, 65536, 0, 983059, 65536, 0, 851992, 0, 0, 851993, 0, 0, 720922, 0, 0, 851994, 0, 0, 720923, 0, 0, 851995, 0, 0, 720924, 0, 0, 720925, 0, 0)

--- a/2d/physics_tests/tests/functional/test_collision_pairs.gd
+++ b/2d/physics_tests/tests/functional/test_collision_pairs.gd
@@ -202,7 +202,7 @@ func _on_option_changed(option, checked):
 
 
 func _find_shape_node(type_name):
-	var node = $Shapes.find_node("RigidBody%s" % type_name)
+	var node = $Shapes.get_node("RigidBody%s" % type_name)
 
 	if not node:
 		Log.print_error("Invalid shape type: " + type_name)

--- a/2d/physics_tests/tests/functional/test_collision_pairs.tscn
+++ b/2d/physics_tests/tests/functional/test_collision_pairs.tscn
@@ -18,40 +18,40 @@ height = 110.0
 segments = PackedVector2Array(-5.93512, -43.2195, 6.44476, -42.9695, 6.44476, -42.9695, 11.127, -54.3941, 11.127, -54.3941, 26.9528, -49.4309, 26.9528, -49.4309, 26.2037, -36.508, 26.2037, -36.508, 37.5346, -28.1737, 37.5346, -28.1737, 47.6282, -34.3806, 47.6282, -34.3806, 58.0427, -20.9631, 58.0427, -20.9631, 51.113, -10.2876, 51.113, -10.2876, 50.9869, 35.2694, 50.9869, 35.2694, 38.8, 47.5, 38.8, 47.5, 15.9852, 54.3613, 15.9852, 54.3613, -14.9507, 54.1845, -14.9507, 54.1845, -36.5, 48.1, -36.5, 48.1, -50.4828, 36.33, -50.4828, 36.33, -51.3668, -9.98545, -51.3668, -9.98545, -57.8889, -20.5885, -57.8889, -20.5885, -46.9473, -34.7342, -46.9473, -34.7342, -37.4014, -28.547, -37.4014, -28.547, -26.0876, -37.0323, -26.0876, -37.0323, -26.9862, -49.15, -26.9862, -49.15, -11.4152, -54.5332, -11.4152, -54.5332, -5.93512, -43.2195)
 
 [node name="Test" type="Node2D"]
-script = ExtResource( "1" )
+script = ExtResource("1")
 
-[node name="Options" parent="." instance=ExtResource( "3" )]
+[node name="Options" parent="." instance=ExtResource("3")]
 
 [node name="Shapes" type="Node2D" parent="."]
 z_index = -1
 z_as_relative = false
 
-[node name="RigidBodyRectangle" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyRectangle" type="RigidBody2D" parent="Shapes"]
 position = Vector2(114.877, 248.76)
 freeze = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Shapes/RigidBodyRectangle"]
 rotation = -1.19206
 scale = Vector2(1.2, 1.2)
-shape = SubResource( "1" )
+shape = SubResource("1")
 
-[node name="RigidBodySphere" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodySphere" type="RigidBody2D" parent="Shapes"]
 position = Vector2(314.894, 257.658)
 freeze = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Shapes/RigidBodySphere"]
-shape = SubResource( "2" )
+shape = SubResource("2")
 
-[node name="RigidBodyCapsule" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyCapsule" type="RigidBody2D" parent="Shapes"]
 position = Vector2(465.629, 261.204)
 freeze = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Shapes/RigidBodyCapsule"]
 rotation = -0.202458
 scale = Vector2(1.2, 1.2)
-shape = SubResource( "3" )
+shape = SubResource("3")
 
-[node name="RigidBodyConvexPolygon" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyConvexPolygon" type="RigidBody2D" parent="Shapes"]
 position = Vector2(613.385, 252.771)
 freeze = true
 
@@ -60,9 +60,9 @@ polygon = PackedVector2Array(10.7, -54.5, 28.3596, -49.4067, 47.6282, -34.3806, 
 
 [node name="GodotIcon" type="Sprite2D" parent="Shapes/RigidBodyConvexPolygon"]
 modulate = Color(1, 1, 1, 0.392157)
-texture = ExtResource( "2" )
+texture = ExtResource("2")
 
-[node name="RigidBodyConcavePolygon" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyConcavePolygon" type="RigidBody2D" parent="Shapes"]
 position = Vector2(771.159, 252.771)
 freeze = true
 
@@ -71,20 +71,21 @@ polygon = PackedVector2Array(-5.93512, -43.2195, 6.44476, -42.9695, 11.127, -54.
 
 [node name="GodotIcon" type="Sprite2D" parent="Shapes/RigidBodyConcavePolygon"]
 modulate = Color(1, 1, 1, 0.392157)
-texture = ExtResource( "2" )
+texture = ExtResource("2")
 
-[node name="RigidBodyConcaveSegments" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyConcaveSegments" type="RigidBody2D" parent="Shapes"]
 position = Vector2(930.097, 252.771)
 freeze = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Shapes/RigidBodyConcaveSegments"]
-shape = SubResource( "4" )
+shape = SubResource("4")
 
 [node name="GodotIcon" type="Sprite2D" parent="Shapes/RigidBodyConcaveSegments"]
 modulate = Color(1, 1, 1, 0.392157)
-texture = ExtResource( "2" )
+texture = ExtResource("2")
 
 [node name="Controls" type="VBoxContainer" parent="."]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 25.3619
@@ -92,54 +93,46 @@ offset_top = 416.765
 offset_right = 218.362
 offset_bottom = 458.765
 theme_override_constants/separation = 10
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="OffsetH" type="HBoxContainer" parent="Controls"]
-offset_right = 204.0
+offset_right = 193.0
 offset_bottom = 26.0
 theme_override_constants/separation = 20
 alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label" type="Label" parent="Controls/OffsetH"]
-offset_right = 64.0
+offset_left = 9.0
+offset_right = 73.0
 offset_bottom = 26.0
 text = "Offset H"
 
 [node name="HSlider" type="HSlider" parent="Controls/OffsetH"]
-offset_left = 84.0
-offset_right = 204.0
+custom_minimum_size = Vector2(100, 0)
+offset_left = 93.0
+offset_right = 193.0
 offset_bottom = 16.0
-rect_min_size = Vector2(120, 0)
 min_value = -1.0
 max_value = 1.0
 step = 0.01
 
 [node name="OffsetV" type="HBoxContainer" parent="Controls"]
 offset_top = 36.0
-offset_right = 204.0
+offset_right = 193.0
 offset_bottom = 62.0
 theme_override_constants/separation = 20
 alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label" type="Label" parent="Controls/OffsetV"]
-offset_left = 2.0
-offset_right = 64.0
+offset_left = 11.0
+offset_right = 73.0
 offset_bottom = 26.0
 text = "Offset V"
 
 [node name="HSlider" type="HSlider" parent="Controls/OffsetV"]
-offset_left = 84.0
-offset_right = 204.0
+custom_minimum_size = Vector2(100, 0)
+offset_left = 93.0
+offset_right = 193.0
 offset_bottom = 16.0
-rect_min_size = Vector2(120, 0)
 min_value = -1.0
 max_value = 1.0
 step = 0.01

--- a/2d/physics_tests/tests/functional/test_one_way_collision.gd
+++ b/2d/physics_tests/tests/functional/test_one_way_collision.gd
@@ -91,7 +91,7 @@ func _ready():
 		_target_area.connect(&"body_entered", Callable(self, "_on_target_entered"))
 		$Timer.connect(&"timeout", Callable(self, "_on_timeout"))
 
-		_rigid_body_template = $RigidDynamicBody2D
+		_rigid_body_template = $RigidBody2D
 		remove_child(_rigid_body_template)
 
 		_character_body_template = $CharacterBody2D
@@ -173,11 +173,11 @@ func _update_platform_angle(value, reset = true):
 	_platform_angle = value
 	if is_inside_tree():
 		if Engine.is_editor_hint():
-			$OneWayStaticBody2D.rotation = deg2rad(value)
+			$OneWayStaticBody2D.rotation = deg_to_rad(value)
 		else:
 			if _platform_body:
-				_platform_body.rotation = deg2rad(value)
-			_platform_template.rotation = deg2rad(value)
+				_platform_body.rotation = deg_to_rad(value)
+			_platform_template.rotation = deg_to_rad(value)
 			if reset:
 				await _reset_test()
 
@@ -190,13 +190,13 @@ func _update_rigidbody_angle(value, reset = true):
 	_body_angle = value
 	if is_inside_tree():
 		if Engine.is_editor_hint():
-			$RigidDynamicBody2D.rotation = deg2rad(value)
-			$CharacterBody2D.rotation = deg2rad(value)
+			$RigidBody2D.rotation = deg_to_rad(value)
+			$CharacterBody2D.rotation = deg_to_rad(value)
 		else:
 			if _moving_body:
-				_moving_body.rotation = deg2rad(value)
-			_rigid_body_template.rotation = deg2rad(value)
-			_character_body_template.rotation = deg2rad(value)
+				_moving_body.rotation = deg_to_rad(value)
+			_rigid_body_template.rotation = deg_to_rad(value)
+			_character_body_template.rotation = deg_to_rad(value)
 			if reset:
 				await _reset_test()
 
@@ -414,7 +414,7 @@ func _reset_test(cancel_test = true):
 			emit_signal("all_tests_done")
 		else:
 			Log.print_log("*** Start around the clock tests")
-		_platform_body.rotation = deg2rad(_platform_angle)
+		_platform_body.rotation = deg_to_rad(_platform_angle)
 		_lock_controls = true
 		$Controls/PlatformAngle/HSlider.value = _platform_angle
 		_lock_controls = false
@@ -429,9 +429,9 @@ func _next_test(force_start = false):
 		_moving_body = null
 
 	if _test_all_angles:
-		var angle = rad2deg(_platform_body.rotation)
+		var angle = rad_to_deg(_platform_body.rotation)
 		if angle >= _platform_angle + TEST_ALL_ANGLES_MAX:
-			_platform_body.rotation = deg2rad(_platform_angle)
+			_platform_body.rotation = deg_to_rad(_platform_angle)
 			_lock_controls = true
 			$Controls/PlatformAngle/HSlider.value = _platform_angle
 			_lock_controls = false
@@ -439,7 +439,7 @@ func _next_test(force_start = false):
 			Log.print_log("*** Done all angles")
 		else:
 			angle = _platform_angle + _test_step * TEST_ALL_ANGLES_STEP
-			_platform_body.rotation = deg2rad(angle)
+			_platform_body.rotation = deg_to_rad(angle)
 			_lock_controls = true
 			$Controls/PlatformAngle/HSlider.value = angle
 			_lock_controls = false
@@ -472,7 +472,7 @@ func _on_target_entered(_body):
 
 
 func _should_collide():
-	var platform_rotation = round(rad2deg(_platform_body.rotation))
+	var platform_rotation = round(rad_to_deg(_platform_body.rotation))
 
 	var angle = fposmod(platform_rotation, 360)
 	return angle > 180
@@ -522,7 +522,7 @@ func _set_result():
 
 	$LabelResult.text = result
 
-	var platform_angle = rad2deg(_platform_body.rotation)
+	var platform_angle = rad_to_deg(_platform_body.rotation)
 
 	result += ": size=%.1f, angle=%.1f, body angle=%.1f" % [_platform_size, platform_angle, _body_angle]
 	Log.print_log("Test %s" % result)

--- a/2d/physics_tests/tests/functional/test_one_way_collision.tscn
+++ b/2d/physics_tests/tests/functional/test_one_way_collision.tscn
@@ -16,7 +16,7 @@ size = Vector2(128, 64)
 size = Vector2(64, 64)
 
 [node name="Test" type="Node2D"]
-script = ExtResource( "1" )
+script = ExtResource("1")
 
 [node name="LabelTestType" type="Label" parent="."]
 offset_left = 14.0
@@ -24,13 +24,11 @@ offset_top = 79.0
 offset_right = 145.0
 offset_bottom = 93.0
 text = "Testing: "
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Options" parent="." instance=ExtResource( "3" )]
+[node name="Options" parent="." instance=ExtResource("3")]
 
 [node name="Controls" type="VBoxContainer" parent="."]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 25.3619
@@ -38,109 +36,107 @@ offset_top = 416.765
 offset_right = 265.362
 offset_bottom = 484.765
 theme_override_constants/separation = 10
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="PlatformSize" type="HBoxContainer" parent="Controls"]
-offset_right = 452.0
+layout_mode = 2
+offset_right = 277.0
 offset_bottom = 26.0
 theme_override_constants/separation = 20
 alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label" type="Label" parent="Controls/PlatformSize"]
-offset_left = 12.0
-offset_right = 112.0
+layout_mode = 2
+offset_left = 4.0
+offset_right = 105.0
 offset_bottom = 26.0
 text = "Platform size"
 
 [node name="HSlider" type="HSlider" parent="Controls/PlatformSize"]
-offset_left = 132.0
-offset_right = 332.0
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+offset_left = 125.0
+offset_right = 225.0
 offset_bottom = 16.0
-rect_min_size = Vector2(200, 0)
 min_value = 64.0
 max_value = 256.0
 value = 64.0
-script = ExtResource( "5" )
+script = ExtResource("5")
 
 [node name="LabelValue" type="Label" parent="Controls/PlatformSize"]
-offset_left = 352.0
-offset_right = 452.0
+layout_mode = 2
+offset_left = 245.0
+offset_right = 277.0
 offset_bottom = 26.0
-rect_min_size = Vector2(100, 0)
 text = "64.0"
-script = ExtResource( "4" )
+script = ExtResource("4")
 
 [node name="PlatformAngle" type="HBoxContainer" parent="Controls"]
+layout_mode = 2
 offset_top = 36.0
-offset_right = 452.0
+offset_right = 277.0
 offset_bottom = 62.0
 theme_override_constants/separation = 20
 alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label" type="Label" parent="Controls/PlatformAngle"]
-offset_right = 112.0
+layout_mode = 2
+offset_right = 114.0
 offset_bottom = 26.0
 text = "Platform angle"
 
 [node name="HSlider" type="HSlider" parent="Controls/PlatformAngle"]
-offset_left = 132.0
-offset_right = 332.0
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+offset_left = 134.0
+offset_right = 234.0
 offset_bottom = 16.0
-rect_min_size = Vector2(200, 0)
 max_value = 360.0
-script = ExtResource( "5" )
+script = ExtResource("5")
 snap_step = 5.0
 
 [node name="LabelValue" type="Label" parent="Controls/PlatformAngle"]
-offset_left = 352.0
-offset_right = 452.0
+layout_mode = 2
+offset_left = 254.0
+offset_right = 277.0
 offset_bottom = 26.0
-rect_min_size = Vector2(100, 0)
 text = "0.0"
-script = ExtResource( "4" )
+script = ExtResource("4")
 
 [node name="BodyAngle" type="HBoxContainer" parent="Controls"]
+layout_mode = 2
 offset_top = 72.0
-offset_right = 452.0
+offset_right = 277.0
 offset_bottom = 98.0
 theme_override_constants/separation = 20
 alignment = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label" type="Label" parent="Controls/BodyAngle"]
-offset_left = 27.0
-offset_right = 112.0
+layout_mode = 2
+offset_left = 28.0
+offset_right = 114.0
 offset_bottom = 26.0
 text = "Body angle"
 
 [node name="HSlider" type="HSlider" parent="Controls/BodyAngle"]
-offset_left = 132.0
-offset_right = 332.0
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+offset_left = 134.0
+offset_right = 234.0
 offset_bottom = 16.0
-rect_min_size = Vector2(200, 0)
 max_value = 360.0
-script = ExtResource( "5" )
+script = ExtResource("5")
 snap_step = 5.0
 
 [node name="LabelValue" type="Label" parent="Controls/BodyAngle"]
-offset_left = 352.0
-offset_right = 452.0
+layout_mode = 2
+offset_left = 254.0
+offset_right = 277.0
 offset_bottom = 26.0
-rect_min_size = Vector2(100, 0)
 text = "0.0"
-script = ExtResource( "4" )
+script = ExtResource("4")
 
 [node name="LabelResultTitle" type="Label" parent="."]
+anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -150,13 +146,9 @@ offset_top = 251.131
 offset_right = 88.1273
 offset_bottom = 265.131
 text = "RESULT: "
-align = 1
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LabelResult" type="Label" parent="."]
+anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -166,13 +158,9 @@ offset_top = 266.131
 offset_right = 88.1273
 offset_bottom = 280.131
 text = "..."
-align = 1
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LabelRestart" type="Label" parent="."]
+anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -182,11 +170,6 @@ offset_top = 304.841
 offset_right = 139.127
 offset_bottom = 318.841
 text = "SPACE - RESTART"
-align = 1
-valign = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Timer" type="Timer" parent="."]
 wait_time = 5.0
@@ -196,29 +179,28 @@ one_shot = true
 position = Vector2(512, 300)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="TargetArea2D"]
-shape = SubResource( "CircleShape2D_e5nt1" )
+shape = SubResource("CircleShape2D_e5nt1")
 
 [node name="OneWayStaticBody2D" type="StaticBody2D" parent="."]
 position = Vector2(512, 300)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OneWayStaticBody2D"]
-shape = SubResource( "2" )
+shape = SubResource("2")
 one_way_collision = true
 
-[node name="RigidDynamicBody2D" type="RigidDynamicBody2D" parent="."]
+[node name="RigidBody2D" type="RigidBody2D" parent="."]
 position = Vector2(300, 300)
 collision_mask = 2147483649
 gravity_scale = 0.0
-contacts_reported = 1
 contact_monitor = true
 
-[node name="Sprite" type="Sprite2D" parent="RigidDynamicBody2D"]
+[node name="Sprite" type="Sprite2D" parent="RigidBody2D"]
 self_modulate = Color(1, 1, 1, 0.501961)
 scale = Vector2(0.5, 0.5)
-texture = ExtResource( "2" )
+texture = ExtResource("2")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="RigidDynamicBody2D"]
-shape = SubResource( "3" )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="RigidBody2D"]
+shape = SubResource("3")
 
 [node name="CharacterBody2D" type="CharacterBody2D" parent="."]
 position = Vector2(300, 300)
@@ -227,10 +209,10 @@ collision_mask = 2147483649
 [node name="Sprite" type="Sprite2D" parent="CharacterBody2D"]
 self_modulate = Color(1, 1, 1, 0.501961)
 scale = Vector2(0.5, 0.5)
-texture = ExtResource( "2" )
+texture = ExtResource("2")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBody2D"]
-shape = SubResource( "3" )
+shape = SubResource("3")
 
 [connection signal="value_changed" from="Controls/PlatformSize/HSlider" to="." method="_update_platform_size"]
 [connection signal="value_changed" from="Controls/PlatformAngle/HSlider" to="." method="_update_platform_angle"]

--- a/2d/physics_tests/tests/functional/test_raycasting.tscn
+++ b/2d/physics_tests/tests/functional/test_raycasting.tscn
@@ -26,7 +26,7 @@ theme_override_font_sizes/font_size = 16
 z_index = -1
 z_as_relative = false
 
-[node name="RigidBodyRectangle" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyRectangle" type="RigidBody2D" parent="Shapes"]
 position = Vector2(114.877, 248.76)
 freeze = true
 
@@ -35,14 +35,14 @@ rotation = -1.19206
 scale = Vector2(1.2, 1.2)
 shape = SubResource( "1" )
 
-[node name="RigidBodySphere" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodySphere" type="RigidBody2D" parent="Shapes"]
 position = Vector2(314.894, 257.658)
 freeze = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Shapes/RigidBodySphere"]
 shape = SubResource( "2" )
 
-[node name="RigidBodyCapsule" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyCapsule" type="RigidBody2D" parent="Shapes"]
 position = Vector2(465.629, 261.204)
 freeze = true
 
@@ -51,7 +51,7 @@ rotation = -0.202458
 scale = Vector2(1.2, 1.2)
 shape = SubResource( "3" )
 
-[node name="RigidBodyConvexPolygon" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyConvexPolygon" type="RigidBody2D" parent="Shapes"]
 position = Vector2(613.385, 252.771)
 freeze = true
 
@@ -62,7 +62,7 @@ polygon = PackedVector2Array(10.7, -54.5, 28.3596, -49.4067, 47.6282, -34.3806, 
 modulate = Color(1, 1, 1, 0.392157)
 texture = ExtResource( "1" )
 
-[node name="RigidBodyConcavePolygon" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyConcavePolygon" type="RigidBody2D" parent="Shapes"]
 position = Vector2(771.159, 252.771)
 freeze = true
 
@@ -73,7 +73,7 @@ polygon = PackedVector2Array(-5.93512, -43.2195, 6.44476, -42.9695, 11.127, -54.
 modulate = Color(1, 1, 1, 0.392157)
 texture = ExtResource( "1" )
 
-[node name="RigidBodyConcaveSegments" type="RigidDynamicBody2D" parent="Shapes"]
+[node name="RigidBodyConcaveSegments" type="RigidBody2D" parent="Shapes"]
 position = Vector2(930.097, 252.771)
 freeze = true
 

--- a/2d/physics_tests/tests/functional/test_shapes.tscn
+++ b/2d/physics_tests/tests/functional/test_shapes.tscn
@@ -20,7 +20,7 @@ script = ExtResource( "2" )
 
 [node name="DynamicShapes" type="Node2D" parent="."]
 
-[node name="RigidBodyRectangle" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyRectangle" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(96, 127)
 script = ExtResource( "3" )
 
@@ -28,7 +28,7 @@ script = ExtResource( "3" )
 rotation = 0.675442
 shape = SubResource( "1" )
 
-[node name="RigidBodyCapsule" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyCapsule" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(270.165, 139.444)
 script = ExtResource( "3" )
 
@@ -36,7 +36,7 @@ script = ExtResource( "3" )
 rotation = -0.202458
 shape = SubResource( "2" )
 
-[node name="RigidBodyConcavePolygon" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyConcavePolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(683.614, 132.749)
 script = ExtResource( "3" )
 
@@ -49,7 +49,7 @@ self_modulate = Color(1, 1, 1, 0.392157)
 scale = Vector2(0.5, 0.5)
 texture = ExtResource( "1" )
 
-[node name="RigidBodyConvexPolygon" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyConvexPolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(473.536, 134.336)
 script = ExtResource( "3" )
 
@@ -62,7 +62,7 @@ self_modulate = Color(1, 1, 1, 0.392157)
 scale = Vector2(0.5, 0.5)
 texture = ExtResource( "1" )
 
-[node name="RigidBodySphere" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodySphere" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(919.968, 115.129)
 script = ExtResource( "3" )
 

--- a/2d/physics_tests/tests/performance/test_perf_contact_islands.tscn
+++ b/2d/physics_tests/tests/performance/test_perf_contact_islands.tscn
@@ -57,28 +57,28 @@ position = Vector2(0, 125.017)
 
 [node name="DynamicShapes" type="Node2D" parent="."]
 
-[node name="RigidBodyRectangle" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyRectangle" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(0, 1024)
 gravity_scale = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodyRectangle"]
 shape = SubResource( "1" )
 
-[node name="RigidBodySphere" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodySphere" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(100, 1024)
 gravity_scale = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodySphere"]
 shape = SubResource( "2" )
 
-[node name="RigidBodyCapsule" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyCapsule" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(200, 1024)
 gravity_scale = 0.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodyCapsule"]
 shape = SubResource( "3" )
 
-[node name="RigidBodyConvexPolygon" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyConvexPolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(300, 1024)
 gravity_scale = 0.0
 
@@ -91,7 +91,7 @@ self_modulate = Color(1, 1, 1, 0.392157)
 scale = Vector2(0.1, 0.1)
 texture = ExtResource( "3" )
 
-[node name="RigidBodyConcavePolygon" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyConcavePolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(400, 1024)
 gravity_scale = 0.0
 

--- a/2d/physics_tests/tests/performance/test_perf_contacts.gd
+++ b/2d/physics_tests/tests/performance/test_perf_contacts.gd
@@ -186,7 +186,7 @@ func _activate_objects():
 		var spawn_parent = get_node(spawn)
 
 		for node_index in range(spawn_parent.get_child_count()):
-			var node = spawn_parent.get_child(node_index) as RigidDynamicBody2D
+			var node = spawn_parent.get_child(node_index) as RigidBody2D
 			node.set_sleeping(false)
 
 

--- a/2d/physics_tests/tests/performance/test_perf_contacts.tscn
+++ b/2d/physics_tests/tests/performance/test_perf_contacts.tscn
@@ -31,25 +31,25 @@ position = Vector2(0, 125.017)
 
 [node name="DynamicShapes" type="Node2D" parent="."]
 
-[node name="RigidBodyRectangle" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyRectangle" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(0, 1024)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodyRectangle"]
 shape = SubResource( "1" )
 
-[node name="RigidBodySphere" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodySphere" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(100, 1024)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodySphere"]
 shape = SubResource( "2" )
 
-[node name="RigidBodyCapsule" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyCapsule" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(200, 1024)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DynamicShapes/RigidBodyCapsule"]
 shape = SubResource( "3" )
 
-[node name="RigidBodyConvexPolygon" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyConvexPolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(300, 1024)
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="DynamicShapes/RigidBodyConvexPolygon"]
@@ -61,7 +61,7 @@ self_modulate = Color(1, 1, 1, 0.392157)
 scale = Vector2(0.25, 0.25)
 texture = ExtResource( "3" )
 
-[node name="RigidBodyConcavePolygon" type="RigidDynamicBody2D" parent="DynamicShapes"]
+[node name="RigidBodyConcavePolygon" type="RigidBody2D" parent="DynamicShapes"]
 position = Vector2(400, 1024)
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="DynamicShapes/RigidBodyConcavePolygon"]

--- a/2d/physics_tests/utils/characterbody_controller.gd
+++ b/2d/physics_tests/utils/characterbody_controller.gd
@@ -51,7 +51,7 @@ func _physics_process(_delta):
 	floor_stop_on_slope = _stop_on_slope
 	floor_block_on_wall = _move_on_floor_only
 	floor_constant_speed = _constant_speed
-	floor_max_angle = deg2rad(_floor_max_angle)
+	floor_max_angle = deg_to_rad(_floor_max_angle)
 	velocity = _velocity
 	move_and_slide()
 	_velocity = velocity

--- a/2d/physics_tests/utils/option_menu.gd
+++ b/2d/physics_tests/utils/option_menu.gd
@@ -47,7 +47,7 @@ func _add_popup(parent_popup, path, label):
 	parent_popup.add_child(popup_menu)
 	parent_popup.add_submenu_item(label, label)
 
-	popup_menu.connect(&"index_pressed", Callable(self, "_on_item_pressed"), [popup_menu, path])
+	popup_menu.connect(&"index_pressed", func(item_index): self._on_item_pressed(item_index, popup_menu, path))
 
 	return popup_menu
 

--- a/2d/physics_tests/utils/rigidbody_controller.gd
+++ b/2d/physics_tests/utils/rigidbody_controller.gd
@@ -1,4 +1,4 @@
-extends RigidDynamicBody2D
+extends RigidBody2D
 
 
 var _initial_velocity = Vector2.ZERO
@@ -62,11 +62,11 @@ func _integrate_forces(state):
 		var normal = state.get_contact_local_normal(i)
 
 		# Detect floor.
-		if acos(normal.dot(Vector2.UP)) <= deg2rad(_floor_max_angle) + 0.01:
+		if acos(normal.dot(Vector2.UP)) <= deg_to_rad(_floor_max_angle) + 0.01:
 			_on_floor = true
 
 		# Detect ceiling.
-		if acos(normal.dot(-Vector2.UP)) <= deg2rad(_floor_max_angle) + 0.01:
+		if acos(normal.dot(-Vector2.UP)) <= deg_to_rad(_floor_max_angle) + 0.01:
 			_jumping = false
 			_velocity.y = 0.0
 

--- a/2d/physics_tests/utils/rigidbody_pick.gd
+++ b/2d/physics_tests/utils/rigidbody_pick.gd
@@ -1,4 +1,4 @@
-extends RigidDynamicBody2D
+extends RigidBody2D
 
 
 var _picked = false

--- a/2d/physics_tests/utils/scroll_log.gd
+++ b/2d/physics_tests/utils/scroll_log.gd
@@ -17,4 +17,4 @@ func _process(_delta):
 
 func _on_scrolling():
 	auto_scroll = false
-	$"../CheckBoxScroll".pressed = false
+	$"../CheckBoxScroll".button_pressed = false


### PR DESCRIPTION
It fixes:

- Class name `RigidDynamicBody2D` to `RigidBody2D`
- The `popup_menu` signal "index_pressed" now uses a lambda to fix the binding arguments
- Godot 4 new method names (like `deg_to_rad` and so on...)
- All `HSlider` appeared broken. They are fixed using a `custom_minimum_size.x` value of 50/100.
- Scenes and godot.project files are just updated to Godot 4 beta 6 (I mean, I didn't change anything, Godot updated the values by itself)

All tests now works properly.