### PR TITLE
GUI/InputRemapMenu demo fixed to work with Godot 4

### DIFF
--- a/gui/drag_and_drop/drag_and_drop.tscn
+++ b/gui/drag_and_drop/drag_and_drop.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=2 format=3 uid="uid://1mfnl544gxqb"]
 
-[ext_resource path="res://drag_drop_script.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://drag_drop_script.gd" id="1"]
 
 [node name="DragAndDrop" type="Control"]
+layout_mode = 3
+anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -11,15 +13,12 @@ offset_left = -512.0
 offset_top = -300.0
 offset_right = 512.0
 offset_bottom = 300.0
-rect_pivot_offset = Vector2(512, 300)
+pivot_offset = Vector2(512, 300)
 size_flags_horizontal = 2
 size_flags_vertical = 2
-__meta__ = {
-"__editor_plugin_screen__": "2D",
-"_edit_use_anchors_": false
-}
 
 [node name="Information" type="Label" parent="."]
+layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -31,12 +30,9 @@ offset_bottom = -150.0
 size_flags_horizontal = 2
 size_flags_vertical = 0
 text = "Drag colors from button to button, or change button colors and drag them again."
-align = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="GridContainer" type="GridContainer" parent="."]
+layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -46,108 +42,75 @@ offset_top = -150.0
 offset_right = 250.0
 offset_bottom = 200.0
 columns = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ColorPickerButton0" type="ColorPickerButton" parent="GridContainer"]
-offset_left = 34.0
-offset_top = 25.0
-offset_right = 130.0
-offset_bottom = 89.0
-rect_min_size = Vector2(96, 64)
+custom_minimum_size = Vector2(96, 64)
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
 color = Color(0.671032, 0.605183, 0, 1)
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("1")
 
 [node name="ColorPickerButton1" type="ColorPickerButton" parent="GridContainer"]
-offset_left = 202.0
-offset_top = 25.0
-offset_right = 298.0
-offset_bottom = 89.0
-rect_min_size = Vector2(96, 64)
+custom_minimum_size = Vector2(96, 64)
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
 color = Color(0, 0.797347, 0.741037, 1)
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="ColorPickerButton2" type="ColorPickerButton" parent="GridContainer"]
-offset_left = 370.0
-offset_top = 25.0
-offset_right = 466.0
-offset_bottom = 89.0
-rect_min_size = Vector2(96, 64)
+custom_minimum_size = Vector2(96, 64)
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
 color = Color(0.443924, 0, 0.632923, 1)
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="ColorPickerButton3" type="ColorPickerButton" parent="GridContainer"]
-offset_left = 34.0
-offset_top = 143.0
-offset_right = 130.0
-offset_bottom = 207.0
-rect_min_size = Vector2(96, 64)
+custom_minimum_size = Vector2(96, 64)
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
 color = Color(1, 1, 1, 1)
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="ColorPickerButton4" type="ColorPickerButton" parent="GridContainer"]
-offset_left = 202.0
-offset_top = 143.0
-offset_right = 298.0
-offset_bottom = 207.0
-rect_min_size = Vector2(96, 64)
+custom_minimum_size = Vector2(96, 64)
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
 color = Color(1, 0.933842, 0, 1)
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="ColorPickerButton5" type="ColorPickerButton" parent="GridContainer"]
-offset_left = 370.0
-offset_top = 143.0
-offset_right = 466.0
-offset_bottom = 207.0
-rect_min_size = Vector2(96, 64)
+custom_minimum_size = Vector2(96, 64)
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
 color = Color(0.287293, 0.886362, 0.122933, 1)
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="ColorPickerButton6" type="ColorPickerButton" parent="GridContainer"]
-offset_left = 34.0
-offset_top = 261.0
-offset_right = 130.0
-offset_bottom = 325.0
-rect_min_size = Vector2(96, 64)
+custom_minimum_size = Vector2(96, 64)
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
 color = Color(0.908461, 0, 0.88789, 1)
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="ColorPickerButton7" type="ColorPickerButton" parent="GridContainer"]
-offset_left = 202.0
-offset_top = 261.0
-offset_right = 298.0
-offset_bottom = 325.0
-rect_min_size = Vector2(96, 64)
+custom_minimum_size = Vector2(96, 64)
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
 color = Color(0, 0.283703, 0, 1)
-script = ExtResource( 1 )
+script = ExtResource("1")
 
 [node name="ColorPickerButton8" type="ColorPickerButton" parent="GridContainer"]
-offset_left = 370.0
-offset_top = 261.0
-offset_right = 466.0
-offset_bottom = 325.0
-rect_min_size = Vector2(96, 64)
+custom_minimum_size = Vector2(96, 64)
+layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 6
 color = Color(0, 0, 0.178211, 1)
-script = ExtResource( 1 )
+script = ExtResource("1")

--- a/gui/drag_and_drop/drag_drop_script.gd
+++ b/gui/drag_and_drop/drag_drop_script.gd
@@ -1,6 +1,6 @@
 extends ColorPickerButton
 
-func get_drag_data(_pos):
+func _get_drag_data(_pos):
 	# Use another colorpicker as drag preview.
 	var cpb = ColorPickerButton.new()
 	cpb.color = color
@@ -10,9 +10,9 @@ func get_drag_data(_pos):
 	return color
 
 
-func can_drop_data(_pos, data):
+func _can_drop_data(_pos, data):
 	return typeof(data) == TYPE_COLOR
 
 
-func drop_data(_pos, data):
+func _drop_data(_pos, data):
 	color = data

--- a/gui/drag_and_drop/icon.png.import
+++ b/gui/drag_and_drop/icon.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture2D"
-path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+type="CompressedTexture2D"
+uid="uid://bw7n2lj3wv6rv"
+path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,24 @@ metadata={
 [deps]
 
 source_file="res://icon.png"
-dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/gui/drag_and_drop/project.godot
+++ b/gui/drag_and_drop/project.godot
@@ -6,7 +6,7 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
+config_version=5
 
 [application]
 
@@ -16,6 +16,7 @@ config/description="A demo showcasing drag and drop functionality.
 - Drag and drop the color buttons to copy their colors over.
 - Click on the buttons to manually adjust their color."
 run/main_scene="res://drag_and_drop.tscn"
+config/features=PackedStringArray("4.0")
 config/icon="res://icon.png"
 
 [display]

--- a/gui/input_mapping/KeyPersistence.gd
+++ b/gui/input_mapping/KeyPersistence.gd
@@ -16,11 +16,11 @@ func _ready() -> void:
 
 
 func load_keymap() -> void:
-	var file := File.new()
-	if not file.file_exists(keymaps_path):
+	var file
+	if not FileAccess.file_exists(keymaps_path):
 		save_keymap() # There is no save file yet, so let's create one.
 		return
-	file.open(keymaps_path, File.READ)
+	file = FileAccess.open(keymaps_path, FileAccess.READ)
 	var temp_keymap = file.get_var(true) as Dictionary
 	file.close()
 	# We don't just replace the keymaps dictionary, because if you
@@ -38,7 +38,6 @@ func load_keymap() -> void:
 
 func save_keymap() -> void:
 	# For saving the keymap, we just save the entire dictionary as a var.
-	var file := File.new()
-	file.open(keymaps_path, File.WRITE)
+	var file := FileAccess.open(keymaps_path, FileAccess.WRITE)
 	file.store_var(keymaps, true)
 	file.close()

--- a/gui/rich_text_bbcode/rich_text_bbcode.tscn
+++ b/gui/rich_text_bbcode/rich_text_bbcode.tscn
@@ -88,5 +88,4 @@ shortcut_in_tooltip = false
 text = "Pause"
 
 [connection signal="meta_clicked" from="RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
-[connection signal="pressed" from="Pause" to="." method="_on_pause_pressed"]
 [connection signal="toggled" from="Pause" to="." method="_on_pause_toggled"]


### PR DESCRIPTION
File class object replaced by the new FileAccess class in order to fix the demo for the latest Godot 4 stable release.

Demo failed with this error:

> runtime error: Parser Error: Indentifier "File" not declarer in current scope in KeyPersistence.gd line 19

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest Godot version of the branch you're submitting to.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
