### PR TITLE
Remove unnecessary `randomize()`

### DIFF
--- a/2d/bullet_shower/bullets.gd
+++ b/2d/bullet_shower/bullets.gd
@@ -24,8 +24,6 @@ class Bullet:
 
 
 func _ready():
-	randomize()
-
 	shape = PhysicsServer2D.circle_shape_create()
 	# Set the collision shape's radius for each bullet in pixels.
 	PhysicsServer2D.shape_set_data(shape, 8)

--- a/2d/dodge_the_creeps/Main.gd
+++ b/2d/dodge_the_creeps/Main.gd
@@ -3,10 +3,6 @@ extends Node
 @export var mob_scene: PackedScene
 var score
 
-func _ready():
-	randomize()
-
-
 func game_over():
 	$ScoreTimer.stop()
 	$MobTimer.stop()

--- a/networking/webrtc_signaling/demo/client_ui.gd
+++ b/networking/webrtc_signaling/demo/client_ui.gd
@@ -65,7 +65,6 @@ func _on_peers_pressed():
 
 
 func _on_ping_pressed():
-	randomize()
 	ping.rpc(randf())
 
 

--- a/viewport/dynamic_split_screen/wall_coloring.gd
+++ b/viewport/dynamic_split_screen/wall_coloring.gd
@@ -5,7 +5,6 @@ extends Node3D
 # To use, attach this script to the "Walls" node.
 
 func _ready():
-	randomize()
 	var walls = get_tree().get_nodes_in_group("walls")
 	for wall in walls:
 		var material = StandardMaterial3D.new()


### PR DESCRIPTION
[@GlobalScope.randomize](https://docs.godotengine.org/en/latest/classes/class_%40globalscope.html#class-globalscope-method-randomize):

> Note: This function is called automatically when the project is run. If you need to fix the [seed](https://docs.godotengine.org/en/latest/classes/class_%40globalscope.html#class-globalscope-method-seed) to have consistent, reproducible results, use seed to initialize the random number generator.