### PR TITLE
Fix GDScript code style regarding colon (demos)

### DIFF
--- a/2d/physics_tests/tests.gd
+++ b/2d/physics_tests/tests.gd
@@ -51,8 +51,8 @@ var _tests = [
 		"path": "res://tests/performance/test_perf_contacts.tscn",
 	},
 	{
-		"id" : "Performance Tests/Contact Islands",
-		"path" : "res://tests/performance/test_perf_contact_islands.tscn",
+		"id": "Performance Tests/Contact Islands",
+		"path": "res://tests/performance/test_perf_contact_islands.tscn",
 	},
 ]
 

--- a/2d/physics_tests/tests/functional/test_character.gd
+++ b/2d/physics_tests/tests/functional/test_character.gd
@@ -26,7 +26,7 @@ const OPTION_MOVE_CHARACTER_CONSTANT_SPEED = "Move Options/Use constant speed (C
 @export var _jump_force = 1000.0
 @export var _snap_distance = 0.0
 @export var _floor_max_angle = 45.0
-@export var _body_type : E_BodyType = 0
+@export var _body_type: E_BodyType = 0
 
 @onready var options = $Options
 
@@ -35,12 +35,12 @@ var _use_stop_on_slope = true
 var _use_floor_only = true
 var _use_constant_speed = false
 
-var _body_parent : Node = null
+var _body_parent: Node = null
 var _character_body_template = null
 var _character_body_ray_template = null
 var _rigid_body_template = null
 var _rigid_body_ray_template = null
-var _moving_body : PhysicsBody2D = null
+var _moving_body: PhysicsBody2D = null
 
 
 func _ready():

--- a/2d/physics_tests/tests/functional/test_character_tilemap.gd
+++ b/2d/physics_tests/tests/functional/test_character_tilemap.gd
@@ -12,7 +12,7 @@ var _test_jump_one_way = false
 var _test_jump_one_way_corner = false
 var _test_fall_one_way = false
 
-var _extra_body : PhysicsBody2D = null
+var _extra_body: PhysicsBody2D = null
 
 var _failed_reason = ""
 

--- a/2d/physics_tests/tests/functional/test_one_way_collision.gd
+++ b/2d/physics_tests/tests/functional/test_one_way_collision.gd
@@ -49,10 +49,10 @@ const TEST_ALL_ANGLES_MAX = 344.0
 
 var _rigid_body_template = null
 var _character_body_template = null
-var _moving_body : PhysicsBody2D = null
+var _moving_body: PhysicsBody2D = null
 
 var _platform_template = null
-var _platform_body : PhysicsBody2D = null
+var _platform_body: PhysicsBody2D = null
 var _platform_velocity = Vector2.ZERO
 
 @onready var _target_area = $TargetArea2D

--- a/2d/physics_tests/tests_menu.gd
+++ b/2d/physics_tests/tests_menu.gd
@@ -9,7 +9,7 @@ class TestData:
 var _test_list = []
 
 var _current_test = null
-var _current_test_scene : Node = null
+var _current_test_scene: Node = null
 
 
 func _ready():

--- a/2d/role_playing_game/dialogue/dialogue_data/npc.json
+++ b/2d/role_playing_game/dialogue/dialogue_data/npc.json
@@ -1,5 +1,5 @@
 {
-  "dialog_1" : {"name": "Unknown", "text": "Hey, it's a good time to have a JRPG fight, right?"},
-  "dialog_2" : {"name": "Unknown", "text": "Let me introduce myself, I'm the OPPONENT"},
-  "dialog_3" : {"name": "Opponent", "text": "Enough talking. Let's fight!"},
+  "dialog_1": {"name": "Unknown", "text": "Hey, it's a good time to have a JRPG fight, right?"},
+  "dialog_2": {"name": "Unknown", "text": "Let me introduce myself, I'm the OPPONENT"},
+  "dialog_3": {"name": "Opponent", "text": "Enough talking. Let's fight!"},
 }

--- a/2d/role_playing_game/dialogue/dialogue_data/object.json
+++ b/2d/role_playing_game/dialogue/dialogue_data/object.json
@@ -1,3 +1,3 @@
 {
-  "dialog_1" : {"name":"Player", "text":"Just some object..." }
+  "dialog_1": {"name": "Player", "text": "Just some object..."}
 }

--- a/2d/role_playing_game/dialogue/dialogue_data/player_lose.json
+++ b/2d/role_playing_game/dialogue/dialogue_data/player_lose.json
@@ -1,3 +1,3 @@
 {
-  "dialog_1" : {"name": "Opponent", "text": "Aha! I won, maybe you can try again next time"}
+  "dialog_1": {"name": "Opponent", "text": "Aha! I won, maybe you can try again next time"}
 }

--- a/2d/role_playing_game/dialogue/dialogue_data/player_won.json
+++ b/2d/role_playing_game/dialogue/dialogue_data/player_won.json
@@ -1,3 +1,3 @@
 {
-  "dialog_1" : {"name": "Opponent", "text": "Congratulations, you won!"}
+  "dialog_1": {"name": "Opponent", "text": "Congratulations, you won!"}
 }

--- a/3d/antialiasing/anti_aliasing.tscn
+++ b/3d/antialiasing/anti_aliasing.tscn
@@ -461,7 +461,7 @@ uniform vec3 uv2_scale;
 uniform vec3 uv2_offset;
 
 float rand(vec2 co){
-    return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+    return fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
 }
 
 void vertex() {

--- a/3d/material_testers/tester.gd
+++ b/3d/material_testers/tester.gd
@@ -88,7 +88,7 @@ func update_gui():
 
 
 func _on_bg_item_selected(index):
-	var sky_material : PanoramaSkyMaterial = $WorldEnvironment.environment.sky.sky_material
+	var sky_material: PanoramaSkyMaterial = $WorldEnvironment.environment.sky.sky_material
 
 	sky_material.panorama = load(backgrounds[index].path)
 

--- a/3d/physics_tests/tests.gd
+++ b/3d/physics_tests/tests.gd
@@ -55,8 +55,8 @@ var _tests = [
 		"path": "res://tests/performance/test_perf_contacts.tscn",
 	},
 	{
-		"id" : "Performance Tests/Contact Islands",
-		"path" : "res://tests/performance/test_perf_contact_islands.tscn",
+		"id": "Performance Tests/Contact Islands",
+		"path": "res://tests/performance/test_perf_contact_islands.tscn",
 	},
 ]
 

--- a/3d/physics_tests/tests/functional/test_moving_platform.gd
+++ b/3d/physics_tests/tests/functional/test_moving_platform.gd
@@ -25,7 +25,7 @@ var _body_scene = {}
 var _key_list = []
 var _current_body_index = 0
 var _current_body_key = ""
-var _current_body : PhysicsBody3D = null
+var _current_body: PhysicsBody3D = null
 var _body_type = ["CharacterBody3D", "RigidBody"]
 
 var _shapes = {}

--- a/3d/physics_tests/tests_menu.gd
+++ b/3d/physics_tests/tests_menu.gd
@@ -9,7 +9,7 @@ class TestData:
 var _test_list = []
 
 var _current_test = null
-var _current_test_scene : Node = null
+var _current_test_scene: Node = null
 
 
 func _ready():

--- a/networking/multiplayer_bomber/player_controls.gd
+++ b/networking/multiplayer_bomber/player_controls.gd
@@ -1,7 +1,7 @@
 extends Node
 
 @export
-var motion = Vector2() :
+var motion = Vector2():
 	set(value):
 		# This will be sent by players, make sure values are within limits.
 		motion = clamp(value, Vector2(-1, -1), Vector2(1, 1))

--- a/networking/websocket_chat/client.gd
+++ b/networking/websocket_chat/client.gd
@@ -1,6 +1,6 @@
 extends Control
 
-@onready var _client : WebSocketClient = $WebSocketClient
+@onready var _client: WebSocketClient = $WebSocketClient
 @onready var _log_dest = $Panel/VBoxContainer/RichTextLabel
 @onready var _line_edit = $Panel/VBoxContainer/Send/LineEdit
 @onready var _host = $Panel/VBoxContainer/Connect/Host

--- a/networking/websocket_chat/server.gd
+++ b/networking/websocket_chat/server.gd
@@ -1,6 +1,6 @@
 extends Control
 
-@onready var _server : WebSocketServer = $WebSocketServer
+@onready var _server: WebSocketServer = $WebSocketServer
 @onready var _log_dest = $Panel/VBoxContainer/RichTextLabel
 @onready var _line_edit = $Panel/VBoxContainer/Send/LineEdit
 @onready var _listen_port = $Panel/VBoxContainer/Connect/Port
@@ -12,13 +12,13 @@ func info(msg):
 
 # Server signals
 func _on_web_socket_server_client_connected(peer_id):
-	var peer : WebSocketPeer = _server.peers[peer_id]
+	var peer: WebSocketPeer = _server.peers[peer_id]
 	info("Remote client connected: %d. Protocol: %s" % [peer_id, peer.get_selected_protocol()])
 	_server.send(-peer_id, "[%d] connected" % peer_id)
 
 
 func _on_web_socket_server_client_disconnected(peer_id):
-	var peer : WebSocketPeer = _server.peers[peer_id]
+	var peer: WebSocketPeer = _server.peers[peer_id]
 	info("Remote client disconnected: %d. Code: %d, Reason: %s" % [peer_id, peer.get_close_code(), peer.get_close_reason()])
 	_server.send(-peer_id, "[%d] disconnected" % peer_id)
 

--- a/networking/websocket_chat/websocket/WebSocketClient.gd
+++ b/networking/websocket_chat/websocket/WebSocketClient.gd
@@ -1,9 +1,9 @@
 extends Node
 class_name WebSocketClient
 
-@export var handshake_headers : PackedStringArray
-@export var supported_protocols : PackedStringArray
-@export var tls_trusted_certificate : X509Certificate
+@export var handshake_headers: PackedStringArray
+@export var supported_protocols: PackedStringArray
+@export var tls_trusted_certificate: X509Certificate
 @export var tls_verify := true
 
 

--- a/networking/websocket_chat/websocket/WebSocketServer.gd
+++ b/networking/websocket_chat/websocket/WebSocketServer.gd
@@ -1,27 +1,27 @@
 extends Node
 class_name WebSocketServer
 
-signal message_received(peer_id : int, message)
-signal client_connected(peer_id : int)
-signal client_disconnected(peer_id : int)
+signal message_received(peer_id: int, message)
+signal client_connected(peer_id: int)
+signal client_disconnected(peer_id: int)
 
 @export var handshake_headers := PackedStringArray()
-@export var supported_protocols : PackedStringArray
+@export var supported_protocols: PackedStringArray
 @export var handshake_timout := 3000
 @export var use_tls := false
-@export var tls_cert : X509Certificate
-@export var tls_key : CryptoKey
-@export var refuse_new_connections := false :
+@export var tls_cert: X509Certificate
+@export var tls_key: CryptoKey
+@export var refuse_new_connections := false:
 	set(refuse):
 		if refuse:
 			pending_peers.clear()
 
 
 class PendingPeer:
-	var connect_time : int
-	var tcp : StreamPeerTCP
-	var connection : StreamPeer
-	var ws : WebSocketPeer
+	var connect_time: int
+	var tcp: StreamPeerTCP
+	var connection: StreamPeer
+	var ws: WebSocketPeer
 
 	func _init(p_tcp: StreamPeerTCP):
 		tcp = p_tcp
@@ -30,11 +30,11 @@ class PendingPeer:
 
 
 var tcp_server := TCPServer.new()
-var pending_peers : Array[PendingPeer] = []
-var peers : Dictionary
+var pending_peers: Array[PendingPeer] = []
+var peers: Dictionary
 
 
-func listen(port : int) -> int:
+func listen(port: int) -> int:
 	assert(not tcp_server.is_listening())
 	return tcp_server.listen(port)
 
@@ -107,7 +107,7 @@ func poll() -> void:
 		pending_peers.erase(r)
 	to_remove.clear()
 	for id in peers:
-		var p : WebSocketPeer = peers[id]
+		var p: WebSocketPeer = peers[id]
 		var packets = p.get_available_packet_count()
 		p.poll()
 		if p.get_ready_state() != WebSocketPeer.STATE_OPEN:

--- a/plugins/addons/material_import_plugin/import.gd
+++ b/plugins/addons/material_import_plugin/import.gd
@@ -67,4 +67,4 @@ func _import(source_file, save_path, options, r_platform_variants, r_gen_files):
 
 	material.albedo_color = color
 
-	return ResourceSaver.save(material ,"%s.%s" % [save_path, _get_save_extension()])
+	return ResourceSaver.save(material, "%s.%s" % [save_path, _get_save_extension()])


### PR DESCRIPTION
[GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html) recommends the `var name: Type` style (no space before the colon). The same goes for [properties](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#properties-setters-and-getters) (it's not in the style guide yet, but vnen confirmed it in Rocket Chat).

Related:

* godotengine/godot#74306
* godotengine/godot-docs#6896