### PR TITLE
disconnect unused signal connected to a removed method

### DIFF
--- a/gui/rich_text_bbcode/rich_text_bbcode.tscn
+++ b/gui/rich_text_bbcode/rich_text_bbcode.tscn
@@ -88,5 +88,4 @@ shortcut_in_tooltip = false
 text = "Pause"
 
 [connection signal="meta_clicked" from="RichTextLabel" to="." method="_on_RichTextLabel_meta_clicked"]
-[connection signal="pressed" from="Pause" to="." method="_on_pause_pressed"]
 [connection signal="toggled" from="Pause" to="." method="_on_pause_toggled"]


### PR DESCRIPTION
Handler "_on_pause_pressed" has been removed but not the signal from the button.

fix the following runtime error:
> E 0:00:01:0716   emit_signalp: Error calling from signal 'pressed' to callable: 'Control(rich_text_bbcode.gd)::_on_pause_pressed': Method not found.
>		<C++ Source>   core/object/object.cpp:1058 @ emit_signalp()

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest Godot version of the branch you're submitting to.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
