### PR TITLE
Matrix Transform: ported to Godot 4.2

### DIFF
--- a/misc/matrix_transform/marker/AxisMarker2D.gd
+++ b/misc/matrix_transform/marker/AxisMarker2D.gd
@@ -1,6 +1,8 @@
 @tool
-class_name AxisMarker2D, "res://marker/AxisMarker2D.svg"
+@icon("res://marker/AxisMarker2D.svg")
+class_name AxisMarker2D
 extends Node2D
+
 
 func _process(_delta):
 	var line: Line2D = get_child(0).get_child(0)

--- a/misc/matrix_transform/marker/AxisMarker2D.svg.import
+++ b/misc/matrix_transform/marker/AxisMarker2D.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/AxisMarker2D.svg-a52a23070c2ca9dcdd860a47183c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/misc/matrix_transform/marker/AxisMarker3D.gd
+++ b/misc/matrix_transform/marker/AxisMarker3D.gd
@@ -1,7 +1,7 @@
 @tool
-extends Node3D
-class_name AxisMarker3D
 @icon("res://marker/AxisMarker3D.svg")
+class_name AxisMarker3D
+extends Node3D
 
 
 func _process(_delta):

--- a/misc/matrix_transform/marker/AxisMarker3D.svg.import
+++ b/misc/matrix_transform/marker/AxisMarker3D.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/AxisMarker3D.svg-613a31ba426aca266949d2735333
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/misc/matrix_transform/project.godot
+++ b/misc/matrix_transform/project.godot
@@ -18,7 +18,7 @@ Do not 'run' this project. You are only meant to use it within the Godot editor.
 For more information, see the Matrices and Transforms article."
 config/tags=PackedStringArray("3d", "demo", "editor", "official")
 run/main_scene="res://3D.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.1")
 config/icon="res://icon.webp"
 
 [rendering]

--- a/misc/matrix_transform/project.godot
+++ b/misc/matrix_transform/project.godot
@@ -8,16 +8,6 @@
 
 config_version=5
 
-_global_script_classes=[{
-"base": "Node3D",
-"class": &"AxisMarker3D",
-"language": &"GDScript",
-"path": "res://marker/AxisMarker3D.gd"
-}]
-_global_script_class_icons={
-"AxisMarker3D": "res://marker/AxisMarker3D.svg"
-}
-
 [application]
 
 config/name="Matrix Transform3D"
@@ -26,10 +16,10 @@ config/description="This demo project is a playground where you can visualize ho
 Do not 'run' this project. You are only meant to use it within the Godot editor.
 
 For more information, see the Matrices and Transforms article."
-run/main_scene="res://3D.tscn"
-config/features=PackedStringArray("4.0")
-config/icon="res://icon.webp"
 config/tags=PackedStringArray("3d", "demo", "editor", "official")
+run/main_scene="res://3D.tscn"
+config/features=PackedStringArray("4.2")
+config/icon="res://icon.webp"
 
 [rendering]
 


### PR DESCRIPTION
v4.2.dev6.official [57a6813bb]

Matrix Transform _(fix `@icon` statement, must be at the top of script)_ https://github.com/godotengine/godot-demo-projects/issues/697