### PR TITLE
Multitouch Cubes: ported to Godot 4.1

### DIFF
--- a/mobile/multitouch_cubes/CubeScene.tscn
+++ b/mobile/multitouch_cubes/CubeScene.tscn
@@ -1,29 +1,28 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=4 format=3 uid="uid://csyb8ij530w1l"]
 
-[ext_resource path="res://default_env.tres" type="Environment" id=1]
+[ext_resource type="Environment" uid="uid://cpe7fpfvhiapa" path="res://default_env.tres" id="1"]
 
-[sub_resource type="StandardMaterial3D" id=1]
-params_diffuse_mode = 1
+[sub_resource type="StandardMaterial3D" id="1"]
+diffuse_mode = 1
 albedo_color = Color(0.149414, 0.796875, 0.569252, 1)
 roughness = 0.0
 
-[sub_resource type="BoxMesh" id=2]
+[sub_resource type="BoxMesh" id="2"]
 
 [node name="Node3D" type="Node3D"]
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
 transform = Transform3D(0.707107, 0, -0.707107, -0.353553, 0.866025, -0.353553, 0.612372, 0.5, 0.612372, 0, 0, 0)
-material_override = SubResource( 1 )
-mesh = SubResource( 2 )
-surface_material_override/0 = null
+material_override = SubResource("1")
+mesh = SubResource("2")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.926535, 0.11439, -0.358396, 0.199614, 0.658013, 0.726067, 0.318884, -0.744267, 0.586839, 0, 0, 0)
 
 [node name="Camera3D" type="Camera3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 5)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.08165e-12, 2.08165e-12, 3)
 fov = 60.0
 near = 0.1
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
-environment = ExtResource( 1 )
+environment = ExtResource("1")

--- a/mobile/multitouch_cubes/GestureArea.gd
+++ b/mobile/multitouch_cubes/GestureArea.gd
@@ -63,9 +63,9 @@ func _gui_input(event):
 				# Touching finger dragged.
 				var unit_drag = _px2unit(base_state[base_state.keys()[0]] - event.position)
 				if one_finger_rot_x:
-					target_node.global_rotate(Vector3.UP, deg2rad(180.0 * unit_drag.x))
+					target_node.global_rotate(Vector3.UP, deg_to_rad(180.0 * unit_drag.x))
 				if one_finger_rot_y:
-					target_node.global_rotate(Vector3.RIGHT, deg2rad(180.0 * unit_drag.y))
+					target_node.global_rotate(Vector3.RIGHT, deg_to_rad(180.0 * unit_drag.y))
 				# Since rotating around two axes, we have to reset the base constantly.
 				curr_state[event.index] = event.position
 				base_state[event.index] = event.position

--- a/mobile/multitouch_cubes/Main.tscn
+++ b/mobile/multitouch_cubes/Main.tscn
@@ -1,160 +1,125 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://didpkugc6cvxv"]
 
-[ext_resource path="res://GestureArea.gd" type="Script" id=1]
-[ext_resource path="res://CubeScene.tscn" type="PackedScene" id=2]
+[ext_resource type="Script" path="res://GestureArea.gd" id="1"]
+[ext_resource type="PackedScene" uid="uid://csyb8ij530w1l" path="res://CubeScene.tscn" id="2"]
 
 [node name="VBoxContainer" type="VBoxContainer"]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 size_flags_horizontal = 0
 size_flags_vertical = 0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
-offset_right = 1024.0
-offset_bottom = 298.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="SubViewportContainer" type="SubViewportContainer" parent="HBoxContainer"]
-offset_right = 510.0
-offset_bottom = 298.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 stretch = true
-script = ExtResource( 1 )
+script = ExtResource("1")
 target = NodePath("SubViewport/Node3D/MeshInstance3D")
 one_finger_rot_y = false
 two_fingers_rot_z = false
 two_fingers_zoom = false
 
 [node name="SubViewport" type="SubViewport" parent="HBoxContainer/SubViewportContainer"]
-size = Vector2(510, 298)
-own_world = true
+own_world_3d = true
 transparent_bg = true
 handle_input_locally = false
-msaa = 2
-hdr = false
-usage = 3
-render_target_update_mode = 3
+size = Vector2i(574, 322)
+render_target_update_mode = 4
 
-[node name="Node3D" parent="HBoxContainer/SubViewportContainer/SubViewport" instance=ExtResource( 2 )]
+[node name="Node3D" parent="HBoxContainer/SubViewportContainer/SubViewport" instance=ExtResource("2")]
 
 [node name="Camera3D" parent="HBoxContainer/SubViewportContainer/SubViewport/Node3D" index="2"]
 current = true
 
 [node name="Label" type="Label" parent="HBoxContainer/SubViewportContainer"]
-offset_left = 7.0
-offset_top = 11.0
-offset_right = 157.0
-offset_bottom = 25.0
+layout_mode = 2
 text = "One-finger rot around X"
 
 [node name="ViewportContainer2" type="SubViewportContainer" parent="HBoxContainer"]
-offset_left = 514.0
-offset_right = 1024.0
-offset_bottom = 298.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 stretch = true
-script = ExtResource( 1 )
+script = ExtResource("1")
 target = NodePath("SubViewport/Node3D/MeshInstance3D")
 two_fingers_rot_z = false
 two_fingers_zoom = false
 
 [node name="SubViewport" type="SubViewport" parent="HBoxContainer/ViewportContainer2"]
-size = Vector2(510, 298)
-own_world = true
+own_world_3d = true
 transparent_bg = true
 handle_input_locally = false
-msaa = 2
-hdr = false
-usage = 3
-render_target_update_mode = 3
+size = Vector2i(574, 322)
+render_target_update_mode = 4
 
-[node name="Node3D" parent="HBoxContainer/ViewportContainer2/SubViewport" instance=ExtResource( 2 )]
+[node name="Node3D" parent="HBoxContainer/ViewportContainer2/SubViewport" instance=ExtResource("2")]
 
 [node name="Camera3D" parent="HBoxContainer/ViewportContainer2/SubViewport/Node3D" index="2"]
 current = true
 
 [node name="Label2" type="Label" parent="HBoxContainer/ViewportContainer2"]
-offset_left = 8.0
-offset_top = 11.0
-offset_right = 196.0
-offset_bottom = 25.0
+layout_mode = 2
 text = "One-finger rot around X and Y"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="."]
-offset_top = 302.0
-offset_right = 1024.0
-offset_bottom = 600.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="SubViewportContainer" type="SubViewportContainer" parent="HBoxContainer2"]
-offset_right = 510.0
-offset_bottom = 298.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 stretch = true
-script = ExtResource( 1 )
+script = ExtResource("1")
 target = NodePath("SubViewport/Node3D/MeshInstance3D")
 two_fingers_zoom = false
 
 [node name="SubViewport" type="SubViewport" parent="HBoxContainer2/SubViewportContainer"]
-size = Vector2(510, 298)
-own_world = true
+own_world_3d = true
 transparent_bg = true
 handle_input_locally = false
-msaa = 2
-hdr = false
-usage = 3
-render_target_update_mode = 3
+size = Vector2i(574, 322)
+render_target_update_mode = 4
 
-[node name="Node3D" parent="HBoxContainer2/SubViewportContainer/SubViewport" instance=ExtResource( 2 )]
+[node name="Node3D" parent="HBoxContainer2/SubViewportContainer/SubViewport" instance=ExtResource("2")]
 
 [node name="Camera3D" parent="HBoxContainer2/SubViewportContainer/SubViewport/Node3D" index="2"]
 current = true
 
 [node name="Label3" type="Label" parent="HBoxContainer2/SubViewportContainer"]
-offset_left = 8.0
-offset_top = 9.0
-offset_right = 236.0
-offset_bottom = 23.0
+layout_mode = 2
 text = "One-finger X/Y rot + two-finger Z rot"
 
 [node name="ViewportContainer2" type="SubViewportContainer" parent="HBoxContainer2"]
-offset_left = 514.0
-offset_right = 1024.0
-offset_bottom = 298.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 stretch = true
-script = ExtResource( 1 )
+script = ExtResource("1")
 target = NodePath("SubViewport/Node3D/MeshInstance3D")
 
 [node name="SubViewport" type="SubViewport" parent="HBoxContainer2/ViewportContainer2"]
-size = Vector2(510, 298)
-own_world = true
+own_world_3d = true
 transparent_bg = true
 handle_input_locally = false
-msaa = 2
-hdr = false
-usage = 3
-render_target_update_mode = 3
+size = Vector2i(574, 322)
+render_target_update_mode = 4
 
-[node name="Node3D" parent="HBoxContainer2/ViewportContainer2/SubViewport" instance=ExtResource( 2 )]
+[node name="Node3D" parent="HBoxContainer2/ViewportContainer2/SubViewport" instance=ExtResource("2")]
 
 [node name="Camera3D" parent="HBoxContainer2/ViewportContainer2/SubViewport/Node3D" index="2"]
 current = true
 
 [node name="Label2" type="Label" parent="HBoxContainer2/ViewportContainer2"]
-offset_left = 12.0
-offset_top = 9.0
-offset_right = 279.0
-offset_bottom = 23.0
+layout_mode = 2
 text = "One-finger X/Y, two-finger Z + pinch"
 
 [editable path="HBoxContainer/SubViewportContainer/SubViewport/Node3D"]

--- a/mobile/multitouch_cubes/default_env.tres
+++ b/mobile/multitouch_cubes/default_env.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Environment" format=2]
+[gd_resource type="Environment" format=3 uid="uid://cpe7fpfvhiapa"]
 
 [resource]
-ambient_light_color = Color( 0.307434, 0.362682, 0.539063, 1 )
+ambient_light_color = Color(0.307434, 0.362682, 0.539063, 1)

--- a/mobile/multitouch_cubes/project.godot
+++ b/mobile/multitouch_cubes/project.godot
@@ -6,15 +6,16 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
+config_version=5
 
 [application]
 
 config/name="Multitouch Cubes Demo "
 config/description="Demo of multitouch input and different gestures using the touch API. This demo is meant to be used with a touch-enabled device such as a phone or tablet."
-run/main_scene="res://Main.tscn"
-config/icon="res://icon.webp"
 config/tags=PackedStringArray("demo", "input", "mobile", "official")
+run/main_scene="res://Main.tscn"
+config/features=PackedStringArray("4.1")
+config/icon="res://icon.webp"
 
 [input_devices]
 
@@ -22,5 +23,6 @@ pointing/emulate_touch_from_mouse=true
 
 [rendering]
 
+textures/vram_compression/import_etc2_astc=true
 environment/defaults/default_clear_color=Color(0.113725, 0.133333, 0.196078, 1)
-environment/default_environment="res://default_env.tres"
+environment/defaults/default_environment="res://default_env.tres"


### PR DESCRIPTION
v4.1.2.stable.official [399c9dc39]

- **Camera3D**: new `Position` (0, 0, 3)
- **SubViewport**: `Own World 3D`, had to be activated manually after automatic conversion





**Test on Android**

https://github.com/godotengine/godot-demo-projects/assets/41921395/91652c69-584a-41a1-b05f-566b2ffd640e

