### PR TITLE
Fix method names in GD Paint that have changed in 4.0

### DIFF
--- a/gui/gd_paint/paint_control.gd
+++ b/gui/gd_paint/paint_control.gd
@@ -115,7 +115,7 @@ func undo_stroke():
 	# If we are undoing a shape, then we can just remove the latest brush.
 	if undo_element_list_num == UNDO_MODE_SHAPE:
 		if brush_data_list.size() > 0:
-			brush_data_list.remove(brush_data_list.size() - 1)
+			brush_data_list.remove_at(brush_data_list.size() - 1)
 
 		# Now that we've undone a shape, we cannot undo again until another stoke is added.
 		undo_element_list_num = UNDO_NONE
@@ -135,7 +135,7 @@ func undo_stroke():
 		undo_element_list_num = UNDO_NONE
 
 	# Redraw the brushes
-	update()
+	queue_redraw()
 
 
 func add_brush(mouse_pos, type):
@@ -187,7 +187,7 @@ func add_brush(mouse_pos, type):
 
 	# Add the brush and update/draw all of the brushes.
 	brush_data_list.append(new_brush)
-	update()
+	queue_redraw()
 
 
 func _draw():
@@ -233,7 +233,7 @@ func save_picture(path):
 	# Get the viewport image.
 	var img = get_viewport().get_texture().get_image()
 	# Crop the image so we only have canvas area.
-	var cropped_image = img.get_rect(Rect2(drawing_area.position, drawing_area.size))
+	var cropped_image = img.get_region(Rect2(drawing_area.position, drawing_area.size))
 
 	# Save the image with the passed in path we got from the save dialog.
 	cropped_image.save_png(path)

--- a/gui/gd_paint/tools_panel.gd
+++ b/gui/gd_paint/tools_panel.gd
@@ -74,7 +74,7 @@ func button_pressed(button_name):
 	# If a opperation button is pressed
 	elif button_name == "clear_picture":
 		paint_control.brush_data_list = []
-		paint_control.update()
+		paint_control.queue_redraw()
 	elif button_name == "save_picture":
 		save_dialog.popup_centered()
 	elif button_name == "undo_stroke":
@@ -97,7 +97,7 @@ func background_color_changed(color):
 	get_parent().get_node(^"DrawingAreaBG").modulate = color
 	paint_control.bg_color = color
 	# Because of how the eraser works we also need to redraw the paint control.
-	paint_control.update()
+	paint_control.queue_redraw()
 
 
 func brush_size_changed(value):


### PR DESCRIPTION
Fixes a few method names in `gui/gd_paint` that have changed in Godot 4.0. This makes the demo fully functioning again as far as I can tell.