### PR TITLE
fsm: Map attack to gamepad X; revise text

### DIFF
--- a/2d/finite_state_machine/Demo.tscn
+++ b/2d/finite_state_machine/Demo.tscn
@@ -60,8 +60,8 @@ text = "This example shows how to apply the State programming pattern in GDScrip
 
 States are common in games. You can use the pattern to:
 
-1. Separate each behavior and transitions between behaviors, thus make scripts shorter and easier to manage
-2. Respect the Single Responsibility Principle. Each State object represents one action
+1. Separate each behavior and transitions between behaviors, thus make scripts shorter and easier to manage.
+2. Respect the Single Responsibility Principle. Each State object represents one action.
 3. Improve your code's structure. Look at the scene tree and FileSystem tab: without looking at the code, you'll know what the Player can or cannot do.
 
 You can read more about States in the excellent Game Programming Patterns ebook."

--- a/2d/finite_state_machine/debug/StatesStackDiplayer.tscn
+++ b/2d/finite_state_machine/debug/StatesStackDiplayer.tscn
@@ -17,7 +17,7 @@ grow_vertical = 2
 
 [node name="Title" type="Label" parent="VBoxContainer"]
 layout_mode = 2
-text = "Pushown"
+text = "StateStack"
 uppercase = true
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]

--- a/2d/finite_state_machine/project.godot
+++ b/2d/finite_state_machine/project.godot
@@ -87,7 +87,7 @@ simulate_damage={
 attack={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":70,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":2,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
 


### PR DESCRIPTION
Move attack map from gamepad Start to X so it's more discoverable.

Change label on state stack. "Pushown" was a typo for "pushdown", but understanding that requires reading a wikipedia page.

Add some periods to Explanations for consistency.
