### PR TITLE
Add tags to all demo projects

### DIFF
--- a/2d/bullet_shower/project.godot
+++ b/2d/bullet_shower/project.godot
@@ -15,7 +15,7 @@ config/description="Demonstrates how to manage large amounts of objects efficien
 run/main_scene="res://shower.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "performance", "2d")
+config/tags=PackedStringArray("2d", "demo", "official", "performance")
 
 [display]
 

--- a/2d/bullet_shower/project.godot
+++ b/2d/bullet_shower/project.godot
@@ -15,6 +15,7 @@ config/description="Demonstrates how to manage large amounts of objects efficien
 run/main_scene="res://shower.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "performance", "2d")
 
 [display]
 

--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -20,7 +20,7 @@ following the tutorial in the documentation."
 run/main_scene="res://Main.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("2d", "official", "demo")
+config/tags=PackedStringArray("2d", "demo", "official")
 
 [debug]
 

--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -20,6 +20,7 @@ following the tutorial in the documentation."
 run/main_scene="res://Main.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("2d", "official", "demo")
 
 [debug]
 

--- a/2d/finite_state_machine/project.godot
+++ b/2d/finite_state_machine/project.godot
@@ -17,6 +17,7 @@ pushdown automaton."
 run/main_scene="res://Demo.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("ai", "demo", "official", "2d")
 
 [display]
 

--- a/2d/finite_state_machine/project.godot
+++ b/2d/finite_state_machine/project.godot
@@ -17,7 +17,7 @@ pushdown automaton."
 run/main_scene="res://Demo.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("ai", "demo", "official", "2d")
+config/tags=PackedStringArray("2d", "ai", "demo", "official")
 
 [display]
 

--- a/2d/glow/project.godot
+++ b/2d/glow/project.godot
@@ -18,6 +18,7 @@ run/main_scene="res://beach_cave.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
 run/name=""
+config/tags=PackedStringArray("2d", "official", "demo", "rendering")
 
 [display]
 

--- a/2d/glow/project.godot
+++ b/2d/glow/project.godot
@@ -18,7 +18,7 @@ run/main_scene="res://beach_cave.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
 run/name=""
-config/tags=PackedStringArray("2d", "official", "demo", "rendering")
+config/tags=PackedStringArray("2d", "demo", "official", "rendering")
 
 [display]
 

--- a/2d/hexagonal_map/project.godot
+++ b/2d/hexagonal_map/project.godot
@@ -15,7 +15,7 @@ config/description="Very simple demo showing a hexagonal TileMap and TileSet."
 run/main_scene="res://map.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("2d", "official", "demo", "tilemap")
+config/tags=PackedStringArray("2d", "demo", "official", "tilemap")
 
 [display]
 

--- a/2d/hexagonal_map/project.godot
+++ b/2d/hexagonal_map/project.godot
@@ -15,6 +15,7 @@ config/description="Very simple demo showing a hexagonal TileMap and TileSet."
 run/main_scene="res://map.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("2d", "official", "demo", "tilemap")
 
 [display]
 

--- a/2d/instancing/project.godot
+++ b/2d/instancing/project.godot
@@ -16,6 +16,7 @@ make many duplicates of the same object."
 run/main_scene="res://scene_instancing.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "2d")
 
 [display]
 

--- a/2d/instancing/project.godot
+++ b/2d/instancing/project.godot
@@ -16,7 +16,7 @@ make many duplicates of the same object."
 run/main_scene="res://scene_instancing.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "2d")
+config/tags=PackedStringArray("2d", "demo", "official")
 
 [display]
 

--- a/2d/isometric/project.godot
+++ b/2d/isometric/project.godot
@@ -18,7 +18,7 @@ as well as be occluded when standing in front or behind them."
 run/main_scene="res://dungeon.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("tilemap", "2d", "official", "demo")
+config/tags=PackedStringArray("2d", "demo", "official", "tilemap")
 
 [display]
 

--- a/2d/isometric/project.godot
+++ b/2d/isometric/project.godot
@@ -18,6 +18,7 @@ as well as be occluded when standing in front or behind them."
 run/main_scene="res://dungeon.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("tilemap", "2d", "official", "demo")
 
 [display]
 

--- a/2d/kinematic_character/project.godot
+++ b/2d/kinematic_character/project.godot
@@ -17,7 +17,7 @@ platforms, can jump through one-way collision platforms, etc."
 run/main_scene="res://world.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("physics", "2d", "official", "demo")
+config/tags=PackedStringArray("2d", "demo", "official", "physics")
 
 [display]
 

--- a/2d/kinematic_character/project.godot
+++ b/2d/kinematic_character/project.godot
@@ -17,6 +17,7 @@ platforms, can jump through one-way collision platforms, etc."
 run/main_scene="res://world.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("physics", "2d", "official", "demo")
 
 [display]
 

--- a/2d/light2d_as_mask/project.godot
+++ b/2d/light2d_as_mask/project.godot
@@ -15,7 +15,7 @@ config/description="Example of how to use 2D lights to mask objects on screen."
 run/main_scene="res://lightmask.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "2d", "rendering")
+config/tags=PackedStringArray("2d", "demo", "official", "rendering")
 
 [display]
 

--- a/2d/light2d_as_mask/project.godot
+++ b/2d/light2d_as_mask/project.godot
@@ -15,6 +15,7 @@ config/description="Example of how to use 2D lights to mask objects on screen."
 run/main_scene="res://lightmask.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "2d", "rendering")
 
 [display]
 

--- a/2d/lights_and_shadows/project.godot
+++ b/2d/lights_and_shadows/project.godot
@@ -16,7 +16,7 @@ using PointLight2D and LightOccluder2D."
 run/main_scene="res://light_shadows.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "2d", "rendering")
+config/tags=PackedStringArray("2d", "demo", "official", "rendering")
 
 [display]
 

--- a/2d/lights_and_shadows/project.godot
+++ b/2d/lights_and_shadows/project.godot
@@ -16,6 +16,7 @@ using PointLight2D and LightOccluder2D."
 run/main_scene="res://light_shadows.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "2d", "rendering")
 
 [display]
 

--- a/2d/navigation/project.godot
+++ b/2d/navigation/project.godot
@@ -17,6 +17,7 @@ a path between two points, and then traverses the resulting path."
 run/main_scene="res://level.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("2d", "ai", "official", "demo")
 
 [display]
 

--- a/2d/navigation/project.godot
+++ b/2d/navigation/project.godot
@@ -17,7 +17,7 @@ a path between two points, and then traverses the resulting path."
 run/main_scene="res://level.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("2d", "ai", "official", "demo")
+config/tags=PackedStringArray("2d", "ai", "demo", "official")
 
 [display]
 

--- a/2d/navigation_astar/project.godot
+++ b/2d/navigation_astar/project.godot
@@ -16,6 +16,7 @@ complete with Steering Behaviors in order to smooth the movement out."
 run/main_scene="res://game.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("ai", "demo", "official", "2d", "tilemap")
 
 [display]
 

--- a/2d/navigation_astar/project.godot
+++ b/2d/navigation_astar/project.godot
@@ -16,7 +16,7 @@ complete with Steering Behaviors in order to smooth the movement out."
 run/main_scene="res://game.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("ai", "demo", "official", "2d", "tilemap")
+config/tags=PackedStringArray("2d", "ai", "demo", "official", "tilemap")
 
 [display]
 

--- a/2d/particles/project.godot
+++ b/2d/particles/project.godot
@@ -15,6 +15,7 @@ config/description="This demo showcases how 2D particle systems work in Godot."
 run/main_scene="res://particles.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "2d", "rendering")
 
 [display]
 

--- a/2d/particles/project.godot
+++ b/2d/particles/project.godot
@@ -15,7 +15,7 @@ config/description="This demo showcases how 2D particle systems work in Godot."
 run/main_scene="res://particles.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "2d", "rendering")
+config/tags=PackedStringArray("2d", "demo", "official", "rendering")
 
 [display]
 

--- a/2d/physics_platformer/project.godot
+++ b/2d/physics_platformer/project.godot
@@ -18,6 +18,7 @@ manual modification of the RigidDynamicBody3D velocity."
 run/main_scene="res://stage.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("2d", "physics", "demo", "official", "tilemap")
 
 [debug]
 

--- a/2d/physics_platformer/project.godot
+++ b/2d/physics_platformer/project.godot
@@ -18,7 +18,7 @@ manual modification of the RigidDynamicBody3D velocity."
 run/main_scene="res://stage.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("2d", "physics", "demo", "official", "tilemap")
+config/tags=PackedStringArray("2d", "demo", "official", "physics", "tilemap")
 
 [debug]
 

--- a/2d/physics_tests/project.godot
+++ b/2d/physics_tests/project.godot
@@ -14,6 +14,7 @@ config/name="2D Physics Tests"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "2d", "physics")
 
 [autoload]
 

--- a/2d/physics_tests/project.godot
+++ b/2d/physics_tests/project.godot
@@ -14,7 +14,7 @@ config/name="2D Physics Tests"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "2d", "physics")
+config/tags=PackedStringArray("2d", "demo", "official", "physics")
 
 [autoload]
 

--- a/2d/platformer/project.godot
+++ b/2d/platformer/project.godot
@@ -23,7 +23,7 @@ run/main_scene="res://game_singleplayer.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
 target_fps="60"
-config/tags=PackedStringArray("2d", "demo", "official", "tilemap", "physics")
+config/tags=PackedStringArray("2d", "demo", "official", "physics", "tilemap")
 
 [debug]
 

--- a/2d/platformer/project.godot
+++ b/2d/platformer/project.godot
@@ -23,6 +23,7 @@ run/main_scene="res://game_singleplayer.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
 target_fps="60"
+config/tags=PackedStringArray("2d", "demo", "official", "tilemap", "physics")
 
 [debug]
 

--- a/2d/pong/project.godot
+++ b/2d/pong/project.godot
@@ -16,6 +16,7 @@ for game development in Godot, including signals."
 run/main_scene="pong.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "2d")
 
 [display]
 

--- a/2d/pong/project.godot
+++ b/2d/pong/project.godot
@@ -16,7 +16,7 @@ for game development in Godot, including signals."
 run/main_scene="pong.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "2d")
+config/tags=PackedStringArray("2d", "demo", "official")
 
 [display]
 

--- a/2d/role_playing_game/project.godot
+++ b/2d/role_playing_game/project.godot
@@ -17,6 +17,7 @@ battle system on top of it."
 run/main_scene="res://Game.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("2d", "gui", "tilemap", "official", "demo")
 
 [display]
 

--- a/2d/role_playing_game/project.godot
+++ b/2d/role_playing_game/project.godot
@@ -17,7 +17,7 @@ battle system on top of it."
 run/main_scene="res://Game.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("2d", "gui", "tilemap", "official", "demo")
+config/tags=PackedStringArray("2d", "demo", "gui", "official", "tilemap")
 
 [display]
 

--- a/2d/screen_space_shaders/project.godot
+++ b/2d/screen_space_shaders/project.godot
@@ -16,7 +16,7 @@ Many common full-res effects are implemented here for reference."
 run/main_scene="res://screen_shaders.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("rendering", "official", "demo", "shaders", "2d")
+config/tags=PackedStringArray("2d", "demo", "official", "rendering", "shaders")
 
 [display]
 

--- a/2d/screen_space_shaders/project.godot
+++ b/2d/screen_space_shaders/project.godot
@@ -16,6 +16,7 @@ Many common full-res effects are implemented here for reference."
 run/main_scene="res://screen_shaders.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("rendering", "official", "demo", "shaders", "2d")
 
 [display]
 

--- a/2d/skeleton/project.godot
+++ b/2d/skeleton/project.godot
@@ -27,7 +27,7 @@ there is a simple character controller that controls the animations."
 run/main_scene="res://level.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("2d", "rendering", "official", "demo", "animation")
+config/tags=PackedStringArray("2d", "animation", "demo", "official", "rendering")
 
 [display]
 

--- a/2d/skeleton/project.godot
+++ b/2d/skeleton/project.godot
@@ -27,6 +27,7 @@ there is a simple character controller that controls the animations."
 run/main_scene="res://level.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("2d", "rendering", "official", "demo", "animation")
 
 [display]
 

--- a/2d/sprite_shaders/project.godot
+++ b/2d/sprite_shaders/project.godot
@@ -16,6 +16,7 @@ Effects include outlines, blurs, distorts, shadows, glows, and more."
 run/main_scene="res://sprite_shaders.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "2d", "rendering", "shaders")
 
 [display]
 

--- a/2d/sprite_shaders/project.godot
+++ b/2d/sprite_shaders/project.godot
@@ -16,7 +16,7 @@ Effects include outlines, blurs, distorts, shadows, glows, and more."
 run/main_scene="res://sprite_shaders.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "2d", "rendering", "shaders")
+config/tags=PackedStringArray("2d", "demo", "official", "rendering", "shaders")
 
 [display]
 

--- a/2d/tween/project.godot
+++ b/2d/tween/project.godot
@@ -17,6 +17,7 @@ config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
 target_fps=60
+config/tags=PackedStringArray("animation", "official", "demo", "2d")
 
 [display]
 

--- a/2d/tween/project.godot
+++ b/2d/tween/project.godot
@@ -17,7 +17,7 @@ config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
 target_fps=60
-config/tags=PackedStringArray("animation", "official", "demo", "2d")
+config/tags=PackedStringArray("2d", "animation", "demo", "official")
 
 [display]
 

--- a/3d/antialiasing/project.godot
+++ b/3d/antialiasing/project.godot
@@ -15,6 +15,7 @@ config/description="This project showcases the various 3D antialiasing technique
 run/main_scene="res://anti_aliasing.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "official", "demo")
 
 [display]
 

--- a/3d/antialiasing/project.godot
+++ b/3d/antialiasing/project.godot
@@ -15,7 +15,7 @@ config/description="This project showcases the various 3D antialiasing technique
 run/main_scene="res://anti_aliasing.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official")
 
 [display]
 

--- a/3d/csg/project.godot
+++ b/3d/csg/project.godot
@@ -20,7 +20,7 @@ run/main_scene="res://csg.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official")
 
 [display]
 

--- a/3d/csg/project.godot
+++ b/3d/csg/project.godot
@@ -20,6 +20,7 @@ run/main_scene="res://csg.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "official", "demo")
 
 [display]
 

--- a/3d/decals/project.godot
+++ b/3d/decals/project.godot
@@ -17,6 +17,7 @@ config/name="Decals"
 run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("rendering", "3d", "official", "demo")
 
 [display]
 

--- a/3d/decals/project.godot
+++ b/3d/decals/project.godot
@@ -17,7 +17,7 @@ config/name="Decals"
 run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("rendering", "3d", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official", "rendering")
 
 [display]
 

--- a/3d/global_illumination/project.godot
+++ b/3d/global_illumination/project.godot
@@ -15,7 +15,7 @@ config/description="This demo showcases Godot's global illumination systems: Lig
 run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("rendering", "3d", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official", "rendering")
 
 [display]
 

--- a/3d/global_illumination/project.godot
+++ b/3d/global_illumination/project.godot
@@ -15,6 +15,7 @@ config/description="This demo showcases Godot's global illumination systems: Lig
 run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("rendering", "3d", "official", "demo")
 
 [display]
 

--- a/3d/graphics_settings/project.godot
+++ b/3d/graphics_settings/project.godot
@@ -14,7 +14,7 @@ config/name="3D Graphics Settings"
 run/main_scene="res://control.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "3d", "rendering", "settings")
+config/tags=PackedStringArray("3d", "demo", "official", "rendering", "settings")
 
 [display]
 

--- a/3d/graphics_settings/project.godot
+++ b/3d/graphics_settings/project.godot
@@ -14,6 +14,7 @@ config/name="3D Graphics Settings"
 run/main_scene="res://control.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "3d", "rendering", "settings")
 
 [display]
 

--- a/3d/ik/project.godot
+++ b/3d/ik/project.godot
@@ -17,7 +17,7 @@ different ways they can be used, including via SkeletonIK3D."
 run/main_scene="res://look_at_ik.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "3d")
+config/tags=PackedStringArray("3d", "demo", "official")
 
 [display]
 

--- a/3d/ik/project.godot
+++ b/3d/ik/project.godot
@@ -17,6 +17,7 @@ different ways they can be used, including via SkeletonIK3D."
 run/main_scene="res://look_at_ik.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "3d")
 
 [display]
 

--- a/3d/kinematic_character/project.godot
+++ b/3d/kinematic_character/project.godot
@@ -16,6 +16,7 @@ This is similar to the 3D platformer demo."
 run/main_scene="res://level.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "official", "demo", "physics")
 
 [display]
 

--- a/3d/kinematic_character/project.godot
+++ b/3d/kinematic_character/project.godot
@@ -16,7 +16,7 @@ This is similar to the 3D platformer demo."
 run/main_scene="res://level.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "official", "demo", "physics")
+config/tags=PackedStringArray("3d", "demo", "official", "physics")
 
 [display]
 

--- a/3d/labels_and_texts/project.godot
+++ b/3d/labels_and_texts/project.godot
@@ -18,7 +18,7 @@ config/description="This project showcases 2 ways to draw text in 3D space: the 
 run/main_scene="res://3d_labels_and_texts.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "3d", "rendering")
+config/tags=PackedStringArray("3d", "demo", "official", "rendering")
 
 [display]
 

--- a/3d/labels_and_texts/project.godot
+++ b/3d/labels_and_texts/project.godot
@@ -18,6 +18,7 @@ config/description="This project showcases 2 ways to draw text in 3D space: the 
 run/main_scene="res://3d_labels_and_texts.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "3d", "rendering")
 
 [display]
 

--- a/3d/lights_and_shadows/project.godot
+++ b/3d/lights_and_shadows/project.godot
@@ -21,6 +21,7 @@ The background sky uses a PhysicalSkyMaterial, which allows for the sky colors t
 run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "official", "demo", "rendering")
 
 [display]
 

--- a/3d/lights_and_shadows/project.godot
+++ b/3d/lights_and_shadows/project.godot
@@ -21,7 +21,7 @@ The background sky uses a PhysicalSkyMaterial, which allows for the sky colors t
 run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "official", "demo", "rendering")
+config/tags=PackedStringArray("3d", "demo", "official", "rendering")
 
 [display]
 

--- a/3d/material_testers/project.godot
+++ b/3d/material_testers/project.godot
@@ -18,7 +18,7 @@ This demo was featured at the beginning of the Godot 3.0 trailer."
 run/main_scene="res://material_tester.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "rendering", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official", "rendering")
 
 [display]
 

--- a/3d/material_testers/project.godot
+++ b/3d/material_testers/project.godot
@@ -18,6 +18,7 @@ This demo was featured at the beginning of the Godot 3.0 trailer."
 run/main_scene="res://material_tester.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "rendering", "official", "demo")
 
 [display]
 

--- a/3d/navigation/project.godot
+++ b/3d/navigation/project.godot
@@ -18,6 +18,7 @@ Code is provided for polyline following in 3D."
 run/main_scene="res://navmesh.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "3d", "ai")
 
 [physics]
 

--- a/3d/navigation/project.godot
+++ b/3d/navigation/project.godot
@@ -18,7 +18,7 @@ Code is provided for polyline following in 3D."
 run/main_scene="res://navmesh.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "3d", "ai")
+config/tags=PackedStringArray("3d", "ai", "demo", "official")
 
 [physics]
 

--- a/3d/occlusion_culling_mesh_lod/project.godot
+++ b/3d/occlusion_culling_mesh_lod/project.godot
@@ -15,6 +15,7 @@ config/description="This demo showcases the use of occlusion culling and mesh le
 run/main_scene="res://node_3d.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "rendering", "performance", "official", "demo")
 
 [display]
 

--- a/3d/occlusion_culling_mesh_lod/project.godot
+++ b/3d/occlusion_culling_mesh_lod/project.godot
@@ -15,7 +15,7 @@ config/description="This demo showcases the use of occlusion culling and mesh le
 run/main_scene="res://node_3d.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "rendering", "performance", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official", "performance", "rendering")
 
 [display]
 

--- a/3d/particles/project.godot
+++ b/3d/particles/project.godot
@@ -18,7 +18,7 @@ config/description="This project showcases various 3D particle features supporte
 run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "official", "demo", "rendering")
+config/tags=PackedStringArray("3d", "demo", "official", "rendering")
 
 [display]
 

--- a/3d/particles/project.godot
+++ b/3d/particles/project.godot
@@ -18,6 +18,7 @@ config/description="This project showcases various 3D particle features supporte
 run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "official", "demo", "rendering")
 
 [display]
 

--- a/3d/physics_tests/project.godot
+++ b/3d/physics_tests/project.godot
@@ -30,7 +30,7 @@ config/name="3D Physics Tests"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("physics", "demo", "3d", "official")
+config/tags=PackedStringArray("3d", "demo", "official", "physics")
 
 [autoload]
 

--- a/3d/physics_tests/project.godot
+++ b/3d/physics_tests/project.godot
@@ -30,6 +30,7 @@ config/name="3D Physics Tests"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("physics", "demo", "3d", "official")
 
 [autoload]
 

--- a/3d/platformer/project.godot
+++ b/3d/platformer/project.godot
@@ -16,6 +16,7 @@ It uses similar code to the 2D platformer, but implemented in 3D."
 run/main_scene="res://game.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "physics", "gridmap", "official", "demo")
 
 [input]
 

--- a/3d/platformer/project.godot
+++ b/3d/platformer/project.godot
@@ -16,7 +16,7 @@ It uses similar code to the 2D platformer, but implemented in 3D."
 run/main_scene="res://game.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "physics", "gridmap", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "gridmap", "official", "physics")
 
 [input]
 

--- a/3d/rigidbody_character/project.godot
+++ b/3d/rigidbody_character/project.godot
@@ -16,7 +16,7 @@ config/description="Rigidbody character demo for 3D using a capsule for the char
 run/main_scene="res://level.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "physics", "demo", "official")
+config/tags=PackedStringArray("3d", "demo", "official", "physics")
 
 [display]
 

--- a/3d/rigidbody_character/project.godot
+++ b/3d/rigidbody_character/project.godot
@@ -16,6 +16,7 @@ config/description="Rigidbody character demo for 3D using a capsule for the char
 run/main_scene="res://level.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "physics", "demo", "official")
 
 [display]
 

--- a/3d/truck_town/project.godot
+++ b/3d/truck_town/project.godot
@@ -16,6 +16,7 @@ varying complexity using vehicle physics."
 run/main_scene="res://car_select/car_select.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "physics", "official", "demo", "vehicle")
 
 [display]
 

--- a/3d/truck_town/project.godot
+++ b/3d/truck_town/project.godot
@@ -16,7 +16,7 @@ varying complexity using vehicle physics."
 run/main_scene="res://car_select/car_select.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "physics", "official", "demo", "vehicle")
+config/tags=PackedStringArray("3d", "demo", "official", "physics", "vehicle")
 
 [display]
 

--- a/3d/variable_rate_shading/project.godot
+++ b/3d/variable_rate_shading/project.godot
@@ -17,6 +17,7 @@ Performance metrics are also displayed to evaluate potential performance gains."
 run/main_scene="res://vrs.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "rendering", "performance", "official", "demo")
 
 [display]
 

--- a/3d/variable_rate_shading/project.godot
+++ b/3d/variable_rate_shading/project.godot
@@ -17,7 +17,7 @@ Performance metrics are also displayed to evaluate potential performance gains."
 run/main_scene="res://vrs.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "rendering", "performance", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official", "performance", "rendering")
 
 [display]
 

--- a/3d/volumetric_fog/project.godot
+++ b/3d/volumetric_fog/project.godot
@@ -14,7 +14,7 @@ config/name="Volumetric Fog"
 run/main_scene="res://volumetric_fog.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "rendering", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official", "rendering")
 
 [display]
 

--- a/3d/volumetric_fog/project.godot
+++ b/3d/volumetric_fog/project.godot
@@ -14,6 +14,7 @@ config/name="Volumetric Fog"
 run/main_scene="res://volumetric_fog.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "rendering", "official", "demo")
 
 [display]
 

--- a/3d/voxel/project.godot
+++ b/3d/voxel/project.godot
@@ -35,6 +35,7 @@ use Zylann's voxel module instead: https://github.com/Zylann/godot_voxel"
 run/main_scene="res://menu/main/main_menu.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "demo", "official")
 
 [autoload]
 

--- a/3d/waypoints/project.godot
+++ b/3d/waypoints/project.godot
@@ -15,6 +15,7 @@ config/description="This is an example of displaying GUI elements such as Labels
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "official", "demo")
 
 [display]
 

--- a/3d/waypoints/project.godot
+++ b/3d/waypoints/project.godot
@@ -15,7 +15,7 @@ config/description="This is an example of displaying GUI elements such as Labels
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official")
 
 [display]
 

--- a/audio/bpm_sync/project.godot
+++ b/audio/bpm_sync/project.godot
@@ -15,6 +15,7 @@ config/description="A demo of how to sync the audio playback with the time for a
 run/main_scene="res://bpm_sync.tscn"
 config/icon="res://icon.webp"
 config/features=PackedStringArray("4.0")
+config/tags=PackedStringArray("official", "audio", "demo")
 
 [rendering]
 

--- a/audio/bpm_sync/project.godot
+++ b/audio/bpm_sync/project.godot
@@ -15,7 +15,7 @@ config/description="A demo of how to sync the audio playback with the time for a
 run/main_scene="res://bpm_sync.tscn"
 config/icon="res://icon.webp"
 config/features=PackedStringArray("4.0")
-config/tags=PackedStringArray("official", "audio", "demo")
+config/tags=PackedStringArray("audio", "demo", "official")
 
 [rendering]
 

--- a/audio/device_changer/project.godot
+++ b/audio/device_changer/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://Changer.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "audio")
 
 [display]
 

--- a/audio/device_changer/project.godot
+++ b/audio/device_changer/project.godot
@@ -16,7 +16,7 @@ run/main_scene="res://Changer.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "audio")
+config/tags=PackedStringArray("audio", "demo", "official")
 
 [display]
 

--- a/audio/generator/project.godot
+++ b/audio/generator/project.godot
@@ -18,6 +18,7 @@ run/main_scene="res://generator.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("audio", "official", "demo")
 
 [display]
 

--- a/audio/generator/project.godot
+++ b/audio/generator/project.godot
@@ -18,7 +18,7 @@ run/main_scene="res://generator.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("audio", "official", "demo")
+config/tags=PackedStringArray("audio", "demo", "official")
 
 [display]
 

--- a/audio/mic_record/project.godot
+++ b/audio/mic_record/project.godot
@@ -17,7 +17,7 @@ run/main_scene="res://MicRecord.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "audio", "demo")
+config/tags=PackedStringArray("audio", "demo", "official")
 
 [audio]
 

--- a/audio/mic_record/project.godot
+++ b/audio/mic_record/project.godot
@@ -17,6 +17,7 @@ run/main_scene="res://MicRecord.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "audio", "demo")
 
 [audio]
 

--- a/audio/midi_piano/project.godot
+++ b/audio/midi_piano/project.godot
@@ -24,6 +24,7 @@ config/name="MIDI Piano Demo"
 run/main_scene="res://piano.tscn"
 config/icon="res://icon.webp"
 config/features=PackedStringArray("4.0")
+config/tags=PackedStringArray("audio", "demo", "official")
 
 [display]
 

--- a/audio/spectrum/project.godot
+++ b/audio/spectrum/project.godot
@@ -16,7 +16,7 @@ run/main_scene="res://show_spectrum.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "audio", "visualization")
+config/tags=PackedStringArray("audio", "demo", "official", "visualization")
 
 [display]
 

--- a/audio/spectrum/project.godot
+++ b/audio/spectrum/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://show_spectrum.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "audio", "visualization")
 
 [display]
 

--- a/audio/text_to_speech/project.godot
+++ b/audio/text_to_speech/project.godot
@@ -15,7 +15,7 @@ config/description="This is a demo showing text-to-speech support."
 run/main_scene="res://control.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("accessibility", "official", "demo", "gui")
+config/tags=PackedStringArray("accessibility", "demo", "gui", "official")
 
 [display]
 

--- a/audio/text_to_speech/project.godot
+++ b/audio/text_to_speech/project.godot
@@ -15,6 +15,7 @@ config/description="This is a demo showing text-to-speech support."
 run/main_scene="res://control.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("accessibility", "official", "demo", "gui")
 
 [display]
 

--- a/gui/bidi_and_font_features/project.godot
+++ b/gui/bidi_and_font_features/project.godot
@@ -15,6 +15,7 @@ run/main_scene="res://bidi.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("gui", "official", "demo")
 
 [display]
 

--- a/gui/bidi_and_font_features/project.godot
+++ b/gui/bidi_and_font_features/project.godot
@@ -15,7 +15,7 @@ run/main_scene="res://bidi.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("gui", "official", "demo")
+config/tags=PackedStringArray("demo", "gui", "official")
 
 [display]
 

--- a/gui/control_gallery/project.godot
+++ b/gui/control_gallery/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://control_gallery.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("gui", "official", "demo")
 
 [display]
 

--- a/gui/control_gallery/project.godot
+++ b/gui/control_gallery/project.godot
@@ -16,7 +16,7 @@ run/main_scene="res://control_gallery.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("gui", "official", "demo")
+config/tags=PackedStringArray("demo", "gui", "official")
 
 [display]
 

--- a/gui/drag_and_drop/project.godot
+++ b/gui/drag_and_drop/project.godot
@@ -19,7 +19,7 @@ run/main_scene="res://drag_and_drop.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("gui", "official", "demo")
+config/tags=PackedStringArray("demo", "gui", "official")
 
 [display]
 

--- a/gui/drag_and_drop/project.godot
+++ b/gui/drag_and_drop/project.godot
@@ -19,6 +19,7 @@ run/main_scene="res://drag_and_drop.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("gui", "official", "demo")
 
 [display]
 

--- a/gui/gd_paint/project.godot
+++ b/gui/gd_paint/project.godot
@@ -17,6 +17,7 @@ and eraser, as well as a rectangle and a circle brush."
 run/main_scene="res://paint_root.tscn"
 config/icon="res://icon.webp"
 config/features=PackedStringArray("4.0")
+config/tags=PackedStringArray("official", "demo", "gui")
 
 [debug]
 

--- a/gui/gd_paint/project.godot
+++ b/gui/gd_paint/project.godot
@@ -17,7 +17,7 @@ and eraser, as well as a rectangle and a circle brush."
 run/main_scene="res://paint_root.tscn"
 config/icon="res://icon.webp"
 config/features=PackedStringArray("4.0")
-config/tags=PackedStringArray("official", "demo", "gui")
+config/tags=PackedStringArray("demo", "gui", "official")
 
 [debug]
 

--- a/gui/input_mapping/project.godot
+++ b/gui/input_mapping/project.godot
@@ -19,7 +19,7 @@ config/description="A demo showing how to build an input key remapping screen.
 run/main_scene="res://InputRemapMenu.tscn"
 config/icon="res://icon.webp"
 config/features=PackedStringArray("4.0")
-config/tags=PackedStringArray("gui", "official", "demo", "input", "settings")
+config/tags=PackedStringArray("demo", "gui", "input", "official", "settings")
 
 [autoload]
 

--- a/gui/input_mapping/project.godot
+++ b/gui/input_mapping/project.godot
@@ -19,6 +19,7 @@ config/description="A demo showing how to build an input key remapping screen.
 run/main_scene="res://InputRemapMenu.tscn"
 config/icon="res://icon.webp"
 config/features=PackedStringArray("4.0")
+config/tags=PackedStringArray("gui", "official", "demo", "input", "settings")
 
 [autoload]
 

--- a/gui/msdf_font/project.godot
+++ b/gui/msdf_font/project.godot
@@ -20,7 +20,7 @@ at small font sizes compared to single-channel signed distance field fonts."
 run/main_scene="res://sdf_font_demo.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("gui", "rendering", "2d", "official", "demo")
+config/tags=PackedStringArray("2d", "demo", "gui", "official", "rendering")
 
 [display]
 

--- a/gui/msdf_font/project.godot
+++ b/gui/msdf_font/project.godot
@@ -20,6 +20,7 @@ at small font sizes compared to single-channel signed distance field fonts."
 run/main_scene="res://sdf_font_demo.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("gui", "rendering", "2d", "official", "demo")
 
 [display]
 

--- a/gui/multiple_resolutions/project.godot
+++ b/gui/multiple_resolutions/project.godot
@@ -31,6 +31,7 @@ run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "gui", "best_practices", "accessibility")
 
 [display]
 

--- a/gui/multiple_resolutions/project.godot
+++ b/gui/multiple_resolutions/project.godot
@@ -31,7 +31,7 @@ run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "gui", "best_practices", "accessibility")
+config/tags=PackedStringArray("accessibility", "best_practices", "demo", "gui", "official")
 
 [display]
 

--- a/gui/pseudolocalization/project.godot
+++ b/gui/pseudolocalization/project.godot
@@ -14,6 +14,7 @@ config/name="Pseudolocalization"
 run/main_scene="res://Pseudolocalization.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "internationalization")
 
 [internationalization]
 

--- a/gui/pseudolocalization/project.godot
+++ b/gui/pseudolocalization/project.godot
@@ -14,7 +14,7 @@ config/name="Pseudolocalization"
 run/main_scene="res://Pseudolocalization.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "internationalization")
+config/tags=PackedStringArray("demo", "internationalization", "official")
 
 [internationalization]
 

--- a/gui/regex/project.godot
+++ b/gui/regex/project.godot
@@ -16,6 +16,7 @@ Can also serve as a playground for regex testing."
 run/main_scene="res://regex.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "gui")
 
 [display]
 

--- a/gui/regex/project.godot
+++ b/gui/regex/project.godot
@@ -16,7 +16,7 @@ Can also serve as a playground for regex testing."
 run/main_scene="res://regex.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "gui")
+config/tags=PackedStringArray("demo", "gui", "official")
 
 [display]
 

--- a/gui/rich_text_bbcode/project.godot
+++ b/gui/rich_text_bbcode/project.godot
@@ -16,7 +16,7 @@ run/main_scene="res://rich_text_bbcode.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("gui", "official", "demo")
+config/tags=PackedStringArray("demo", "gui", "official")
 
 [display]
 

--- a/gui/rich_text_bbcode/project.godot
+++ b/gui/rich_text_bbcode/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://rich_text_bbcode.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("gui", "official", "demo")
 
 [display]
 

--- a/gui/theming_override/project.godot
+++ b/gui/theming_override/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("gui", "demo", "official")
 
 [display]
 

--- a/gui/theming_override/project.godot
+++ b/gui/theming_override/project.godot
@@ -16,7 +16,7 @@ run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("gui", "demo", "official")
+config/tags=PackedStringArray("demo", "gui", "official")
 
 [display]
 

--- a/gui/translation/project.godot
+++ b/gui/translation/project.godot
@@ -16,6 +16,7 @@ the use of localized resources and texts."
 run/main_scene="res://translation_demo.tscn"
 config/icon="res://icon.webp"
 config/features=PackedStringArray("4.0")
+config/tags=PackedStringArray("internationalization", "official", "demo")
 
 [display]
 

--- a/gui/translation/project.godot
+++ b/gui/translation/project.godot
@@ -16,7 +16,7 @@ the use of localized resources and texts."
 run/main_scene="res://translation_demo.tscn"
 config/icon="res://icon.webp"
 config/features=PackedStringArray("4.0")
-config/tags=PackedStringArray("internationalization", "official", "demo")
+config/tags=PackedStringArray("demo", "internationalization", "official")
 
 [display]
 

--- a/gui/ui_mirroring/project.godot
+++ b/gui/ui_mirroring/project.godot
@@ -13,3 +13,4 @@ config_version=4
 config/name="UI Mirroring Demo"
 run/main_scene="res://ui_mirroring.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("internationalization", "official", "demo", "gui")

--- a/gui/ui_mirroring/project.godot
+++ b/gui/ui_mirroring/project.godot
@@ -13,4 +13,4 @@ config_version=4
 config/name="UI Mirroring Demo"
 run/main_scene="res://ui_mirroring.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("internationalization", "official", "demo", "gui")
+config/tags=PackedStringArray("demo", "gui", "internationalization", "official")

--- a/loading/autoload/project.godot
+++ b/loading/autoload/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://scene_a.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "best_practices")
 
 [autoload]
 

--- a/loading/autoload/project.godot
+++ b/loading/autoload/project.godot
@@ -16,7 +16,7 @@ run/main_scene="res://scene_a.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "best_practices")
+config/tags=PackedStringArray("best_practices", "demo", "official")
 
 [autoload]
 

--- a/loading/load_threaded/project.godot
+++ b/loading/load_threaded/project.godot
@@ -16,7 +16,7 @@ run/main_scene="res://load_threaded.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("best_practices", "performance", "official", "demo")
+config/tags=PackedStringArray("best_practices", "demo", "official", "performance")
 
 [display]
 

--- a/loading/load_threaded/project.godot
+++ b/loading/load_threaded/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://load_threaded.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("best_practices", "performance", "official", "demo")
 
 [display]
 

--- a/loading/scene_changer/project.godot
+++ b/loading/scene_changer/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://scene_a.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.svg"
+config/tags=PackedStringArray("demo", "official")
 
 [display]
 

--- a/loading/serialization/project.godot
+++ b/loading/serialization/project.godot
@@ -35,6 +35,7 @@ https://docs.godotengine.org/en/latest/tutorials/io/saving_games.html"
 run/main_scene="res://save_load.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "filesystem")
 
 [display]
 

--- a/loading/serialization/project.godot
+++ b/loading/serialization/project.godot
@@ -35,7 +35,7 @@ https://docs.godotengine.org/en/latest/tutorials/io/saving_games.html"
 run/main_scene="res://save_load.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "filesystem")
+config/tags=PackedStringArray("demo", "filesystem", "official")
 
 [display]
 

--- a/loading/threads/project.godot
+++ b/loading/threads/project.godot
@@ -18,7 +18,7 @@ run/low_processor_mode=true
 config/icon="res://icon.webp"
 run/stretch/aspect="expand"
 run/stretch/mode="canvas_items"
-config/tags=PackedStringArray("best_practices", "official", "demo", "performance")
+config/tags=PackedStringArray("best_practices", "demo", "official", "performance")
 
 [display]
 

--- a/loading/threads/project.godot
+++ b/loading/threads/project.godot
@@ -18,6 +18,7 @@ run/low_processor_mode=true
 config/icon="res://icon.webp"
 run/stretch/aspect="expand"
 run/stretch/mode="canvas_items"
+config/tags=PackedStringArray("best_practices", "official", "demo", "performance")
 
 [display]
 

--- a/misc/2.5d/project.godot
+++ b/misc/2.5d/project.godot
@@ -45,6 +45,7 @@ in Godot by mixing 2D and 3D nodes. It also adds a
 run/main_scene="res://assets/demo_scene.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "2d")
 
 [display]
 

--- a/misc/2.5d/project.godot
+++ b/misc/2.5d/project.godot
@@ -45,7 +45,7 @@ in Godot by mixing 2D and 3D nodes. It also adds a
 run/main_scene="res://assets/demo_scene.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "2d")
+config/tags=PackedStringArray("2d", "demo", "official")
 
 [display]
 

--- a/misc/compute_shader_heightmap/project.godot
+++ b/misc/compute_shader_heightmap/project.godot
@@ -15,6 +15,7 @@ run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("performance", "official", "demo", "rendering", "shaders")
 
 [display]
 

--- a/misc/compute_shader_heightmap/project.godot
+++ b/misc/compute_shader_heightmap/project.godot
@@ -15,7 +15,7 @@ run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("performance", "official", "demo", "rendering", "shaders")
+config/tags=PackedStringArray("demo", "official", "performance", "rendering", "shaders")
 
 [display]
 

--- a/misc/joypads/project.godot
+++ b/misc/joypads/project.godot
@@ -16,7 +16,7 @@ run/main_scene="res://joypads.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("input", "gui", "official", "demo")
+config/tags=PackedStringArray("demo", "gui", "input", "official")
 
 [display]
 

--- a/misc/joypads/project.godot
+++ b/misc/joypads/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://joypads.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("input", "gui", "official", "demo")
 
 [display]
 

--- a/misc/large_world_coordinates/project.godot
+++ b/misc/large_world_coordinates/project.godot
@@ -17,6 +17,7 @@ run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("physics", "3d", "official", "demo", "rendering")
 
 [display]
 

--- a/misc/large_world_coordinates/project.godot
+++ b/misc/large_world_coordinates/project.godot
@@ -17,7 +17,7 @@ run/main_scene="res://test.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("physics", "3d", "official", "demo", "rendering")
+config/tags=PackedStringArray("3d", "demo", "official", "physics", "rendering")
 
 [display]
 

--- a/misc/matrix_transform/project.godot
+++ b/misc/matrix_transform/project.godot
@@ -29,7 +29,7 @@ For more information, see the Matrices and Transforms article."
 run/main_scene="res://3D.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "official", "demo", "editor")
+config/tags=PackedStringArray("3d", "demo", "editor", "official")
 
 [rendering]
 

--- a/misc/matrix_transform/project.godot
+++ b/misc/matrix_transform/project.godot
@@ -29,6 +29,7 @@ For more information, see the Matrices and Transforms article."
 run/main_scene="res://3D.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "official", "demo", "editor")
 
 [rendering]
 

--- a/misc/noise_viewer/project.godot
+++ b/misc/noise_viewer/project.godot
@@ -12,11 +12,11 @@ config_version=5
 
 config/name="Noise Viewer"
 config/description="This is a sample project which allows the user to tweak different parameters of a FastNoiseLite texture."
+config/tags=PackedStringArray("demo", "gui", "official", "procedural", "visualization")
 run/main_scene="res://noise_viewer.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("gui", "official", "demo", "procedural", "visualization")
 
 [display]
 

--- a/misc/noise_viewer/project.godot
+++ b/misc/noise_viewer/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://noise_viewer.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("gui", "official", "demo", "procedural", "visualization")
 
 [display]
 

--- a/misc/os_test/project.godot
+++ b/misc/os_test/project.godot
@@ -17,11 +17,11 @@ new platform or to check for regressions.
 
 In a nutshell, this demo shows how you can get information from the
 operating system, or interact with the operating system."
+config/tags=PackedStringArray("demo", "official", "porting")
 run/main_scene="res://os_test.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("porting", "official", "demo")
 
 [display]
 

--- a/misc/os_test/project.godot
+++ b/misc/os_test/project.godot
@@ -21,6 +21,7 @@ run/main_scene="res://os_test.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("porting", "official", "demo")
 
 [display]
 

--- a/misc/pause/project.godot
+++ b/misc/pause/project.godot
@@ -15,7 +15,7 @@ config/description="A demo showing how a game made in Godot can be paused."
 run/main_scene="res://spinpause.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo")
+config/tags=PackedStringArray("demo", "official")
 
 [display]
 

--- a/misc/pause/project.godot
+++ b/misc/pause/project.godot
@@ -15,6 +15,7 @@ config/description="A demo showing how a game made in Godot can be paused."
 run/main_scene="res://spinpause.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo")
 
 [display]
 

--- a/misc/window_management/project.godot
+++ b/misc/window_management/project.godot
@@ -16,6 +16,7 @@ run/main_scene="res://window_management.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("porting", "official", "demo")
 
 [display]
 

--- a/misc/window_management/project.godot
+++ b/misc/window_management/project.godot
@@ -16,7 +16,7 @@ run/main_scene="res://window_management.tscn"
 config/features=PackedStringArray("4.0")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("porting", "official", "demo")
+config/tags=PackedStringArray("demo", "official", "porting")
 
 [display]
 

--- a/mobile/android_iap/project.godot
+++ b/mobile/android_iap/project.godot
@@ -20,6 +20,7 @@ config/description="This demo shows how to make in-app payments in Android.
 Note: Running the demo requires exporting and uploading the game to Google Play."
 run/main_scene="res://main.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "porting", "mobile")
 
 [display]
 

--- a/mobile/android_iap/project.godot
+++ b/mobile/android_iap/project.godot
@@ -20,7 +20,7 @@ config/description="This demo shows how to make in-app payments in Android.
 Note: Running the demo requires exporting and uploading the game to Google Play."
 run/main_scene="res://main.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "porting", "mobile")
+config/tags=PackedStringArray("demo", "mobile", "official", "porting")
 
 [display]
 

--- a/mobile/multitouch_cubes/project.godot
+++ b/mobile/multitouch_cubes/project.godot
@@ -14,6 +14,7 @@ config/name="Multitouch Cubes Demo "
 config/description="Demo of multitouch input and different gestures using the touch API. This demo is meant to be used with a touch-enabled device such as a phone or tablet."
 run/main_scene="res://Main.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("mobile", "input", "official", "demo")
 
 [input_devices]
 

--- a/mobile/multitouch_cubes/project.godot
+++ b/mobile/multitouch_cubes/project.godot
@@ -14,7 +14,7 @@ config/name="Multitouch Cubes Demo "
 config/description="Demo of multitouch input and different gestures using the touch API. This demo is meant to be used with a touch-enabled device such as a phone or tablet."
 run/main_scene="res://Main.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("mobile", "input", "official", "demo")
+config/tags=PackedStringArray("demo", "input", "mobile", "official")
 
 [input_devices]
 

--- a/mobile/multitouch_view/project.godot
+++ b/mobile/multitouch_view/project.godot
@@ -14,7 +14,7 @@ config/name="Multitouch View"
 config/description="Simple debugger for multitouch input. Shows red dots everywhere you press."
 run/main_scene="res://Main.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "mobile", "input")
+config/tags=PackedStringArray("demo", "input", "mobile", "official")
 
 [autoload]
 

--- a/mobile/multitouch_view/project.godot
+++ b/mobile/multitouch_view/project.godot
@@ -14,6 +14,7 @@ config/name="Multitouch View"
 config/description="Simple debugger for multitouch input. Shows red dots everywhere you press."
 run/main_scene="res://Main.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "mobile", "input")
 
 [autoload]
 

--- a/mobile/sensors/project.godot
+++ b/mobile/sensors/project.godot
@@ -19,7 +19,7 @@ config/description="A demo showing the use of various sensors: an accelerometer,
 These sensors are typically found on mobile devices, so don't expect this to work on a desktop."
 run/main_scene="res://main.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("mobile", "official", "demo")
+config/tags=PackedStringArray("demo", "mobile", "official")
 
 [rendering]
 

--- a/mobile/sensors/project.godot
+++ b/mobile/sensors/project.godot
@@ -19,6 +19,7 @@ config/description="A demo showing the use of various sensors: an accelerometer,
 These sensors are typically found on mobile devices, so don't expect this to work on a desktop."
 run/main_scene="res://main.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("mobile", "official", "demo")
 
 [rendering]
 

--- a/mono/2.5d/project.godot
+++ b/mono/2.5d/project.godot
@@ -16,6 +16,7 @@ in Godot by mixing 2D and 3D nodes. It also adds a
 2.5D editor viewport for easily editing 2.5D levels."
 run/main_scene="res://assets/demo_scene.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "2d")
 
 [display]
 

--- a/mono/2.5d/project.godot
+++ b/mono/2.5d/project.godot
@@ -16,7 +16,7 @@ in Godot by mixing 2D and 3D nodes. It also adds a
 2.5D editor viewport for easily editing 2.5D levels."
 run/main_scene="res://assets/demo_scene.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "2d")
+config/tags=PackedStringArray("2d", "demo", "official")
 
 [display]
 

--- a/mono/android_iap/project.godot
+++ b/mono/android_iap/project.godot
@@ -16,6 +16,7 @@ config/description="This demo shows how to make in-app payments in Android in C#
 Note: Running the demo requires exporting and uploading the game to Google Play."
 run/main_scene="res://main.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "mobile", "porting")
 
 [display]
 

--- a/mono/android_iap/project.godot
+++ b/mono/android_iap/project.godot
@@ -16,7 +16,7 @@ config/description="This demo shows how to make in-app payments in Android in C#
 Note: Running the demo requires exporting and uploading the game to Google Play."
 run/main_scene="res://main.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "mobile", "porting")
+config/tags=PackedStringArray("demo", "mobile", "official", "porting")
 
 [display]
 

--- a/mono/dodge_the_creeps/project.godot
+++ b/mono/dodge_the_creeps/project.godot
@@ -19,6 +19,7 @@ tutorial in the documentation, but ported to C#. For more details,
 consider following the tutorial in the documentation."
 run/main_scene="res://Main.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "2d")
 
 [display]
 

--- a/mono/dodge_the_creeps/project.godot
+++ b/mono/dodge_the_creeps/project.godot
@@ -19,7 +19,7 @@ tutorial in the documentation, but ported to C#. For more details,
 consider following the tutorial in the documentation."
 run/main_scene="res://Main.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "2d")
+config/tags=PackedStringArray("2d", "demo", "official")
 
 [display]
 

--- a/mono/multiplayer_pong/project.godot
+++ b/mono/multiplayer_pong/project.godot
@@ -16,7 +16,7 @@ One of the players should press 'host', while the
 other should select the address and press 'join'."
 run/main_scene="res://lobby.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "2d", "network")
+config/tags=PackedStringArray("2d", "demo", "network", "official")
 
 [display]
 

--- a/mono/multiplayer_pong/project.godot
+++ b/mono/multiplayer_pong/project.godot
@@ -16,6 +16,7 @@ One of the players should press 'host', while the
 other should select the address and press 'join'."
 run/main_scene="res://lobby.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "2d", "network")
 
 [display]
 

--- a/mono/pong/project.godot
+++ b/mono/pong/project.godot
@@ -15,6 +15,7 @@ config/description="A simple Pong game. This demo shows best practices
 for game development in Godot, including signals."
 run/main_scene="pong.tscn"
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "2d")
 
 [display]
 

--- a/mono/pong/project.godot
+++ b/mono/pong/project.godot
@@ -15,7 +15,7 @@ config/description="A simple Pong game. This demo shows best practices
 for game development in Godot, including signals."
 run/main_scene="pong.tscn"
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "2d")
+config/tags=PackedStringArray("2d", "demo", "official")
 
 [display]
 

--- a/networking/multiplayer_bomber/project.godot
+++ b/networking/multiplayer_bomber/project.godot
@@ -17,6 +17,7 @@ should type in his address and press 'play'."
 run/main_scene="res://lobby.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("network", "2d", "official", "demo")
 
 [autoload]
 

--- a/networking/multiplayer_bomber/project.godot
+++ b/networking/multiplayer_bomber/project.godot
@@ -17,7 +17,7 @@ should type in his address and press 'play'."
 run/main_scene="res://lobby.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("network", "2d", "official", "demo")
+config/tags=PackedStringArray("2d", "demo", "network", "official")
 
 [autoload]
 

--- a/networking/multiplayer_pong/project.godot
+++ b/networking/multiplayer_pong/project.godot
@@ -17,6 +17,7 @@ other should select the address and press 'join'."
 run/main_scene="res://lobby.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("2d", "demo", "official", "network")
 
 [display]
 

--- a/networking/multiplayer_pong/project.godot
+++ b/networking/multiplayer_pong/project.godot
@@ -17,7 +17,7 @@ other should select the address and press 'join'."
 run/main_scene="res://lobby.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("2d", "demo", "official", "network")
+config/tags=PackedStringArray("2d", "demo", "network", "official")
 
 [display]
 

--- a/networking/webrtc_minimal/project.godot
+++ b/networking/webrtc_minimal/project.godot
@@ -14,6 +14,7 @@ config/name="WebRTC Minimal Connection"
 config/description="This is a minimal sample of using WebRTC connections to connect two peers to each other."
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
+config/tags=PackedStringArray("network", "official", "demo")
 
 [autoload]
 

--- a/networking/webrtc_minimal/project.godot
+++ b/networking/webrtc_minimal/project.godot
@@ -14,7 +14,7 @@ config/name="WebRTC Minimal Connection"
 config/description="This is a minimal sample of using WebRTC connections to connect two peers to each other."
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.0")
-config/tags=PackedStringArray("network", "official", "demo")
+config/tags=PackedStringArray("demo", "network", "official")
 
 [autoload]
 

--- a/networking/webrtc_signaling/project.godot
+++ b/networking/webrtc_signaling/project.godot
@@ -17,6 +17,7 @@ The protocol is text based, and composed by a command and possibly
 multiple payload arguments, each separated by a new line."
 run/main_scene="res://demo/main.tscn"
 config/features=PackedStringArray("4.0")
+config/tags=PackedStringArray("official", "demo", "network")
 
 [debug]
 

--- a/networking/webrtc_signaling/project.godot
+++ b/networking/webrtc_signaling/project.godot
@@ -17,7 +17,7 @@ The protocol is text based, and composed by a command and possibly
 multiple payload arguments, each separated by a new line."
 run/main_scene="res://demo/main.tscn"
 config/features=PackedStringArray("4.0")
-config/tags=PackedStringArray("official", "demo", "network")
+config/tags=PackedStringArray("demo", "network", "official")
 
 [debug]
 

--- a/networking/websocket_chat/project.godot
+++ b/networking/websocket_chat/project.godot
@@ -15,3 +15,4 @@ config/description="This is a demo of a simple chat implemented using WebSockets
 run/main_scene="res://combo.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("network", "official", "demo")

--- a/networking/websocket_chat/project.godot
+++ b/networking/websocket_chat/project.godot
@@ -15,4 +15,4 @@ config/description="This is a demo of a simple chat implemented using WebSockets
 run/main_scene="res://combo.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("network", "official", "demo")
+config/tags=PackedStringArray("demo", "network", "official")

--- a/networking/websocket_minimal/project.godot
+++ b/networking/websocket_minimal/project.godot
@@ -14,6 +14,7 @@ config/name="WebSocket Minimal Demo"
 config/description="This is a minimal sample of connecting two peers to each other using websockets."
 run/main_scene="res://Main.tscn"
 config/features=PackedStringArray("4.0")
+config/tags=PackedStringArray("official", "demo", "network")
 
 [rendering]
 

--- a/networking/websocket_minimal/project.godot
+++ b/networking/websocket_minimal/project.godot
@@ -14,7 +14,7 @@ config/name="WebSocket Minimal Demo"
 config/description="This is a minimal sample of connecting two peers to each other using websockets."
 run/main_scene="res://Main.tscn"
 config/features=PackedStringArray("4.0")
-config/tags=PackedStringArray("official", "demo", "network")
+config/tags=PackedStringArray("demo", "network", "official")
 
 [rendering]
 

--- a/networking/websocket_multiplayer/project.godot
+++ b/networking/websocket_multiplayer/project.godot
@@ -15,7 +15,7 @@ config/description="This is a sample showing how the use WebSockets along with t
 run/main_scene="res://scene/combo.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("demo", "official", "network")
+config/tags=PackedStringArray("demo", "network", "official")
 
 [rendering]
 

--- a/networking/websocket_multiplayer/project.godot
+++ b/networking/websocket_multiplayer/project.godot
@@ -15,6 +15,7 @@ config/description="This is a sample showing how the use WebSockets along with t
 run/main_scene="res://scene/combo.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "network")
 
 [rendering]
 

--- a/plugins/project.godot
+++ b/plugins/project.godot
@@ -23,7 +23,7 @@ This project contains 4 plugins:
 run/main_scene="res://test_scene.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("official", "demo", "editor")
+config/tags=PackedStringArray("demo", "editor", "official")
 
 [editor_plugins]
 

--- a/plugins/project.godot
+++ b/plugins/project.godot
@@ -23,6 +23,7 @@ This project contains 4 plugins:
 run/main_scene="res://test_scene.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("official", "demo", "editor")
 
 [editor_plugins]
 

--- a/viewport/2d_in_3d/project.godot
+++ b/viewport/2d_in_3d/project.godot
@@ -15,6 +15,7 @@ config/description="A demo showing how a 2D scene can be shown within a 3D one u
 run/main_scene="res://2d_in_3d.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "2d", "rendering", "official", "demo")
 
 [input]
 

--- a/viewport/2d_in_3d/project.godot
+++ b/viewport/2d_in_3d/project.godot
@@ -15,7 +15,7 @@ config/description="A demo showing how a 2D scene can be shown within a 3D one u
 run/main_scene="res://2d_in_3d.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "2d", "rendering", "official", "demo")
+config/tags=PackedStringArray("2d", "3d", "demo", "official", "rendering")
 
 [input]
 

--- a/viewport/3d_in_2d/project.godot
+++ b/viewport/3d_in_2d/project.godot
@@ -15,6 +15,7 @@ config/description="A demo showing how a 3D scene can be shown within a 2D one u
 run/main_scene="res://3d_in_2d.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("2d", "official", "demo", "rendering", "3d")
 
 [display]
 

--- a/viewport/3d_in_2d/project.godot
+++ b/viewport/3d_in_2d/project.godot
@@ -15,7 +15,7 @@ config/description="A demo showing how a 3D scene can be shown within a 2D one u
 run/main_scene="res://3d_in_2d.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("2d", "official", "demo", "rendering", "3d")
+config/tags=PackedStringArray("2d", "3d", "demo", "official", "rendering")
 
 [display]
 

--- a/viewport/3d_scaling/project.godot
+++ b/viewport/3d_scaling/project.godot
@@ -19,6 +19,7 @@ non-pixel-art viewport for HUD elements."
 run/main_scene="res://hud.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "rendering", "demo", "official")
 
 [display]
 

--- a/viewport/3d_scaling/project.godot
+++ b/viewport/3d_scaling/project.godot
@@ -19,7 +19,7 @@ non-pixel-art viewport for HUD elements."
 run/main_scene="res://hud.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "rendering", "demo", "official")
+config/tags=PackedStringArray("3d", "demo", "official", "rendering")
 
 [display]
 

--- a/viewport/dynamic_split_screen/project.godot
+++ b/viewport/dynamic_split_screen/project.godot
@@ -16,7 +16,7 @@ split screen, also called Voronoi split screen, using GDSL."
 run/main_scene="res://split_screen.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "official", "demo")
+config/tags=PackedStringArray("3d", "demo", "official")
 
 [input]
 

--- a/viewport/dynamic_split_screen/project.godot
+++ b/viewport/dynamic_split_screen/project.godot
@@ -16,6 +16,7 @@ split screen, also called Voronoi split screen, using GDSL."
 run/main_scene="res://split_screen.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "official", "demo")
 
 [input]
 

--- a/viewport/gui_in_3d/project.godot
+++ b/viewport/gui_in_3d/project.godot
@@ -16,6 +16,7 @@ as well as forwarding mouse and keyboard input to the GUI."
 run/main_scene="res://gui_in_3d.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("3d", "official", "demo", "gui")
 
 [gdnative]
 

--- a/viewport/gui_in_3d/project.godot
+++ b/viewport/gui_in_3d/project.godot
@@ -16,7 +16,7 @@ as well as forwarding mouse and keyboard input to the GUI."
 run/main_scene="res://gui_in_3d.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "official", "demo", "gui")
+config/tags=PackedStringArray("3d", "demo", "gui", "official")
 
 [gdnative]
 

--- a/viewport/screen_capture/project.godot
+++ b/viewport/screen_capture/project.godot
@@ -15,6 +15,7 @@ config/description="An example showing how to take screenshots of the screen."
 run/main_scene="res://screen_capture.tscn"
 config/features=PackedStringArray("4.0")
 config/icon="res://icon.webp"
+config/tags=PackedStringArray("demo", "official", "rendering")
 
 [display]
 


### PR DESCRIPTION
This makes sorting them in the project manager easier, as you can click tags in the project manager to filter to a specific tag.

Project tags are a new feature in 4.1, but this new setting won't break the demos when opened in 4.0.x.

## Preview

*We could improve the display of some tags by using the editor property capitalization when displaying tags in the project manager. This is a change that needs to be performed in Godot itself, not in this PR.*

![Screenshot_20230626_175340](https://github.com/godotengine/godot-demo-projects/assets/180032/ff3a1188-1d48-4a7d-a0fb-07cfd8b93e5e)
