### PR TITLE
[WebSocket] Fix chat demo to updated TLS function.

### DIFF
--- a/networking/websocket_chat/chat.tscn
+++ b/networking/websocket_chat/chat.tscn
@@ -11,75 +11,59 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Panel" type="Panel" parent="."]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
 [node name="Listen" type="HBoxContainer" parent="Panel/VBoxContainer"]
-offset_right = 1152.0
+layout_mode = 2
 
 [node name="Connect" type="HBoxContainer" parent="Panel/VBoxContainer"]
-offset_top = 4.0
-offset_right = 1152.0
-offset_bottom = 35.0
+layout_mode = 2
 
 [node name="Host" type="LineEdit" parent="Panel/VBoxContainer/Connect"]
-offset_right = 930.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_horizontal = 3
 text = "ws://localhost:8000/test/"
 placeholder_text = "ws://my.server/path/"
 
 [node name="Connect" type="Button" parent="Panel/VBoxContainer/Connect"]
-offset_left = 934.0
-offset_right = 1006.0
-offset_bottom = 31.0
+layout_mode = 2
 toggle_mode = true
 text = "Connect"
 
 [node name="Port" type="SpinBox" parent="Panel/VBoxContainer/Connect"]
-offset_left = 1010.0
-offset_right = 1093.0
-offset_bottom = 31.0
+layout_mode = 2
 min_value = 1.0
 max_value = 65535.0
 value = 8000.0
 
 [node name="Listen" type="Button" parent="Panel/VBoxContainer/Connect"]
-offset_left = 1097.0
-offset_right = 1152.0
-offset_bottom = 31.0
+layout_mode = 2
 toggle_mode = true
 text = "Listen"
 
 [node name="Send" type="HBoxContainer" parent="Panel/VBoxContainer"]
-offset_top = 39.0
-offset_right = 1152.0
-offset_bottom = 70.0
+layout_mode = 2
 
 [node name="LineEdit" type="LineEdit" parent="Panel/VBoxContainer/Send"]
-offset_right = 1101.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Enter some text to send..."
 
 [node name="Send" type="Button" parent="Panel/VBoxContainer/Send"]
-offset_left = 1105.0
-offset_right = 1152.0
-offset_bottom = 31.0
+layout_mode = 2
 text = "Send"
 
 [node name="RichTextLabel" type="RichTextLabel" parent="Panel/VBoxContainer"]
-offset_top = 74.0
-offset_right = 1152.0
-offset_bottom = 648.0
+layout_mode = 2
 size_flags_vertical = 3

--- a/networking/websocket_chat/client.tscn
+++ b/networking/websocket_chat/client.tscn
@@ -13,44 +13,17 @@ supported_protocols = PackedStringArray("demo-chat")
 
 [node name="Panel" parent="." index="1"]
 layout_mode = 1
+anchors_preset = 15
 
 [node name="VBoxContainer" parent="Panel" index="0"]
 layout_mode = 1
-
-[node name="Listen" parent="Panel/VBoxContainer" index="0"]
-layout_mode = 2
-
-[node name="Connect" parent="Panel/VBoxContainer" index="1"]
-layout_mode = 2
-
-[node name="Host" parent="Panel/VBoxContainer/Connect" index="0"]
-layout_mode = 2
-offset_right = 1076.0
-
-[node name="Connect" parent="Panel/VBoxContainer/Connect" index="1"]
-layout_mode = 2
-offset_left = 1080.0
-offset_right = 1152.0
+anchors_preset = 15
 
 [node name="Port" parent="Panel/VBoxContainer/Connect" index="2"]
 visible = false
-layout_mode = 2
 
 [node name="Listen" parent="Panel/VBoxContainer/Connect" index="3"]
 visible = false
-layout_mode = 2
-
-[node name="Send" parent="Panel/VBoxContainer" index="2"]
-layout_mode = 2
-
-[node name="LineEdit" parent="Panel/VBoxContainer/Send" index="0"]
-layout_mode = 2
-
-[node name="Send" parent="Panel/VBoxContainer/Send" index="1"]
-layout_mode = 2
-
-[node name="RichTextLabel" parent="Panel/VBoxContainer" index="3"]
-layout_mode = 2
 
 [connection signal="connected_to_server" from="WebSocketClient" to="." method="_on_web_socket_client_connected_to_server"]
 [connection signal="connection_closed" from="WebSocketClient" to="." method="_on_web_socket_client_connection_closed"]

--- a/networking/websocket_chat/combo.tscn
+++ b/networking/websocket_chat/combo.tscn
@@ -13,44 +13,24 @@ grow_vertical = 2
 mouse_filter = 1
 
 [node name="Box" type="HBoxContainer" parent="."]
-anchors_preset = 15
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
 [node name="Server" parent="Box" instance=ExtResource("1_0srxc")]
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_right = 574.0
-offset_bottom = 648.0
+layout_mode = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Box"]
-offset_left = 578.0
-offset_right = 1152.0
-offset_bottom = 648.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="Client" parent="Box/VBoxContainer" instance=ExtResource("2_percb")]
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_right = 574.0
-offset_bottom = 213.0
+layout_mode = 2
 
 [node name="Client2" parent="Box/VBoxContainer" instance=ExtResource("2_percb")]
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_top = 217.0
-offset_right = 574.0
-offset_bottom = 430.0
+layout_mode = 2
 
 [node name="Client3" parent="Box/VBoxContainer" instance=ExtResource("2_percb")]
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_top = 434.0
-offset_right = 574.0
-offset_bottom = 648.0
+layout_mode = 2

--- a/networking/websocket_chat/project.godot
+++ b/networking/websocket_chat/project.godot
@@ -8,22 +8,6 @@
 
 config_version=5
 
-_global_script_classes=[{
-"base": "Node",
-"class": &"WebSocketClient",
-"language": &"GDScript",
-"path": "res://websocket/WebSocketClient.gd"
-}, {
-"base": "Node",
-"class": &"WebSocketServer",
-"language": &"GDScript",
-"path": "res://websocket/WebSocketServer.gd"
-}]
-_global_script_class_icons={
-"WebSocketClient": "",
-"WebSocketServer": ""
-}
-
 [application]
 
 config/name="WebSocket Chat Demo"

--- a/networking/websocket_chat/server.tscn
+++ b/networking/websocket_chat/server.tscn
@@ -12,47 +12,18 @@ script = ExtResource("3_0eqsy")
 supported_protocols = PackedStringArray("demo-chat")
 
 [node name="Panel" parent="." index="1"]
-layout_mode = 3
+layout_mode = 1
+anchors_preset = 15
 
 [node name="VBoxContainer" parent="Panel" index="0"]
-layout_mode = 3
-
-[node name="Listen" parent="Panel/VBoxContainer" index="0"]
-layout_mode = 3
-
-[node name="Connect" parent="Panel/VBoxContainer" index="1"]
-layout_mode = 3
+layout_mode = 1
+anchors_preset = 15
 
 [node name="Host" parent="Panel/VBoxContainer/Connect" index="0"]
 visible = false
-layout_mode = 3
-offset_right = 1006.0
 
 [node name="Connect" parent="Panel/VBoxContainer/Connect" index="1"]
 visible = false
-layout_mode = 3
-
-[node name="Port" parent="Panel/VBoxContainer/Connect" index="2"]
-layout_mode = 3
-offset_left = 0.0
-offset_right = 83.0
-
-[node name="Listen" parent="Panel/VBoxContainer/Connect" index="3"]
-layout_mode = 3
-offset_left = 87.0
-offset_right = 142.0
-
-[node name="Send" parent="Panel/VBoxContainer" index="2"]
-layout_mode = 3
-
-[node name="LineEdit" parent="Panel/VBoxContainer/Send" index="0"]
-layout_mode = 3
-
-[node name="Send" parent="Panel/VBoxContainer/Send" index="1"]
-layout_mode = 3
-
-[node name="RichTextLabel" parent="Panel/VBoxContainer" index="3"]
-layout_mode = 3
 
 [connection signal="client_connected" from="WebSocketServer" to="." method="_on_web_socket_server_client_connected"]
 [connection signal="client_disconnected" from="WebSocketServer" to="." method="_on_web_socket_server_client_disconnected"]

--- a/networking/websocket_chat/websocket/WebSocketClient.gd
+++ b/networking/websocket_chat/websocket/WebSocketClient.gd
@@ -3,8 +3,7 @@ class_name WebSocketClient
 
 @export var handshake_headers: PackedStringArray
 @export var supported_protocols: PackedStringArray
-@export var tls_trusted_certificate: X509Certificate
-@export var tls_verify := true
+var tls_options: TLSOptions = null
 
 
 var socket = WebSocketPeer.new()
@@ -19,7 +18,7 @@ signal message_received(message: Variant)
 func connect_to_url(url) -> int:
 	socket.supported_protocols = supported_protocols
 	socket.handshake_headers = handshake_headers
-	var err = socket.connect_to_url(url, tls_verify, tls_trusted_certificate)
+	var err = socket.connect_to_url(url, tls_options)
 	if err != OK:
 		return err
 	last_state = socket.get_ready_state()

--- a/networking/websocket_chat/websocket/WebSocketServer.gd
+++ b/networking/websocket_chat/websocket/WebSocketServer.gd
@@ -145,7 +145,7 @@ func _connect_pending(p: PendingPeer) -> bool:
 		if p.connection == p.tcp:
 			assert(tls_key != null and tls_cert != null)
 			var tls = StreamPeerTLS.new()
-			tls.accept_stream(p.tcp, tls_key, tls_cert)
+			tls.accept_stream(p.tcp, TLSOptions.server(tls_key, tls_cert))
 			p.connection = tls
 		p.connection.poll()
 		var status = p.connection.get_status()


### PR DESCRIPTION
Old cert + key/servername have been replaced with the new TLSOption configuration object.

The scene changes are just the result of opening the project and re-saving the scene with godot 4.0.2 stable.