### PR TITLE
Change Icon header ordering for 2.5d GD Script Demo

### DIFF
--- a/misc/2.5d/addons/node25d/node_25d.gd
+++ b/misc/2.5d/addons/node25d/node_25d.gd
@@ -1,9 +1,10 @@
 # This node converts a 3D position to 2D using a 2.5D transformation matrix.
 # The transformation of its 2D form is controlled by its 3D child.
 @tool
+@icon("res://addons/node25d/icons/node_25d_icon.png")
 extends Node2D
 class_name Node25D
-@icon("res://addons/node25d/icons/node_25d_icon.png")
+
 
 # SCALE is the number of 2D units in one 3D unit. Ideally, but not necessarily, an integer.
 const SCALE = 32

--- a/misc/2.5d/addons/node25d/shadow_math_25d.gd
+++ b/misc/2.5d/addons/node25d/shadow_math_25d.gd
@@ -2,9 +2,10 @@
 # Place this ShadowMath25D node as a child of a Shadow25D, which
 # is below the target object in the scene tree (not as a child).
 @tool
+@icon("res://addons/node25d/icons/shadow_math_25d_icon.png")
 extends CharacterBody3D
 class_name ShadowMath25D
-@icon("res://addons/node25d/icons/shadow_math_25d_icon.png")
+
 
 # The maximum distance below objects that shadows will appear (in 3D units).
 var shadow_length = 1000.0

--- a/misc/2.5d/addons/node25d/y_sort_25d.gd
+++ b/misc/2.5d/addons/node25d/y_sort_25d.gd
@@ -3,9 +3,10 @@
 # because the execution order is different and otherwise
 # sorting is delayed by one frame.
 @tool
+@icon("res://addons/node25d/icons/y_sort_25d_icon.png")
 extends Node # Note: NOT Node2D, Node25D, or Node2D
 class_name YSort25D
-@icon("res://addons/node25d/icons/y_sort_25d_icon.png")
+
 
 # Whether or not to automatically call sort() in _process().
 @export var sort_enabled := true


### PR DESCRIPTION
Just following the rules! 
Moved up the icon statements above the other includes. This got rid of errors preventing plugin from loading.

There's still a race condition when the plugin starts up. It's looking for an editor interface child that hasn't been loaded yet. May want to use _ready to define some behavior before _enter_tree is used.