### PR TITLE
Fix joypad demo for Godot 4.x

### DIFF
--- a/misc/joypads/joypads.tscn
+++ b/misc/joypads/joypads.tscn
@@ -46,6 +46,7 @@ corner_detail = 3
 
 [node name="JoypadsDemo" type="Control"]
 layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 30.0

--- a/misc/joypads/joypads.tscn
+++ b/misc/joypads/joypads.tscn
@@ -44,17 +44,14 @@ corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 3
 
-[node name="joypads" type="Control"]
+[node name="JoypadsDemo" type="Control"]
 layout_mode = 3
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -270.0
-offset_top = -240.0
-offset_right = 270.0
-offset_bottom = 240.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 30.0
+offset_top = 30.0
+offset_right = -30.0
+offset_bottom = -30.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1")
@@ -67,8 +64,7 @@ scale = Vector2(0.5, 0.5)
 layout_mode = 1
 anchors_preset = 10
 anchor_right = 1.0
-offset_top = -10.0
-offset_bottom = 40.0
+offset_bottom = 50.0
 grow_horizontal = 2
 
 [node name="Label" type="Label" parent="DeviceInfo"]
@@ -421,8 +417,8 @@ anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -250.0
-offset_top = -138.0
-offset_bottom = -22.0
+offset_top = -150.0
+offset_bottom = -34.0
 grow_horizontal = 0
 grow_vertical = 0
 
@@ -567,9 +563,8 @@ layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
-offset_top = -128.0
+offset_top = -144.0
 offset_right = 270.0
-offset_bottom = 16.0
 grow_vertical = 0
 
 [node name="Weak" type="HBoxContainer" parent="Vibration"]
@@ -652,8 +647,7 @@ anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -261.0
-offset_top = -18.0
-offset_bottom = 13.0
+offset_top = -31.0
 grow_horizontal = 0
 grow_vertical = 0
 alignment = 1

--- a/misc/joypads/project.godot
+++ b/misc/joypads/project.godot
@@ -23,7 +23,6 @@ config/tags=PackedStringArray("demo", "gui", "input", "official")
 window/size/viewport_width=600
 window/size/viewport_height=560
 window/vsync/vsync_mode=0
-window/subwindows/embed_subwindows=false
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 

--- a/misc/joypads/project.godot
+++ b/misc/joypads/project.godot
@@ -23,6 +23,7 @@ config/tags=PackedStringArray("demo", "gui", "input", "official")
 window/size/viewport_width=600
 window/size/viewport_height=560
 window/vsync/vsync_mode=0
+window/subwindows/embed_subwindows=false
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 

--- a/misc/joypads/remap/remap_wizard.gd
+++ b/misc/joypads/remap/remap_wizard.gd
@@ -18,6 +18,8 @@ var last_mapping = ""
 @onready var joy_mapping_axis_invert = $Mapping/Margin/VBox/Info/Extra/InvertAxis
 
 
+# Connected to Mapping.window_input, otherwise no gamepad events will be received when the subwindow is
+# focused
 func _input(event):
 	if cur_step == -1:
 		return

--- a/misc/joypads/remap/remap_wizard.gd
+++ b/misc/joypads/remap/remap_wizard.gd
@@ -27,8 +27,8 @@ func _input(event):
 		if abs(motion.axis_value) > DEADZONE:
 			var idx = motion.axis
 			var map = JoyMapping.new(JoyMapping.TYPE.AXIS, idx)
-			map.inverted = joy_mapping_axis_invert.pressed
-			if joy_mapping_full_axis.pressed:
+			map.inverted = joy_mapping_axis_invert.button_pressed
+			if joy_mapping_full_axis.button_pressed:
 				map.axis = JoyMapping.AXIS.FULL
 			elif motion.axis_value > 0:
 				map.axis = JoyMapping.AXIS.HALF_PLUS
@@ -125,8 +125,8 @@ func _update_step():
 		var cur = cur_mapping[steps[cur_step]]
 		joy_mapping_text.text = cur.to_human_string()
 		if cur.type == JoyMapping.TYPE.AXIS:
-			joy_mapping_full_axis.pressed = cur.axis == JoyMapping.AXIS.FULL
-			joy_mapping_axis_invert.pressed = cur.inverted
+			joy_mapping_full_axis.button_pressed = cur.axis == JoyMapping.AXIS.FULL
+			joy_mapping_axis_invert.button_pressed = cur.inverted
 
 
 func _on_Wizard_pressed():

--- a/misc/joypads/remap/remap_wizard.gd
+++ b/misc/joypads/remap/remap_wizard.gd
@@ -116,6 +116,8 @@ func _update_step():
 	if key in ["leftx", "lefty", "rightx", "righty"]:
 		joy_axes.get_node(str(idx) + "+").show()
 		joy_axes.get_node(str(idx) + "-").show()
+	elif key in ["lefttrigger", "righttrigger"]:
+		joy_axes.get_node(str(idx)).show()
 	else:
 		joy_buttons.get_node(str(idx)).show()
 

--- a/misc/joypads/remap/remap_wizard.gd
+++ b/misc/joypads/remap/remap_wizard.gd
@@ -3,6 +3,7 @@ extends Node
 
 const DEADZONE = 0.3
 
+var joy_index = -1
 var joy_guid = ""
 var joy_name = ""
 
@@ -22,6 +23,12 @@ var last_mapping = ""
 # focused
 func _input(event):
 	if cur_step == -1:
+		return
+	# Ignore events not related to gamepads
+	if not (event is InputEventJoypadButton or event is InputEventJoypadMotion):
+		return
+	# Ignore devices other than the one being remapped. Handles accidental input and analog drift
+	if event.device != joy_index:
 		return
 	if event is InputEventJoypadMotion:
 		get_viewport().set_input_as_handled()
@@ -60,6 +67,7 @@ func create_mapping_string(mapping):
 
 
 func start(idx):
+	joy_index = idx
 	joy_guid = Input.get_joy_guid(idx)
 	joy_name = Input.get_joy_name(idx)
 	if joy_guid.is_empty():

--- a/misc/joypads/remap/remap_wizard.gd
+++ b/misc/joypads/remap/remap_wizard.gd
@@ -3,14 +3,14 @@ extends Node
 
 const DEADZONE = 0.3
 
-var joy_index = -1
-var joy_guid = ""
-var joy_name = ""
+var joy_index: int = -1
+var joy_guid: String = ""
+var joy_name: String = ""
 
-var steps = JoyMapping.BASE.keys()
-var cur_step = -1
-var cur_mapping = {}
-var last_mapping = ""
+var steps: Array = JoyMapping.BASE.keys()
+var cur_step: int = -1
+var cur_mapping: Dictionary = {}
+var last_mapping: String = ""
 
 @onready var joy_buttons = $Mapping/Margin/VBox/SubViewportContainer/SubViewport/JoypadDiagram/Buttons
 @onready var joy_axes = $Mapping/Margin/VBox/SubViewportContainer/SubViewport/JoypadDiagram/Axes
@@ -19,15 +19,15 @@ var last_mapping = ""
 @onready var joy_mapping_axis_invert = $Mapping/Margin/VBox/Info/Extra/InvertAxis
 
 
-# Connected to Mapping.window_input, otherwise no gamepad events will be received when the subwindow is
-# focused
+# Connected to Mapping.window_input, otherwise no gamepad events
+# will be received when the subwindow is focused.
 func _input(event):
 	if cur_step == -1:
 		return
-	# Ignore events not related to gamepads
+	# Ignore events not related to gamepads.
 	if not (event is InputEventJoypadButton or event is InputEventJoypadMotion):
 		return
-	# Ignore devices other than the one being remapped. Handles accidental input and analog drift
+	# Ignore devices other than the one being remapped. Handles accidental input and analog drift.
 	if event.device != joy_index:
 		return
 	if event is InputEventJoypadMotion:
@@ -53,7 +53,7 @@ func _input(event):
 		cur_mapping[steps[cur_step]] = map
 
 
-func create_mapping_string(mapping):
+func create_mapping_string(mapping: Dictionary) -> String:
 	var string = "%s,%s," % [joy_guid, joy_name]
 	for k in mapping:
 		var m = mapping[k]
@@ -66,7 +66,7 @@ func create_mapping_string(mapping):
 	return string + "platform:" + platform
 
 
-func start(idx):
+func start(idx: int):
 	joy_index = idx
 	joy_guid = Input.get_joy_guid(idx)
 	joy_name = Input.get_joy_name(idx)
@@ -82,7 +82,7 @@ func start(idx):
 		_on_Wizard_pressed()
 
 
-func remap_and_close(mapping):
+func remap_and_close(mapping: Dictionary) -> void:
 	last_mapping = create_mapping_string(mapping)
 	Input.add_joy_mapping(last_mapping, true)
 	reset()

--- a/misc/joypads/remap/remap_wizard.tscn
+++ b/misc/joypads/remap/remap_wizard.tscn
@@ -253,6 +253,7 @@ size_flags_vertical = 3
 [connection signal="pressed" from="Start/Margin/Layout/Buttons/Cancel" to="." method="_on_Cancel_pressed"]
 [connection signal="pressed" from="Start/Margin/Layout/Buttons/Wizard" to="." method="_on_Wizard_pressed"]
 [connection signal="close_requested" from="Mapping" to="." method="_on_mapping_close_requested"]
+[connection signal="window_input" from="Mapping" to="." method="_input"]
 [connection signal="toggled" from="Mapping/Margin/VBox/Info/Extra/FullAxis" to="." method="_on_FullAxis_toggled"]
 [connection signal="toggled" from="Mapping/Margin/VBox/Info/Extra/InvertAxis" to="." method="_on_InvertAxis_toggled"]
 [connection signal="pressed" from="Mapping/Margin/VBox/Info/Buttons/Prev" to="." method="_on_Prev_pressed"]

--- a/misc/joypads/remap/remap_wizard.tscn
+++ b/misc/joypads/remap/remap_wizard.tscn
@@ -93,8 +93,8 @@ offset_bottom = 31.0
 text = "Wizard"
 
 [node name="Mapping" type="Window" parent="."]
-position = Vector2i(130, 200)
-size = Vector2i(340, 100)
+position = Vector2i(130, 100)
+size = Vector2i(340, 400)
 visible = false
 min_size = Vector2i(340, 100)
 
@@ -104,6 +104,10 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 30
+theme_override_constants/margin_top = 30
+theme_override_constants/margin_right = 30
+theme_override_constants/margin_bottom = 30
 
 [node name="VBox" type="VBoxContainer" parent="Mapping/Margin"]
 layout_mode = 2
@@ -111,13 +115,14 @@ offset_right = 600.0
 offset_bottom = 540.0
 
 [node name="SubViewportContainer" type="SubViewportContainer" parent="Mapping/Margin/VBox"]
+custom_minimum_size = Vector2(0, 260)
 layout_mode = 2
 offset_right = 600.0
 stretch = true
 
 [node name="SubViewport" type="SubViewport" parent="Mapping/Margin/VBox/SubViewportContainer"]
 handle_input_locally = false
-size = Vector2i(600, 0)
+size = Vector2i(600, 260)
 render_target_update_mode = 0
 
 [node name="JoypadDiagram" parent="Mapping/Margin/VBox/SubViewportContainer/SubViewport" instance=ExtResource("2")]


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
This fixes a number of issues preventing to use the remap feature:
- The gamepad images with the button layout were not visible
- Gamepad input was not being detected while the remap window was focused
- Some porting issues where `.pressed` appeared where `.button_pressed` was meant
- The wrong buttons being highlighted when remapping triggers
- The remap window was accepting events from all gamepads rather than only the one being remapped, which could be an issue if another connected controller has analog drift of is accidentally pressed for whatever reason.

~Input detection only works with native subwindows. I couldn't get it to work when using embedded subwindows. The subwindow seems to stop event propagation even with handle_input_locally disabled. You can workaround it by clicking outside the remap window before pressing a button but it should get a proper fix~
Checking the Godot source code it seems to be by design. Subwindows will always handle input when focused. Managed to fix it by connecting to Window.window_input