### PR TITLE
Fixed websocket_chat demo for Godot 4.0.2

### DIFF
--- a/networking/websocket_chat/combo.tscn
+++ b/networking/websocket_chat/combo.tscn
@@ -13,44 +13,24 @@ grow_vertical = 2
 mouse_filter = 1
 
 [node name="Box" type="HBoxContainer" parent="."]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
 [node name="Server" parent="Box" instance=ExtResource("1_0srxc")]
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_right = 574.0
-offset_bottom = 648.0
+layout_mode = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Box"]
-offset_left = 578.0
-offset_right = 1152.0
-offset_bottom = 648.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="Client" parent="Box/VBoxContainer" instance=ExtResource("2_percb")]
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_right = 574.0
-offset_bottom = 213.0
+layout_mode = 2
 
 [node name="Client2" parent="Box/VBoxContainer" instance=ExtResource("2_percb")]
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_top = 217.0
-offset_right = 574.0
-offset_bottom = 430.0
+layout_mode = 2
 
 [node name="Client3" parent="Box/VBoxContainer" instance=ExtResource("2_percb")]
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_top = 434.0
-offset_right = 574.0
-offset_bottom = 648.0
+layout_mode = 2

--- a/networking/websocket_chat/project.godot
+++ b/networking/websocket_chat/project.godot
@@ -8,22 +8,6 @@
 
 config_version=5
 
-_global_script_classes=[{
-"base": "Node",
-"class": &"WebSocketClient",
-"language": &"GDScript",
-"path": "res://websocket/WebSocketClient.gd"
-}, {
-"base": "Node",
-"class": &"WebSocketServer",
-"language": &"GDScript",
-"path": "res://websocket/WebSocketServer.gd"
-}]
-_global_script_class_icons={
-"WebSocketClient": "",
-"WebSocketServer": ""
-}
-
 [application]
 
 config/name="WebSocket Chat Demo"

--- a/networking/websocket_chat/websocket/WebSocketClient.gd
+++ b/networking/websocket_chat/websocket/WebSocketClient.gd
@@ -19,7 +19,11 @@ signal message_received(message: Variant)
 func connect_to_url(url) -> int:
 	socket.supported_protocols = supported_protocols
 	socket.handshake_headers = handshake_headers
-	var err = socket.connect_to_url(url, tls_verify, tls_trusted_certificate)
+	var err = null
+	if tls_verify:
+		err = socket.connect_to_url(url, TLSOptions.client(tls_trusted_certificate))
+	else:
+		err = socket.connect_to_url(url, TLSOptions.client_unsafe(tls_trusted_certificate))
 	if err != OK:
 		return err
 	last_state = socket.get_ready_state()

--- a/networking/websocket_chat/websocket/WebSocketServer.gd
+++ b/networking/websocket_chat/websocket/WebSocketServer.gd
@@ -145,7 +145,7 @@ func _connect_pending(p: PendingPeer) -> bool:
 		if p.connection == p.tcp:
 			assert(tls_key != null and tls_cert != null)
 			var tls = StreamPeerTLS.new()
-			tls.accept_stream(p.tcp, tls_key, tls_cert)
+			tls.accept_stream(p.tcp, TLSOptions.server(tls_key, tls_cert))
 			p.connection = tls
 		p.connection.poll()
 		var status = p.connection.get_status()


### PR DESCRIPTION
I made only changes to:
 - `networking/websocket_chat/websocket/WebSocketClient.gd`.
 - `networking/websocket_chat/websocket/WebSocketServer.gd`.

The `layout_mode` changes in combo.tscn(on first run) as well as changes to `project.godot`(on opening project) were done automatically by the editor.
I kept them since it might simplify the project and didn't break anything. I will remove it if advised.

![image](https://user-images.githubusercontent.com/11459028/232252580-4e9a285f-538c-4a63-975a-019a1b9e3fce.png)
No more errors. And everything seems to work fine.

My first MR as part of https://github.com/godotengine/godot-demo-projects/issues/697.