### PR TITLE
Fix particles in Platformer 3D demo, add coin glow

### DIFF
--- a/3d/platformer/coin/coin.tscn
+++ b/3d/platformer/coin/coin.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=15 format=3 uid="uid://dfxo2jwbj4aeh"]
+[gd_scene load_steps=19 format=3 uid="uid://dfxo2jwbj4aeh"]
 
 [ext_resource type="Script" path="res://coin/coin.gd" id="1"]
 [ext_resource type="AudioStream" uid="uid://b23l5nfatq2d2" path="res://coin/sound_coin.wav" id="2"]
 [ext_resource type="Material" uid="uid://dp0bangabfrg" path="res://coin/coin_material.tres" id="2_n0rbc"]
-[ext_resource type="Texture2D" uid="uid://y3opjgnv67r8" path="res://particle.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://y3opjgnv67r8" path="res://particle.webp" id="3"]
 
 [sub_resource type="CylinderMesh" id="CylinderMesh_fpglg"]
 top_radius = 0.2
@@ -11,6 +11,29 @@ bottom_radius = 0.2
 height = 0.05
 radial_segments = 16
 rings = 1
+
+[sub_resource type="QuadMesh" id="QuadMesh_kqa4x"]
+
+[sub_resource type="Gradient" id="Gradient_cd1ha"]
+interpolation_mode = 2
+offsets = PackedFloat32Array(0, 0.642276, 1)
+colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0.180392, 1, 1, 1, 0)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_qhu5r"]
+gradient = SubResource("Gradient_cd1ha")
+fill = 1
+fill_from = Vector2(0.5, 0.5)
+fill_to = Vector2(0.5, 0.01)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7q0mq"]
+transparency = 1
+blend_mode = 1
+shading_mode = 0
+albedo_color = Color(1, 0.858824, 0.572549, 0.25098)
+albedo_texture = SubResource("GradientTexture2D_qhu5r")
+billboard_mode = 1
+proximity_fade_enabled = true
+proximity_fade_distance = 0.15
 
 [sub_resource type="Animation" id="Animation_r4jod"]
 length = 0.001
@@ -33,6 +56,30 @@ tracks/1/path = NodePath("Circle:visible")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("GlowSprite:transparency")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("GlowSprite:visible")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 1,
@@ -106,6 +153,30 @@ tracks/2/keys = {
 "update": 1,
 "values": [true]
 }
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("GlowSprite:transparency")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0.0, 1.0]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("GlowSprite:visible")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_7v453"]
 _data = {
@@ -127,9 +198,12 @@ albedo_color = Color(1, 1, 0.759137, 1)
 albedo_texture = ExtResource("3")
 texture_filter = 4
 billboard_mode = 3
+billboard_keep_scale = true
 particles_anim_h_frames = 1
 particles_anim_v_frames = 1
 particles_anim_loop = false
+proximity_fade_enabled = true
+proximity_fade_distance = 0.5
 
 [sub_resource type="PlaneMesh" id="7"]
 material = SubResource("6")
@@ -152,6 +226,14 @@ transform = Transform3D(1, 0, 0, 0, -3.61999e-06, -1, 0, 1, -3.61999e-06, 0.0055
 layers = 2
 mesh = SubResource("CylinderMesh_fpglg")
 surface_material_override/0 = ExtResource("2_n0rbc")
+
+[node name="GlowSprite" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+visibility_range_begin = 3.0
+visibility_range_begin_margin = 3.0
+visibility_range_fade_mode = 1
+mesh = SubResource("QuadMesh_kqa4x")
+surface_material_override/0 = SubResource("StandardMaterial3D_7q0mq")
 
 [node name="Animation" type="AnimationPlayer" parent="."]
 autoplay = "spin"

--- a/3d/platformer/enemy/enemy.tscn
+++ b/3d/platformer/enemy/enemy.tscn
@@ -428,8 +428,8 @@ orientation = 2
 
 [sub_resource type="Curve" id="17"]
 max_value = 3.0
-_data = [Vector2(0, 1), 0.0, 0.0, 0, 0, Vector2(0.0349232, 2.1123), 0.0, 0.0, 0, 0, Vector2(0.151192, 0.823242), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
-point_count = 4
+_data = [Vector2(0, 0), 0.0, 0.0, 0, 0, Vector2(0.2, 0.6), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 3
 
 [node name="Enemy" type="RigidBody3D"]
 axis_lock_angular_x = true
@@ -510,13 +510,15 @@ doppler_tracking = 1
 
 [node name="Explosion" type="CPUParticles3D" parent="."]
 emitting = false
-lifetime = 0.5
+amount = 16
 one_shot = true
 explosiveness = 1.0
 mesh = SubResource("16")
 emission_shape = 1
 emission_sphere_radius = 1.0
-gravity = Vector3(0, 0, 0)
+direction = Vector3(0, 1, 0)
+initial_velocity_min = 2.0
+initial_velocity_max = 2.0
 scale_amount_curve = SubResource("17")
 
 [editable path="Enemy"]

--- a/3d/platformer/particle_material.tres
+++ b/3d/platformer/particle_material.tres
@@ -1,6 +1,6 @@
 [gd_resource type="StandardMaterial3D" load_steps=2 format=3 uid="uid://c1lk3srtdadr6"]
 
-[ext_resource type="Texture2D" uid="uid://y3opjgnv67r8" path="res://particle.png" id="1_ryem2"]
+[ext_resource type="Texture2D" uid="uid://y3opjgnv67r8" path="res://particle.webp" id="1_ryem2"]
 
 [resource]
 transparency = 1
@@ -11,6 +11,9 @@ albedo_color = Color(1, 1, 0.759137, 1)
 albedo_texture = ExtResource("1_ryem2")
 texture_filter = 0
 billboard_mode = 3
+billboard_keep_scale = true
 particles_anim_h_frames = 1
 particles_anim_v_frames = 1
 particles_anim_loop = false
+proximity_fade_enabled = true
+proximity_fade_distance = 0.5

--- a/3d/platformer/player/bullet/bullet.tscn
+++ b/3d/platformer/player/bullet/bullet.tscn
@@ -3,11 +3,10 @@
 [ext_resource type="Script" path="res://player/bullet/bullet.gd" id="1"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_p7q83"]
+transparency = 1
+blend_mode = 1
+shading_mode = 0
 albedo_color = Color(0.701961, 0.698039, 0.513726, 1)
-roughness = 0.0
-emission_enabled = true
-emission = Color(1, 0.884824, 0.513098, 1)
-emission_energy_multiplier = 0.5
 
 [sub_resource type="SphereMesh" id="SphereMesh_gjrxu"]
 material = SubResource("StandardMaterial3D_p7q83")

--- a/3d/platformer/player/player.tscn
+++ b/3d/platformer/player/player.tscn
@@ -91,6 +91,7 @@ stream_0/weight = 1.0
 
 [sub_resource type="Gradient" id="Gradient_p2tu5"]
 interpolation_mode = 2
+offsets = PackedFloat32Array(0.2, 1)
 colors = PackedColorArray(0, 0, 0, 1, 0, 0, 0, 0)
 
 [sub_resource type="GradientTexture2D" id="GradientTexture2D_kvc1x"]
@@ -225,6 +226,7 @@ volume_db = -6.0
 [node name="BlobShadow" type="Decal" parent="."]
 size = Vector3(1.6, 12, 1.6)
 texture_albedo = SubResource("GradientTexture2D_kvc1x")
+albedo_mix = 0.8
 upper_fade = 3.99999
 lower_fade = 1.0
 cull_mask = 1048573


### PR DESCRIPTION
- Add a visible coin glow around coins to make them more noticeable at a distance.
- Enable Billboard Keep Scale material property on particle draw materials that required it.
- Use transparent additive shading as intended for the bullet trail.
- Tweak blob shadow texture and decal to be slightly more subtle.

## Preview

![Coin glow](https://user-images.githubusercontent.com/180032/232174413-eb426e7a-f22b-4c14-9203-abd01248e180.png)