### PR TITLE
Fix renamed `vulkan/rendering/back_end=1` setting (Vulkan Mobile)

### DIFF
--- a/2d/bullet_shower/project.godot
+++ b/2d/bullet_shower/project.godot
@@ -34,4 +34,4 @@ window/stretch/aspect="expand"
 
 [rendering]
 
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"

--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -76,4 +76,4 @@ start_game={
 
 [rendering]
 
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"

--- a/2d/instancing/project.godot
+++ b/2d/instancing/project.godot
@@ -30,4 +30,4 @@ window/stretch/aspect="expand"
 
 environment/defaults/default_clear_color=Color(0.239216, 0.0823529, 0.156863, 1)
 anti_aliasing/quality/msaa_2d=2
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"

--- a/2d/pong/project.godot
+++ b/2d/pong/project.godot
@@ -59,5 +59,5 @@ right_move_up={
 
 environment/defaults/default_clear_color=Color(0.105882, 0.105882, 0.12549, 1)
 textures/canvas_textures/default_texture_filter=0
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"
 2d/snapping/use_gpu_pixel_snap=true

--- a/audio/mic_record/project.godot
+++ b/audio/mic_record/project.godot
@@ -33,4 +33,4 @@ window/stretch/aspect="expand"
 
 [rendering]
 
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"

--- a/gui/control_gallery/project.godot
+++ b/gui/control_gallery/project.godot
@@ -27,4 +27,3 @@ window/stretch/aspect="expand"
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
-vulkan/rendering/back_end=1

--- a/gui/gd_paint/project.godot
+++ b/gui/gd_paint/project.godot
@@ -29,4 +29,4 @@ window/stretch/aspect="keep_height"
 
 [rendering]
 
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"

--- a/gui/input_mapping/project.godot
+++ b/gui/input_mapping/project.godot
@@ -61,4 +61,4 @@ dash={
 
 [rendering]
 
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"

--- a/gui/multiple_resolutions/project.godot
+++ b/gui/multiple_resolutions/project.godot
@@ -47,6 +47,5 @@ theme/default_font_multichannel_signed_distance_field=true
 
 [rendering]
 
+renderer/rendering_method="mobile"
 environment/defaults/default_clear_color=Color(0.133333, 0.133333, 0.2, 1)
-vulkan/rendering/back_end=1
-quality/driver/driver_name="GLES2"

--- a/gui/pseudolocalization/project.godot
+++ b/gui/pseudolocalization/project.godot
@@ -22,4 +22,4 @@ pseudolocalization/double_vowels=true
 
 [rendering]
 
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"

--- a/gui/translation/project.godot
+++ b/gui/translation/project.godot
@@ -41,4 +41,4 @@ translations=PackedStringArray("res://text.en.translation", "res://text.es.trans
 
 [rendering]
 
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"

--- a/misc/pause/project.godot
+++ b/misc/pause/project.godot
@@ -26,4 +26,4 @@ window/stretch/aspect="expand"
 environment/defaults/default_clear_color=Color(0.133333, 0.133333, 0.133333, 1)
 anti_aliasing/quality/msaa_3d=2
 anti_aliasing/quality/use_debanding=true
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"

--- a/misc/window_management/project.godot
+++ b/misc/window_management/project.godot
@@ -83,4 +83,4 @@ move_right={
 renderer/rendering_method="mobile"
 textures/default_filters/anisotropic_filtering_level=4
 anti_aliasing/quality/msaa_3d=2
-vulkan/rendering/back_end=1
+renderer/rendering_method="mobile"


### PR DESCRIPTION
See #866. These demos work on Forward+ in master, but READMEs say Vulkan Mobile.