### PR TITLE
[Squash The Creeps] Use `Basis.looking_at` to control facing

### DIFF
--- a/3d/squash_the_creeps/Player.gd
+++ b/3d/squash_the_creeps/Player.gd
@@ -26,7 +26,8 @@ func _physics_process(delta):
 	if direction != Vector3.ZERO:
 		# In the lines below, we turn the character when moving and make the animation play faster.
 		direction = direction.normalized()
-		$Pivot.look_at(position + direction, Vector3.UP)
+		# Setting the basis property will affect the rotation of the node.
+		$Pivot.basis = Basis.looking_at(direction)
 		$AnimationPlayer.speed_scale = 4
 	else:
 		$AnimationPlayer.speed_scale = 1


### PR DESCRIPTION
Not technically wrong as `Player` is in global space but easily confusing to new users if they keep using `position` for this method.

Related:
* https://github.com/godotengine/godot-docs/pull/7890
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
