### PR TITLE
Fix property name of viewport width/height settings in Multiple resolutions

### DIFF
--- a/gui/multiple_resolutions/main.gd
+++ b/gui/multiple_resolutions/main.gd
@@ -4,7 +4,10 @@
 # (with their rect spread across the whole viewport, and Anchor set to Full Rect).
 extends Control
 
-var base_window_size = Vector2(ProjectSettings.get_setting("display/window/size/width"), ProjectSettings.get_setting("display/window/size/height"))
+var base_window_size = Vector2(
+	ProjectSettings.get_setting("display/window/size/viewport_width"),
+	ProjectSettings.get_setting("display/window/size/viewport_height")
+)
 
 # These defaults match this demo's project settings. Adjust as needed if adapting this
 # in your own project.

--- a/gui/multiple_resolutions/main.gd
+++ b/gui/multiple_resolutions/main.gd
@@ -5,8 +5,8 @@
 extends Control
 
 var base_window_size = Vector2(
-	ProjectSettings.get_setting("display/window/size/viewport_width"),
-	ProjectSettings.get_setting("display/window/size/viewport_height")
+		ProjectSettings.get_setting("display/window/size/viewport_width"),
+		ProjectSettings.get_setting("display/window/size/viewport_height")
 )
 
 # These defaults match this demo's project settings. Adjust as needed if adapting this


### PR DESCRIPTION
A fix for the `gui/multiple_resolutions` demo which wouldn't launch because it was using the old property name for viewport width/height settings. This led to the `Vector2` constructor being given null values which gave the following error: 
 
```
main.gd:7 - at function: @implicit_new: "Invalid call. Nonexistent 'Vector2' constructor." 
```
