### PR TITLE
GUI/InputRemapMenu demo fixed to work with Godot 4 stable

### DIFF
--- a/gui/input_mapping/KeyPersistence.gd
+++ b/gui/input_mapping/KeyPersistence.gd
@@ -16,11 +16,11 @@ func _ready() -> void:
 
 
 func load_keymap() -> void:
-	var file := File.new()
-	if not file.file_exists(keymaps_path):
+	var file
+	if not FileAccess.file_exists(keymaps_path):
 		save_keymap() # There is no save file yet, so let's create one.
 		return
-	file.open(keymaps_path, File.READ)
+	file = FileAccess.open(keymaps_path, FileAccess.READ)
 	var temp_keymap = file.get_var(true) as Dictionary
 	file.close()
 	# We don't just replace the keymaps dictionary, because if you
@@ -38,7 +38,6 @@ func load_keymap() -> void:
 
 func save_keymap() -> void:
 	# For saving the keymap, we just save the entire dictionary as a var.
-	var file := File.new()
-	file.open(keymaps_path, File.WRITE)
+	var file := FileAccess.open(keymaps_path, FileAccess.WRITE)
 	file.store_var(keymaps, true)
 	file.close()

--- a/gui/input_mapping/KeyPersistence.gd
+++ b/gui/input_mapping/KeyPersistence.gd
@@ -16,11 +16,10 @@ func _ready() -> void:
 
 
 func load_keymap() -> void:
-	var file
 	if not FileAccess.file_exists(keymaps_path):
 		save_keymap() # There is no save file yet, so let's create one.
 		return
-	file = FileAccess.open(keymaps_path, FileAccess.READ)
+	var file = FileAccess.open(keymaps_path, FileAccess.READ)
 	var temp_keymap = file.get_var(true) as Dictionary
 	file.close()
 	# We don't just replace the keymaps dictionary, because if you


### PR DESCRIPTION
File class object replaced by the new FileAccess class in order to fix the demo for Godot 4 release.

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest Godot version of the branch you're submitting to.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
