### PR TITLE
Fix joypads demo button/axis mappings for 4.0

### DIFF
--- a/misc/joypads/joypad_diagram.tscn
+++ b/misc/joypads/joypad_diagram.tscn
@@ -39,70 +39,62 @@ region_enabled = true
 region_rect = Rect2(0, 0, 45, 45)
 
 [node name="4" type="Sprite2D" parent="Buttons"]
-position = Vector2(-161.038, -158.037)
-scale = Vector2(5.3348, 3.35512)
-texture = ExtResource("2")
-region_enabled = true
-region_rect = Rect2(10, 10, 10, 10)
-
-[node name="5" type="Sprite2D" parent="Buttons"]
-position = Vector2(159.362, -156.977)
-scale = Vector2(5.3348, 3.35512)
-texture = ExtResource("2")
-region_enabled = true
-region_rect = Rect2(10, 10, 10, 10)
-
-[node name="6" type="Sprite2D" parent="Buttons"]
-position = Vector2(-159.349, -221.878)
-scale = Vector2(1.0458, 2.16952)
-texture = ExtResource("2")
-flip_h = true
-region_enabled = true
-region_rect = Rect2(0, 0, 45, 22)
-
-[node name="7" type="Sprite2D" parent="Buttons"]
-position = Vector2(156.677, -220.11)
-scale = Vector2(1.0458, 2.16952)
-texture = ExtResource("2")
-region_enabled = true
-region_rect = Rect2(0, 0, 45, 22)
-
-[node name="8" type="Sprite2D" parent="Buttons"]
-position = Vector2(-67.5308, 164.422)
-scale = Vector2(0.9, 0.9)
-texture = ExtResource("2")
-region_enabled = true
-region_rect = Rect2(0, 0, 45, 45)
-
-[node name="9" type="Sprite2D" parent="Buttons"]
-position = Vector2(75.8825, 167.363)
-scale = Vector2(0.9, 0.9)
-texture = ExtResource("2")
-region_enabled = true
-region_rect = Rect2(0, 0, 45, 45)
-
-[node name="10" type="Sprite2D" parent="Buttons"]
 position = Vector2(-46.6707, 52.702)
 scale = Vector2(0.810497, 0.57205)
 texture = ExtResource("2")
 region_enabled = true
 region_rect = Rect2(0, 0, 45, 45)
 
-[node name="11" type="Sprite2D" parent="Buttons"]
-position = Vector2(56.2581, 54.4382)
+[node name="5" type="Sprite2D" parent="Buttons"]
+position = Vector2(4.00006, 64)
+scale = Vector2(0.9, 0.9)
+texture = ExtResource("2")
+region_enabled = true
+region_rect = Rect2(0, 0, 45, 45)
+
+[node name="6" type="Sprite2D" parent="Buttons"]
+position = Vector2(56.2582, 54.4382)
 scale = Vector2(0.810497, 0.57205)
 texture = ExtResource("2")
 region_enabled = true
 region_rect = Rect2(0, 0, 45, 45)
 
-[node name="12" type="Sprite2D" parent="Buttons"]
+[node name="7" type="Sprite2D" parent="Buttons"]
+position = Vector2(-67.5308, 164.422)
+scale = Vector2(0.9, 0.9)
+texture = ExtResource("2")
+region_enabled = true
+region_rect = Rect2(0, 0, 45, 45)
+
+[node name="8" type="Sprite2D" parent="Buttons"]
+position = Vector2(75.8825, 167.363)
+scale = Vector2(0.9, 0.9)
+texture = ExtResource("2")
+region_enabled = true
+region_rect = Rect2(0, 0, 45, 45)
+
+[node name="9" type="Sprite2D" parent="Buttons"]
+position = Vector2(-161.038, -158.037)
+scale = Vector2(5.3348, 3.35512)
+texture = ExtResource("2")
+region_enabled = true
+region_rect = Rect2(10, 10, 10, 10)
+
+[node name="10" type="Sprite2D" parent="Buttons"]
+position = Vector2(159.362, -156.977)
+scale = Vector2(5.3348, 3.35512)
+texture = ExtResource("2")
+region_enabled = true
+region_rect = Rect2(10, 10, 10, 10)
+
+[node name="11" type="Sprite2D" parent="Buttons"]
 position = Vector2(-139.402, 46.8295)
 scale = Vector2(0.9, 0.9)
 texture = ExtResource("2")
 region_enabled = true
 region_rect = Rect2(50, 0, 54, 14)
 
-[node name="13" type="Sprite2D" parent="Buttons"]
+[node name="12" type="Sprite2D" parent="Buttons"]
 position = Vector2(-139.838, 115.789)
 scale = Vector2(0.9, 0.9)
 texture = ExtResource("2")
@@ -110,14 +102,14 @@ flip_v = true
 region_enabled = true
 region_rect = Rect2(50, 0, 54, 14)
 
-[node name="14" type="Sprite2D" parent="Buttons"]
+[node name="13" type="Sprite2D" parent="Buttons"]
 position = Vector2(-172.262, 81.8793)
 scale = Vector2(0.9, 0.9)
 texture = ExtResource("2")
 region_enabled = true
 region_rect = Rect2(50, 0, 14, 54)
 
-[node name="15" type="Sprite2D" parent="Buttons"]
+[node name="14" type="Sprite2D" parent="Buttons"]
 position = Vector2(-105.085, 81.0326)
 scale = Vector2(0.9, 0.9)
 texture = ExtResource("2")
@@ -125,9 +117,9 @@ flip_h = true
 region_enabled = true
 region_rect = Rect2(50, 0, 14, 54)
 
-[node name="16" type="Sprite2D" parent="Buttons"]
-position = Vector2(4, 64)
-scale = Vector2(0.9, 0.9)
+[node name="15" type="Sprite2D" parent="Buttons"]
+position = Vector2(3.5, 106.906)
+scale = Vector2(0.810497, 0.57205)
 texture = ExtResource("2")
 region_enabled = true
 region_rect = Rect2(0, 0, 45, 45)
@@ -193,3 +185,18 @@ texture = ExtResource("2")
 flip_v = true
 region_enabled = true
 region_rect = Rect2(50, 0, 54, 14)
+
+[node name="4" type="Sprite2D" parent="Axes"]
+position = Vector2(-159.349, -221.878)
+scale = Vector2(1.0458, 2.16952)
+texture = ExtResource("2")
+flip_h = true
+region_enabled = true
+region_rect = Rect2(0, 0, 45, 22)
+
+[node name="5" type="Sprite2D" parent="Axes"]
+position = Vector2(156.677, -220.11)
+scale = Vector2(1.0458, 2.16952)
+texture = ExtResource("2")
+region_enabled = true
+region_rect = Rect2(0, 0, 45, 22)

--- a/misc/joypads/joypads.gd
+++ b/misc/joypads/joypads.gd
@@ -37,7 +37,7 @@ func _process(_delta):
 		joypad_name.set_text(Input.get_joy_name(joy_num) + "\n" + Input.get_joy_guid(joy_num))
 
 	# Loop through the axes and show their current values.
-	for axis in range(int(min(JOY_AXIS_MAX, 11))):
+	for axis in range(int(min(JOY_AXIS_MAX, 10))):
 		axis_value = Input.get_joy_axis(joy_num, axis)
 		axes.get_node("Axis" + str(axis) + "/ProgressBar").set_value(100 * axis_value)
 		axes.get_node("Axis" + str(axis) + "/ProgressBar/Value").set_text(str(axis_value))
@@ -58,20 +58,13 @@ func _process(_delta):
 				joypad_axes.get_node(str(axis) + "-").show()
 				# Transparent white modulate, non-alpha color channels are not changed here.
 				joypad_axes.get_node(str(axis) + "-").self_modulate.a = scaled_alpha_value
-		elif axis == JOY_AXIS_TRIGGER_LEFT:
+		elif axis == JOY_AXIS_TRIGGER_LEFT || axis == JOY_AXIS_TRIGGER_RIGHT:
 			if axis_value <= DEADZONE:
-				joypad_buttons.get_child(JOY_AXIS_TRIGGER_LEFT).hide()
+				joypad_axes.get_node(str(axis)).hide()
 			else:
-				joypad_buttons.get_child(JOY_AXIS_TRIGGER_LEFT).show()
+				joypad_axes.get_node(str(axis)).show()
 				# Transparent white modulate, non-alpha color channels are not changed here.
-				joypad_buttons.get_child(JOY_AXIS_TRIGGER_LEFT).self_modulate.a = scaled_alpha_value
-		elif axis == JOY_AXIS_TRIGGER_RIGHT:
-			if axis_value <= DEADZONE:
-				joypad_buttons.get_child(JOY_AXIS_TRIGGER_RIGHT).hide()
-			else:
-				joypad_buttons.get_child(JOY_AXIS_TRIGGER_RIGHT).show()
-				# Transparent white modulate, non-alpha color channels are not changed here.
-				joypad_buttons.get_child(JOY_AXIS_TRIGGER_RIGHT).self_modulate.a = scaled_alpha_value
+				joypad_axes.get_node(str(axis)).self_modulate.a = scaled_alpha_value
 
 		# Highlight axis labels that are within the "active" value range. Simular to the button highlighting for loop below.
 		axes.get_node("Axis" + str(axis) + "/Label").add_theme_color_override("font_color", FONT_COLOR_DEFAULT)
@@ -79,14 +72,14 @@ func _process(_delta):
 			axes.get_node("Axis" + str(axis) + "/Label").add_theme_color_override("font_color", FONT_COLOR_ACTIVE)
 
 	# Loop through the buttons and highlight the ones that are pressed.
-	for button in range(int(min(JOY_BUTTON_MAX, 24))):
+	for button in range(int(min(JOY_BUTTON_SDL_MAX, 21))):
 		if Input.is_joy_button_pressed(joy_num, button):
 			button_grid.get_child(button).add_theme_color_override("font_color", FONT_COLOR_ACTIVE)
-			if button < 17 and button != JOY_AXIS_TRIGGER_LEFT and button != JOY_AXIS_TRIGGER_RIGHT:
+			if button <= JOY_BUTTON_MISC1:
 				joypad_buttons.get_child(button).show()
 		else:
 			button_grid.get_child(button).add_theme_color_override("font_color", FONT_COLOR_DEFAULT)
-			if button < 17 and button != JOY_AXIS_TRIGGER_LEFT and button != JOY_AXIS_TRIGGER_RIGHT:
+			if button <= JOY_BUTTON_MISC1:
 				joypad_buttons.get_child(button).hide()
 
 

--- a/misc/joypads/joypads.tscn
+++ b/misc/joypads/joypads.tscn
@@ -60,65 +60,54 @@ grow_vertical = 2
 script = ExtResource("1")
 
 [node name="JoypadDiagram" parent="." instance=ExtResource("2")]
-position = Vector2(415, 170)
+position = Vector2(415, 183)
 scale = Vector2(0.5, 0.5)
 
 [node name="DeviceInfo" type="HBoxContainer" parent="."]
-anchors_preset = 10
+layout_mode = 0
 anchor_right = 1.0
 offset_bottom = 30.0
 grow_horizontal = 2
 
 [node name="Label" type="Label" parent="DeviceInfo"]
-offset_right = 52.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_vertical = 1
 text = "Device"
 
 [node name="JoyNumber" type="SpinBox" parent="DeviceInfo"]
-offset_left = 56.0
-offset_right = 139.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_vertical = 0
 max_value = 16.0
 
 [node name="VSeparator" type="VSeparator" parent="DeviceInfo"]
 modulate = Color(1, 1, 1, 0)
-offset_left = 143.0
-offset_right = 147.0
-offset_bottom = 31.0
+layout_mode = 2
 
 [node name="JoyName" type="Label" parent="DeviceInfo"]
-offset_left = 151.0
-offset_right = 540.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "Controller Name Here"
 
 [node name="Axes" type="VBoxContainer" parent="."]
-offset_top = 50.0
+layout_mode = 0
+offset_top = 62.0
 offset_right = 255.0
-offset_bottom = 310.0
+offset_bottom = 322.0
 theme_override_constants/separation = -2
 
 [node name="Axis0" type="HBoxContainer" parent="Axes"]
-offset_right = 255.0
-offset_bottom = 26.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis0"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 0"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis0"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_g3l3j")
@@ -128,7 +117,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis0/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -138,23 +127,17 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Axis1" type="HBoxContainer" parent="Axes"]
-offset_top = 24.0
-offset_right = 255.0
-offset_bottom = 50.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis1"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 1"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis1"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
@@ -164,7 +147,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis1/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -174,23 +157,17 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Axis2" type="HBoxContainer" parent="Axes"]
-offset_top = 48.0
-offset_right = 255.0
-offset_bottom = 74.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis2"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 2"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis2"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
@@ -200,7 +177,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis2/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -210,23 +187,17 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Axis3" type="HBoxContainer" parent="Axes"]
-offset_top = 72.0
-offset_right = 255.0
-offset_bottom = 98.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis3"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 3"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis3"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
@@ -236,7 +207,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis3/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -246,23 +217,17 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Axis4" type="HBoxContainer" parent="Axes"]
-offset_top = 96.0
-offset_right = 255.0
-offset_bottom = 122.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis4"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 4"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis4"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
@@ -272,7 +237,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis4/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -282,23 +247,17 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Axis5" type="HBoxContainer" parent="Axes"]
-offset_top = 120.0
-offset_right = 255.0
-offset_bottom = 146.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis5"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 5"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis5"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
@@ -308,7 +267,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis5/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -318,23 +277,17 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Axis6" type="HBoxContainer" parent="Axes"]
-offset_top = 144.0
-offset_right = 255.0
-offset_bottom = 170.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis6"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 6"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis6"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
@@ -344,7 +297,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis6/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -354,23 +307,17 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Axis7" type="HBoxContainer" parent="Axes"]
-offset_top = 168.0
-offset_right = 255.0
-offset_bottom = 194.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis7"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 7"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis7"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
@@ -380,7 +327,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis7/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -390,23 +337,17 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Axis8" type="HBoxContainer" parent="Axes"]
-offset_top = 192.0
-offset_right = 255.0
-offset_bottom = 218.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis8"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 8"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis8"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
@@ -416,7 +357,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis8/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -426,23 +367,17 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Axis9" type="HBoxContainer" parent="Axes"]
-offset_top = 216.0
-offset_right = 255.0
-offset_bottom = 242.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Axes/Axis9"]
-offset_right = 57.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 0.3
 text = "Axis 9"
 
 [node name="ProgressBar" type="ProgressBar" parent="Axes/Axis9"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
@@ -452,43 +387,7 @@ step = 0.0001
 show_percentage = false
 
 [node name="Value" type="Label" parent="Axes/Axis9/ProgressBar"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_vertical = 1
-text = "0"
-horizontal_alignment = 1
-
-[node name="Axis10" type="HBoxContainer" parent="Axes"]
-offset_top = 240.0
-offset_right = 255.0
-offset_bottom = 266.0
-
-[node name="Label" type="Label" parent="Axes/Axis10"]
-offset_right = 57.0
-offset_bottom = 26.0
-size_flags_horizontal = 3
-size_flags_vertical = 1
-size_flags_stretch_ratio = 0.3
-text = "Axis 10"
-
-[node name="ProgressBar" type="ProgressBar" parent="Axes/Axis10"]
-offset_left = 61.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 23.0
-size_flags_horizontal = 3
-size_flags_vertical = 4
-theme_override_styles/background = SubResource("StyleBoxFlat_ehk82")
-theme_override_styles/fill = SubResource("StyleBoxFlat_ujhcf")
-min_value = -100.0
-step = 0.0001
-show_percentage = false
-
-[node name="Value" type="Label" parent="Axes/Axis10/ProgressBar"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
@@ -498,300 +397,207 @@ text = "0"
 horizontal_alignment = 1
 
 [node name="Buttons" type="VBoxContainer" parent="."]
+layout_mode = 1
 anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -250.0
-offset_top = -150.0
-offset_bottom = -34.0
+offset_top = -138.0
+offset_bottom = -22.0
 grow_horizontal = 0
 grow_vertical = 0
 
 [node name="Label" type="Label" parent="Buttons"]
-offset_right = 66.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 2
 size_flags_vertical = 0
 text = "Buttons:"
 
 [node name="ButtonGrid" type="GridContainer" parent="Buttons"]
-offset_top = 30.0
-offset_right = 250.0
-offset_bottom = 116.0
+layout_mode = 2
 columns = 8
 
 [node name="0" type="Label" parent="Buttons/ButtonGrid"]
-offset_right = 28.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "0"
 
 [node name="1" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 32.0
-offset_right = 60.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "1"
 
 [node name="2" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 64.0
-offset_right = 92.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "2"
 
 [node name="3" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 96.0
-offset_right = 124.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "3"
 
 [node name="4" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 128.0
-offset_right = 156.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "4"
 
 [node name="5" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 160.0
-offset_right = 188.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "5"
 
 [node name="6" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 192.0
-offset_right = 219.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "6"
 
 [node name="7" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 223.0
-offset_right = 250.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "7"
 
 [node name="8" type="Label" parent="Buttons/ButtonGrid"]
-offset_top = 30.0
-offset_right = 28.0
-offset_bottom = 56.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "8"
 
 [node name="9" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 32.0
-offset_top = 30.0
-offset_right = 60.0
-offset_bottom = 56.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "9"
 
 [node name="10" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 64.0
-offset_top = 30.0
-offset_right = 92.0
-offset_bottom = 56.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "10"
 
 [node name="11" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 96.0
-offset_top = 30.0
-offset_right = 124.0
-offset_bottom = 56.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "11"
 
 [node name="12" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 128.0
-offset_top = 30.0
-offset_right = 156.0
-offset_bottom = 56.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "12"
 
 [node name="13" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 160.0
-offset_top = 30.0
-offset_right = 188.0
-offset_bottom = 56.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "13"
 
 [node name="14" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 192.0
-offset_top = 30.0
-offset_right = 219.0
-offset_bottom = 56.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "14"
 
 [node name="15" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 223.0
-offset_top = 30.0
-offset_right = 250.0
-offset_bottom = 56.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "15"
 
 [node name="16" type="Label" parent="Buttons/ButtonGrid"]
-offset_top = 60.0
-offset_right = 28.0
-offset_bottom = 86.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "16"
 
 [node name="17" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 32.0
-offset_top = 60.0
-offset_right = 60.0
-offset_bottom = 86.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "17"
 
 [node name="18" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 64.0
-offset_top = 60.0
-offset_right = 92.0
-offset_bottom = 86.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "18"
 
 [node name="19" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 96.0
-offset_top = 60.0
-offset_right = 124.0
-offset_bottom = 86.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "19"
 
 [node name="20" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 128.0
-offset_top = 60.0
-offset_right = 156.0
-offset_bottom = 86.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "20"
 
-[node name="21" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 160.0
-offset_top = 60.0
-offset_right = 188.0
-offset_bottom = 86.0
-size_flags_horizontal = 3
-size_flags_vertical = 1
-text = "21"
-
-[node name="22" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 192.0
-offset_top = 60.0
-offset_right = 219.0
-offset_bottom = 86.0
-size_flags_horizontal = 3
-size_flags_vertical = 1
-text = "22"
-
-[node name="23" type="Label" parent="Buttons/ButtonGrid"]
-offset_left = 223.0
-offset_top = 60.0
-offset_right = 250.0
-offset_bottom = 86.0
-size_flags_horizontal = 3
-size_flags_vertical = 1
-text = "23"
-
 [node name="Vibration" type="VBoxContainer" parent="."]
+layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
-offset_top = -140.0
-offset_right = 260.0
+offset_top = -128.0
+offset_right = 270.0
+offset_bottom = 16.0
 grow_vertical = 0
 
 [node name="Weak" type="HBoxContainer" parent="Vibration"]
-offset_right = 270.0
-offset_bottom = 31.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Vibration/Weak"]
-offset_right = 183.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "Vibration Weak Motor:"
 
 [node name="Value" type="SpinBox" parent="Vibration/Weak"]
-offset_left = 187.0
-offset_right = 270.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_vertical = 3
 max_value = 1.0
 step = 0.05
 value = 1.0
 
 [node name="Strong" type="HBoxContainer" parent="Vibration"]
-offset_top = 35.0
-offset_right = 270.0
-offset_bottom = 66.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Vibration/Strong"]
-offset_right = 183.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "Vibration Strong Motor:"
 
 [node name="Value" type="SpinBox" parent="Vibration/Strong"]
-offset_left = 187.0
-offset_right = 270.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_vertical = 3
 max_value = 1.0
 step = 0.05
 value = 1.0
 
 [node name="Duration" type="HBoxContainer" parent="Vibration"]
-offset_top = 70.0
-offset_right = 270.0
-offset_bottom = 101.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="Vibration/Duration"]
-offset_right = 183.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 text = "Vibration Duration:"
 
 [node name="Value" type="SpinBox" parent="Vibration/Duration"]
-offset_left = 187.0
-offset_right = 270.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_vertical = 3
 max_value = 10.0
 step = 0.1
@@ -799,18 +605,13 @@ value = 1.0
 
 [node name="HSeparator" type="HSeparator" parent="Vibration"]
 modulate = Color(1, 1, 1, 0)
-offset_top = 105.0
-offset_right = 270.0
-offset_bottom = 109.0
+layout_mode = 2
 
 [node name="Buttons" type="HBoxContainer" parent="Vibration"]
-offset_top = 113.0
-offset_right = 270.0
-offset_bottom = 144.0
+layout_mode = 2
 
 [node name="Start" type="Button" parent="Vibration/Buttons"]
-offset_right = 129.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 focus_mode = 0
@@ -818,46 +619,38 @@ text = "Start Vibration"
 
 [node name="VSeparator" type="VSeparator" parent="Vibration/Buttons"]
 modulate = Color(1, 1, 1, 0)
-offset_left = 133.0
-offset_right = 137.0
-offset_bottom = 31.0
+layout_mode = 2
 
 [node name="Stop" type="Button" parent="Vibration/Buttons"]
-offset_left = 141.0
-offset_right = 270.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 text = "Stop Vibration"
 
 [node name="VBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 1
 anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -261.0
-offset_top = -30.0
-offset_bottom = 1.0
+offset_top = -18.0
+offset_bottom = 13.0
 grow_horizontal = 0
 grow_vertical = 0
 alignment = 1
 
 [node name="Clear" type="Button" parent="VBoxContainer"]
-offset_right = 141.0
-offset_bottom = 31.0
+layout_mode = 2
 text = "Set Raw Mapping"
 
 [node name="Remap" type="Button" parent="VBoxContainer"]
-offset_left = 145.0
-offset_right = 207.0
-offset_bottom = 31.0
+layout_mode = 2
 text = "Remap"
 
 [node name="Show" type="Button" parent="VBoxContainer"]
-offset_left = 211.0
-offset_right = 261.0
-offset_bottom = 31.0
+layout_mode = 2
 text = "Show"
 
 [node name="RemapWizard" parent="." instance=ExtResource("3")]

--- a/misc/joypads/project.godot
+++ b/misc/joypads/project.godot
@@ -8,16 +8,6 @@
 
 config_version=5
 
-_global_script_classes=[{
-"base": "RefCounted",
-"class": &"JoyMapping",
-"language": &"GDScript",
-"path": "res://remap/joy_mapping.gd"
-}]
-_global_script_class_icons={
-"JoyMapping": ""
-}
-
 [application]
 
 config/name="Joypads"
@@ -30,7 +20,7 @@ config/icon="res://icon.png"
 [display]
 
 window/size/viewport_width=600
-window/size/viewport_height=540
+window/size/viewport_height=560
 window/vsync/vsync_mode=0
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"


### PR DESCRIPTION
- Many of the values in the diagram were out of sync with their current enum values.
- Properly moved triggers from buttons to axes.
- Removed 'Axis 10' (11th axis), we only support 10.
- Removed buttons beyond SDL_MAX.
- Show approximate position for MISC button, though we lack it on the gamepad image.

Couldn't really test the latter as with my Xbox Series gamepad on Linux it errors with:
```
ERROR: Index (int)p_button = 260154452 is out of bounds ((int)JoyButton::MAX = 128).
   at: joy_button (core/input/input.cpp:953)
```
But that's a Godot bug.