### PR TITLE
fix: mic_record script a bit for mac

### DIFF
--- a/audio/mic_record/MicRecord.gd
+++ b/audio/mic_record/MicRecord.gd
@@ -1,7 +1,7 @@
 extends Control
 
 var effect  # See AudioEffect in docs
-var recording  # See AudioStreamSample in docs
+var recording  # See AudioStreamWAV in docs
 
 var stereo := true
 var mix_rate := 44100  # This is the default mix rate on recordings
@@ -93,4 +93,8 @@ func _on_StereoCheckButton_toggled(button_pressed: bool) -> void:
 
 
 func _on_open_user_folder_button_pressed():
-	OS.shell_open(ProjectSettings.globalize_path("user://"))
+	match OS.get_name():
+		"macOS", "MacOS", "OSX":
+			OS.shell_open("file://" + ProjectSettings.globalize_path("user://"))
+		_:
+			OS.shell_open(ProjectSettings.globalize_path("user://"))

--- a/audio/mic_record/MicRecord.gd
+++ b/audio/mic_record/MicRecord.gd
@@ -94,7 +94,7 @@ func _on_StereoCheckButton_toggled(button_pressed: bool) -> void:
 
 func _on_open_user_folder_button_pressed():
 	match OS.get_name():
-		"macOS", "MacOS", "OSX":
+		"macOS":
 			OS.shell_open("file://" + ProjectSettings.globalize_path("user://"))
 		_:
 			OS.shell_open(ProjectSettings.globalize_path("user://"))


### PR DESCRIPTION
Realised this demo was a bit broken while testing something irrelevant to the changes.

Also using all 3 names as iirc, OSX was what we used in 3.x. Though TBH not sure been a while since I used Godot 3. And I am not sure about the capitalisation part.