### PR TITLE
Fix "is mount_event" check in gui_in_3d to work with both 4 beta and 4 rc 

### DIFF
--- a/plugins/addons/main_screen/main_screen_plugin.gd
+++ b/plugins/addons/main_screen/main_screen_plugin.gd
@@ -29,7 +29,7 @@ func _make_visible(visible):
 
 # If your plugin doesn't handle any node types, you can remove this method.
 func _handles(object):
-	return object is preload("res://addons/main_screen/handled_by_main_screen.gd")
+	return is_instance_of(object, preload("res://addons/main_screen/handled_by_main_screen.gd"))
 
 
 func _get_plugin_name():

--- a/viewport/gui_in_3d/gui_3d.gd
+++ b/viewport/gui_in_3d/gui_3d.gd
@@ -36,7 +36,7 @@ func _unhandled_input(event):
 	# Check if the event is a non-mouse/non-touch event
 	var is_mouse_event = false
 	for mouse_event in [InputEventMouseButton, InputEventMouseMotion, InputEventScreenDrag, InputEventScreenTouch]:
-		if event is mouse_event:
+		if is_instance_of(event, mouse_event):
 			is_mouse_event = true
 			break
 


### PR DESCRIPTION
The existing code for the `gui_in_3d` demo doesn't work on the latest RC, it throws this error:

    Error at (39, 18): Could not find type "mouse_event" in the current scope".

I changed it to use get_class and a simple match which works on beta17 and rc5


<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest Godot version of the branch you're submitting to.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
