### PR TITLE
Fix and update the Operating System Testing demo

### DIFF
--- a/misc/os_test/actions.gd
+++ b/misc/os_test/actions.gd
@@ -67,7 +67,14 @@ func _on_AddGlobalMenuItems_pressed():
 
 
 func _on_RemoveGlobalMenuItem_pressed():
+	DisplayServer.global_menu_remove_item("_main/Hello", 2)
+	DisplayServer.global_menu_remove_item("_main/Hello", 1)
+	DisplayServer.global_menu_remove_item("_main/Hello", 0)
 	DisplayServer.global_menu_remove_item("_main", 0)
+
+	DisplayServer.global_menu_remove_item("_dock/Hello", 2)
+	DisplayServer.global_menu_remove_item("_dock/Hello", 1)
+	DisplayServer.global_menu_remove_item("_dock/Hello", 0)
 	DisplayServer.global_menu_remove_item("_dock", 0)
 
 

--- a/misc/os_test/actions.gd
+++ b/misc/os_test/actions.gd
@@ -55,7 +55,14 @@ func _on_VibrateDeviceLong_pressed():
 func _on_AddGlobalMenuItems_pressed():
 	# Add a menu to the main menu bar.
 	DisplayServer.global_menu_add_submenu_item("_main", "Hello", "_main/Hello")
-	DisplayServer.global_menu_add_item("_main/Hello", "World", func(tag): print("Clicked main 1 " + str(tag)))
+	DisplayServer.global_menu_add_item(
+			"_main/Hello",
+			"World",
+			func(tag): print("Clicked main 1 " + str(tag)),
+			func(tag): print("Key main 1 " + str(tag)),
+			null,
+			KEY_MASK_META + KEY_1
+	)
 	DisplayServer.global_menu_add_separator("_main/Hello")
 	DisplayServer.global_menu_add_item("_main/Hello", "World2", func(tag): print("Clicked main 2 " + str(tag)))
 

--- a/misc/os_test/actions.gd
+++ b/misc/os_test/actions.gd
@@ -55,15 +55,15 @@ func _on_VibrateDeviceLong_pressed():
 func _on_AddGlobalMenuItems_pressed():
 	# Add a menu to the main menu bar.
 	DisplayServer.global_menu_add_submenu_item("_main", "Hello", "_main/Hello")
-	DisplayServer.global_menu_add_item("_main/Hello", "World", func(): print("Clicked"))
+	DisplayServer.global_menu_add_item("_main/Hello", "World", func(tag): print("Clicked main 1 " + str(tag)))
 	DisplayServer.global_menu_add_separator("_main/Hello")
-	DisplayServer.global_menu_add_item("_main/Hello", "World2", func(): print("Clicked 2"))
+	DisplayServer.global_menu_add_item("_main/Hello", "World2", func(tag): print("Clicked main 2 " + str(tag)))
 
 	# Add a menu to the Dock context menu.
 	DisplayServer.global_menu_add_submenu_item("_dock", "Hello", "_dock/Hello")
-	DisplayServer.global_menu_add_item("_dock/Hello", "World", func(): print("Clicked"))
+	DisplayServer.global_menu_add_item("_dock/Hello", "World", func(tag): print("Clicked dock 1 " + str(tag)))
 	DisplayServer.global_menu_add_separator("_dock/Hello")
-	DisplayServer.global_menu_add_item("_dock/Hello", "World2", func(): print("Clicked 2"))
+	DisplayServer.global_menu_add_item("_dock/Hello", "World2", func(tag): print("Clicked dock 2 " + str(tag)))
 
 
 func _on_RemoveGlobalMenuItem_pressed():

--- a/misc/os_test/actions.gd
+++ b/misc/os_test/actions.gd
@@ -11,6 +11,10 @@ func _on_OpenShellFolder_pressed():
 		# Windows-specific.
 		path = OS.get_environment("USERPROFILE")
 
+	if OS.get_name() == "macOS":
+		# MacOS-specific.
+		path = "file://" + path
+
 	OS.shell_open(path)
 
 

--- a/misc/os_test/actions.gd
+++ b/misc/os_test/actions.gd
@@ -53,13 +53,22 @@ func _on_VibrateDeviceLong_pressed():
 
 
 func _on_AddGlobalMenuItems_pressed():
-	DisplayServer.global_menu_add_item("Hello", "World", func(): print("Clicked"), func(): print("Clicked Key"))
-	DisplayServer.global_menu_add_separator("Example Separator")
-	DisplayServer.global_menu_add_item("Hello2", "World2", func(): print("Clicked 2"), func(): print("Clicked Key 2"))
+	# Add a menu to the main menu bar.
+	DisplayServer.global_menu_add_submenu_item("_main", "Hello", "_main/Hello")
+	DisplayServer.global_menu_add_item("_main/Hello", "World", func(): print("Clicked"))
+	DisplayServer.global_menu_add_separator("_main/Hello")
+	DisplayServer.global_menu_add_item("_main/Hello", "World2", func(): print("Clicked 2"))
+
+	# Add a menu to the Dock context menu.
+	DisplayServer.global_menu_add_submenu_item("_dock", "Hello", "_dock/Hello")
+	DisplayServer.global_menu_add_item("_dock/Hello", "World", func(): print("Clicked"))
+	DisplayServer.global_menu_add_separator("_dock/Hello")
+	DisplayServer.global_menu_add_item("_dock/Hello", "World2", func(): print("Clicked 2"))
 
 
 func _on_RemoveGlobalMenuItem_pressed():
-	DisplayServer.global_menu_remove_item("Hello", 0)
+	DisplayServer.global_menu_remove_item("_main", 0)
+	DisplayServer.global_menu_remove_item("_dock", 0)
 
 
 func _on_GetClipboard_pressed():

--- a/misc/os_test/os_test.gd
+++ b/misc/os_test/os_test.gd
@@ -115,8 +115,10 @@ func _ready():
 
 	add_header("Input")
 	add_line("Device has touch screen", DisplayServer.is_touchscreen_available())
-	add_line("Device has virtual keyboard", DisplayServer.has_feature(DisplayServer.FEATURE_VIRTUAL_KEYBOARD))
-	add_line("Virtual keyboard height", DisplayServer.virtual_keyboard_get_height())
+	var has_virtual_keyboard = DisplayServer.has_feature(DisplayServer.FEATURE_VIRTUAL_KEYBOARD)
+	add_line("Device has virtual keyboard", has_virtual_keyboard)
+	if has_virtual_keyboard:
+		add_line("Virtual keyboard height", DisplayServer.virtual_keyboard_get_height())
 
 	add_header("Localization")
 	add_line("Locale", OS.get_locale())

--- a/misc/os_test/os_test.gd
+++ b/misc/os_test/os_test.gd
@@ -114,7 +114,7 @@ func _ready():
 	add_line("Device unique ID", OS.get_unique_id())
 
 	add_header("Input")
-	add_line("Device has touch screen", DisplayServer.screen_is_touchscreen())
+	add_line("Device has touch screen", DisplayServer.is_touchscreen_available())
 	add_line("Device has virtual keyboard", DisplayServer.has_feature(DisplayServer.FEATURE_VIRTUAL_KEYBOARD))
 	add_line("Virtual keyboard height", DisplayServer.virtual_keyboard_get_height())
 

--- a/misc/os_test/os_test.gd
+++ b/misc/os_test/os_test.gd
@@ -160,5 +160,9 @@ func _ready():
 		"CPU",
 	][RenderingServer.get_video_adapter_type()])
 	add_line("Adapter graphics API version", RenderingServer.get_video_adapter_api_version())
-	add_line("Adapter driver name", OS.get_video_adapter_driver_info()[0])
-	add_line("Adapter driver version", OS.get_video_adapter_driver_info()[1])
+
+	var video_adapter_driver_info = OS.get_video_adapter_driver_info()
+	if video_adapter_driver_info.size() > 0:
+		add_line("Adapter driver name", video_adapter_driver_info[0])
+	if video_adapter_driver_info.size() > 1:
+		add_line("Adapter driver version", video_adapter_driver_info[1])


### PR DESCRIPTION
Some fixes for the `misc/os_test` demo. One of them is an API change in 4.0 and the other two are platform specific. I wouldn't be surprised if the file URL change could be relevant on Linux also, but I don't have a machine setup to test that.

The demo now works without errors. Tested on beta 12.