### PR TITLE
 loading/serialization demo fixed to work with Godot 4 stable

### DIFF
--- a/loading/serialization/save_load_json.gd
+++ b/loading/serialization/save_load_json.gd
@@ -34,7 +34,7 @@ func save_game():
 			position = var_to_str(enemy.position),
 		})
 
-	file.store_line(JSON.new().stringify(save_dict))
+	file.store_line(JSON.stringify(save_dict))
 
 	get_node(^"../LoadJSON").disabled = false
 


### PR DESCRIPTION
Fix the warning: 

> The function 'stringify()' is a static function but was called from an instance. Instead, it should be directly called from the type: 'JSON.stringify()'.<GDScript Error>STATIC_CALLED_ON_INSTANCE <GDScript Source>save_load_json.gd:37

<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest Godot version of the branch you're submitting to.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
