### PR TITLE
fix errors and warnings in 3D/graphics_settings demo

### DIFF
--- a/3d/graphics_settings/settings.gd
+++ b/3d/graphics_settings/settings.gd
@@ -27,7 +27,7 @@ func _ready() -> void:
 	DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	fps_label.text = "%d FPS (%.2f mspf)" % [Engine.get_frames_per_second(), 1000.0 / Engine.get_frames_per_second()]
 
 
@@ -125,7 +125,10 @@ func _on_taa_option_button_item_selected(index: int) -> void:
 func _on_fxaa_option_button_item_selected(index: int) -> void:
 	# Fast approximate anti-aliasing. Much faster than MSAA (and works on alpha scissor edges),
 	# but blurs the whole scene rendering slightly.
-	get_viewport().screen_space_aa = index == 1
+	if index == 0:
+		get_viewport().screen_space_aa = Viewport.ScreenSpaceAA.SCREEN_SPACE_AA_DISABLED
+	elif index == 1:
+		get_viewport().screen_space_aa = Viewport.ScreenSpaceAA.SCREEN_SPACE_AA_FXAA
 
 
 func _on_fullscreen_option_button_item_selected(index: int) -> void:
@@ -292,10 +295,10 @@ func _on_glow_option_button_item_selected(index: int) -> void:
 		world_environment.environment.glow_enabled = false
 	if index == 1: # Low
 		world_environment.environment.glow_enabled = true
-		RenderingServer.environment_glow_set_use_high_quality(false)
+		RenderingServer.environment_glow_set_use_bicubic_upscale(false)
 	if index == 2: # High
 		world_environment.environment.glow_enabled = true
-		RenderingServer.environment_glow_set_use_high_quality(true)
+		RenderingServer.environment_glow_set_use_bicubic_upscale(true)
 
 
 func _on_volumetric_fog_option_button_item_selected(index: int) -> void:


### PR DESCRIPTION
fix errors:
-bool value used as _Viewport.ScreenSpaceAA_ enum member
-unknown function "_environment_glow_set_use_high_quality_" in class "_RenderingServer_".

NOTE: these warnings still remains:

> 	W 0:00:06:0682   settings.gd:27 @ _ready(): The requested V-Sync mode Disabled is not available. Falling back to V-Sync mode Enabled.
>  <C++ Source>   drivers/vulkan/vulkan_context.cpp:1899 @ _update_swap_chain()
>  <Stack Trace>  settings.gd:27 @ _ready()
>  W 0:01:10:0812   settings.gd:99 @ _on_vsync_option_button_item_selected(): The requested V-Sync mode Disabled is not available. Falling back to V-Sync mode Enabled.
>  <C++ Source>   drivers/vulkan/vulkan_context.cpp:1899 @ _update_swap_chain()
>  <Stack Trace>  settings.gd:99 @ _on_vsync_option_button_item_selected()

It would need to check VSync capabilities first or engine should report warning to GDScript layer first to act accordingly.
<!--
Only submit a pull request if all of the following conditions are met:

* It must work with the latest Godot version of the branch you're submitting to.

* It must follow all of the Godot style guides, including the GDScript
  style guide and the C# style guide.

* The demo should not be overcomplicated. Simplicity is usually preferred.

* If you are submitting a new demo, please ensure that it includes a
  README file similar to the other demos.

* If you are submitting a copy of a demo translated to C# etc:

    * Please ensure that there is a good reason to have this demo translated.
      We don't want to have multiple copies of every single project.

    * Please ensure that the code mirrors the original closely.

    * In the project.godot file and in the README, include "with C#" etc in
      the title, and also include a link to the original in the README.
-->
