### PR TITLE
Update 3D Graphics Settings demo for 4.0

### DIFF
--- a/3d/graphics_settings/control.tscn
+++ b/3d/graphics_settings/control.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://ye05btta37gb"]
+[gd_scene load_steps=6 format=3 uid="uid://ye05btta37gb"]
 
 [ext_resource type="Script" path="res://settings.gd" id="1_gm54x"]
 [ext_resource type="PackedScene" uid="uid://cbdt8lmycl8pc" path="res://3d_scene.tscn" id="2_hsbu5"]
@@ -26,6 +26,10 @@ content_margin_top = 50.0
 content_margin_right = 20.0
 content_margin_bottom = 10.0
 bg_color = Color(0.231373, 0.231373, 0.231373, 0.768627)
+
+[sub_resource type="Gradient" id="Gradient_ehij4"]
+offsets = PackedFloat32Array(0, 0.333, 0.667, 1)
+colors = PackedColorArray(1, 0.17, 0.17, 1, 1, 0.816, 0.08, 1, 0.644, 1, 0.11, 1, 0.14, 0.885333, 1, 1)
 
 [node name="Control" type="Control"]
 layout_mode = 3
@@ -273,6 +277,7 @@ theme_override_font_sizes/font_size = 16
 text = "Anti-Aliasing (FXAA):"
 
 [node name="FXAAOptionButton" type="OptionButton" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
@@ -598,6 +603,7 @@ grow_horizontal = 0
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 horizontal_alignment = 2
+metadata/gradient = SubResource("Gradient_ehij4")
 
 [node name="ResolutionLabel" type="Label" parent="."]
 layout_mode = 1

--- a/3d/graphics_settings/polyhaven/dutch_ship_medium_1k.gltf.import
+++ b/3d/graphics_settings/polyhaven/dutch_ship_medium_1k.gltf.import
@@ -26,5 +26,7 @@ skins/use_named_skins=true
 animation/import=true
 animation/fps=30
 animation/trimming=false
+animation/remove_immutable_tracks=true
 import_script/path=""
 _subresources={}
+gltf/embedded_image_handling=1

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_arm_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_arm_1k.jpg.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dhmrl40t2na37"
 path.s3tc="res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.s3tc.ctex"
-path.etc2="res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_hull_arm_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.s3tc.ctex", "res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.etc2.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=true

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_diff_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_diff_1k.jpg.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://88gdijjjr6p4"
 path.s3tc="res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.s3tc.ctex"
-path.etc2="res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_hull_diff_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.s3tc.ctex", "res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.etc2.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=true

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_nor_gl_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_nor_gl_1k.jpg.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://c22y3qjf8th8a"
 path.s3tc="res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.s3tc.ctex"
-path.etc2="res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_hull_nor_gl_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.s3tc.ctex", "res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.etc2.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=1
 compress/channel_pack=0
 mipmaps/generate=true

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_arm_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_arm_1k.jpg.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://15se8alkcbla"
 path.s3tc="res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.s3tc.ctex"
-path.etc2="res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_rigging_arm_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.s3tc.ctex", "res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.etc2.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=true

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_diff_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_diff_1k.jpg.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://c0yhj4wwbvgvu"
 path.s3tc="res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.s3tc.ctex"
-path.etc2="res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_rigging_diff_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.s3tc.ctex", "res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.etc2.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=true

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_nor_gl_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_nor_gl_1k.jpg.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://csbfe6x0jyswi"
 path.s3tc="res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.s3tc.ctex"
-path.etc2="res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_rigging_nor_gl_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.s3tc.ctex", "res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.etc2.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=1
 compress/channel_pack=0
 mipmaps/generate=true

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_arm_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_arm_1k.jpg.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://70shlrquand4"
 path.s3tc="res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.s3tc.ctex"
-path.etc2="res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_sails_arm_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.s3tc.ctex", "res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.etc2.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=true

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_diff_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_diff_1k.jpg.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dde6ofm1jcwiv"
 path.s3tc="res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.s3tc.ctex"
-path.etc2="res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_sails_diff_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.s3tc.ctex", "res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.etc2.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=true

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_nor_gl_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_nor_gl_1k.jpg.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://doc73t5xbl8to"
 path.s3tc="res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.s3tc.ctex"
-path.etc2="res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_sails_nor_gl_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.s3tc.ctex", "res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.etc2.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=1
 compress/channel_pack=0
 mipmaps/generate=true


### PR DESCRIPTION
- Fix scripts for Godot 4.0.stable.
- Tweak Low preset (enable FXAA, disable MSAA to improve performance).
- Colorize FPS counter depending on framerate (red = bad, yellow = OK, green = good, cyan = great).
- Use first-class Signal syntax to reduce reliance on strings.
