### PR TITLE
Use Compatibility rendering method in Multiple Resolutions demo

### DIFF
--- a/gui/multiple_resolutions/README.md
+++ b/gui/multiple_resolutions/README.md
@@ -43,13 +43,14 @@ higher-than-default screen resolutions.
 
 Language: GDScript
 
-Renderer: Vulkan Mobile
+Renderer: Compatibility
 
 ## Technical notes
 
 The demo works with the following project settings:
 
-- `canvas_items` stretch mode (formerly `2d`). Recommended for most non-pixel art games.
+- `canvas_items` stretch mode (this was called `2d` in Godot 3.x).
+  Recommended for most non-pixel art games.
 - `expand` stretch aspect (allows support for multiple aspect ratios without
   distortion or black bars).
 - Using a base window size with a 1:1 aspect ratio (`648×648` in this demo).
@@ -65,7 +66,7 @@ The demo works with the following project settings:
     feature 16:10 displays, so it's recommended to use a 16:10 resolution or
     narrower as a base window size to ensure a good gameplay experience out of
     the box on those devices.
-- Using a test window size with a 16:9 aspect ratio (`1152×648` in this demo).
+- Using a window size override with a 16:9 aspect ratio (`1152×648` in this demo).
   This way, the project starts in a 16:9 window even if the base window size has
   a 1:1 aspect ratio.
   - The test window height matches the width and height of the base window size,

--- a/gui/multiple_resolutions/main.tscn
+++ b/gui/multiple_resolutions/main.tscn
@@ -23,6 +23,8 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 script = ExtResource("1")
 
 [node name="OuterSideLabel" type="Label" parent="."]
@@ -42,6 +44,8 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_vvbdh")
 
 [node name="InnerSideLabel" type="Label" parent="Panel"]
@@ -65,6 +69,8 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="Panel" type="Panel" parent="Panel/AspectRatioContainer"]
 layout_mode = 2
@@ -79,6 +85,7 @@ layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
+grow_horizontal = 0
 color = Color(1, 1, 1, 0.25098)
 
 [node name="BottomLeft" type="ColorRect" parent="Panel/AspectRatioContainer/Panel"]
@@ -86,6 +93,7 @@ layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
+grow_vertical = 0
 color = Color(1, 1, 1, 0.25098)
 
 [node name="BottomRight" type="ColorRect" parent="Panel/AspectRatioContainer/Panel"]
@@ -95,6 +103,8 @@ anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 0
+grow_vertical = 0
 color = Color(1, 1, 1, 0.25098)
 
 [node name="CenterContainer" type="CenterContainer" parent="Panel/AspectRatioContainer/Panel"]
@@ -102,6 +112,8 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="Options" type="VBoxContainer" parent="Panel/AspectRatioContainer/Panel/CenterContainer"]
 layout_mode = 2

--- a/gui/multiple_resolutions/project.godot
+++ b/gui/multiple_resolutions/project.godot
@@ -35,11 +35,11 @@ config/icon="res://icon.webp"
 [display]
 
 window/size/viewport_width=648
+window/size/window_width_override=1152
+window/size/window_height_override=648
 window/handheld/orientation="sensor"
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
-window/size/test_width=1152
-window/size/test_height=648
 
 [gui]
 
@@ -47,5 +47,5 @@ theme/default_font_multichannel_signed_distance_field=true
 
 [rendering]
 
-renderer/rendering_method="mobile"
+renderer/rendering_method="gl_compatibility"
 environment/defaults/default_clear_color=Color(0.133333, 0.133333, 0.2, 1)


### PR DESCRIPTION
This also fixes the missing window size override.

See https://github.com/godotengine/godot/issues/75876#issuecomment-1502017699.
