### PR TITLE
Add alpha antialiasing example to 3D Antialiasing demo

### DIFF
--- a/3d/antialiasing/README.md
+++ b/3d/antialiasing/README.md
@@ -24,6 +24,11 @@ This project showcases the various 3D antialiasing techniques supported by Godot
 	the 3D framebuffer will be 3840×2160.
   - SSAA can be used together with FXAA or TAA to counter the blurring added by
 	those algorithms, while further improving antialiasing quality.
+- **Alpha antialiasing:** Applied on certain materials in the demo, available in
+  two modes (Alpha Edge Blend and Alpha Edge Clip). This is most effective when
+  MSAA is enabled, as Godot enables alpha-to-coverage rendering on the material
+  in this case. When MSAA is disabled, a fixed dithering pattern is applied on
+  the edge of transparent areas on the material.
 
 Godot allows using multiple antialiasing techniques at the same time. This can
 be useful to obtain the best possible quality, or to find a better performance

--- a/3d/antialiasing/anti_aliasing.tscn
+++ b/3d/antialiasing/anti_aliasing.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=49 format=3 uid="uid://clyxqp0e6qemi"]
+[gd_scene load_steps=55 format=3 uid="uid://clyxqp0e6qemi"]
 
 [ext_resource type="Texture2D" uid="uid://ccgkupemr6e1q" path="res://textures/paint.png" id="3_2nulf"]
 [ext_resource type="PackedScene" uid="uid://daokc0jvx7nkw" path="res://thin_lines.tscn" id="3_5ehjl"]
@@ -234,13 +234,20 @@ size = Vector2(128, 128)
 
 [sub_resource type="BoxMesh" id="BoxMesh_gwe28"]
 
-[sub_resource type="FastNoiseLite" id="FastNoiseLite_fiqc5"]
+[sub_resource type="Gradient" id="Gradient_jyuoy"]
+offsets = PackedFloat32Array(0.1, 0.768293)
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_kv21n"]
+frequency = 0.02
+fractal_type = 3
 fractal_octaves = 9
-fractal_gain = 1.0
+fractal_gain = 0.9
+fractal_ping_pong_strength = -1.2
 
 [sub_resource type="NoiseTexture2D" id="NoiseTexture_bgiac"]
 seamless = true
-noise = SubResource("FastNoiseLite_fiqc5")
+color_ramp = SubResource("Gradient_jyuoy")
+noise = SubResource("FastNoiseLite_kv21n")
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_x42ya"]
 albedo_color = Color(1.2, 1, 0.7, 1)
@@ -248,60 +255,85 @@ albedo_texture = SubResource("NoiseTexture_bgiac")
 uv1_scale = Vector3(3, 2, 1)
 texture_filter = 5
 
-[sub_resource type="NoiseTexture2D" id="NoiseTexture_7yxqs"]
-width = 32
-height = 32
-seamless = true
-noise = SubResource("FastNoiseLite_fiqc5")
+[sub_resource type="Gradient" id="Gradient_ylwhn"]
+offsets = PackedFloat32Array(0.378049, 0.408537, 0.603659, 1)
+colors = PackedColorArray(0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_fmnt8"]
+gradient = SubResource("Gradient_ylwhn")
+width = 16
+height = 16
+fill = 2
+fill_from = Vector2(0.5, 0.5)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_6yfdy"]
-albedo_texture = SubResource("NoiseTexture_7yxqs")
+specular_mode = 2
+albedo_color = Color(0.301961, 1, 0.6, 1)
+albedo_texture = SubResource("GradientTexture2D_fmnt8")
 uv1_scale = Vector3(3, 2, 1)
 texture_filter = 4
 
-[sub_resource type="Gradient" id="Gradient_ekf3m"]
-offsets = PackedFloat32Array(0, 0.298851, 0.609195, 0.781609, 0.873563, 1)
-colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 1, 1, 0.133693, 0.238417, 0.655738, 1, 0.4, 0.47451, 0, 1, 0.364109, 0.476658, 1, 1, 1, 1, 0)
+[sub_resource type="PlaneMesh" id="PlaneMesh_nllvr"]
+size = Vector2(3.9, 3.9)
 
-[sub_resource type="NoiseTexture2D" id="NoiseTexture_uv2tn"]
-seamless = true
-color_ramp = SubResource("Gradient_ekf3m")
-noise = SubResource("FastNoiseLite_fiqc5")
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_bjmm1"]
+albedo_color = Color(1, 0, 0, 1)
+
+[sub_resource type="Gradient" id="Gradient_e2xbk"]
+offsets = PackedFloat32Array(0.3, 0.5, 0.699, 0.7)
+colors = PackedColorArray(1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_ufeca"]
+gradient = SubResource("Gradient_e2xbk")
+width = 128
+height = 128
+fill = 2
+fill_from = Vector2(0.5, 0.5)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_qcf1j"]
 transparency = 1
-cull_mode = 2
-albedo_color = Color(1.2, 1, 0.7, 1)
-albedo_texture = SubResource("NoiseTexture_uv2tn")
-uv1_scale = Vector3(3, 2, 1)
+albedo_texture = SubResource("GradientTexture2D_ufeca")
+uv1_scale = Vector3(12, 8, 1)
 texture_filter = 5
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_xbqpl"]
 transparency = 2
-alpha_scissor_threshold = 0.72
+alpha_scissor_threshold = 0.5
 alpha_antialiasing_mode = 0
-cull_mode = 2
-albedo_color = Color(1.2, 1, 0.7, 1)
-albedo_texture = SubResource("NoiseTexture_uv2tn")
-uv1_scale = Vector3(3, 2, 1)
+albedo_texture = SubResource("GradientTexture2D_ufeca")
+uv1_scale = Vector3(12, 8, 1)
+texture_filter = 5
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_txrd8"]
+transparency = 2
+alpha_scissor_threshold = 0.5
+alpha_antialiasing_mode = 1
+alpha_antialiasing_edge = 0.3
+albedo_texture = SubResource("GradientTexture2D_ufeca")
+uv1_scale = Vector3(12, 8, 1)
+texture_filter = 5
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_xhqpm"]
+transparency = 2
+alpha_scissor_threshold = 0.5
+alpha_antialiasing_mode = 2
+alpha_antialiasing_edge = 0.3
+albedo_texture = SubResource("GradientTexture2D_ufeca")
+uv1_scale = Vector3(12, 8, 1)
 texture_filter = 5
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_mjkwh"]
 transparency = 3
 alpha_hash_scale = 1.0
 alpha_antialiasing_mode = 0
-cull_mode = 2
-albedo_color = Color(1.2, 1, 0.7, 1)
-albedo_texture = SubResource("NoiseTexture_uv2tn")
-uv1_scale = Vector3(3, 2, 1)
+albedo_texture = SubResource("GradientTexture2D_ufeca")
+uv1_scale = Vector3(12, 8, 1)
 texture_filter = 5
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_f4l4p"]
 transparency = 4
-cull_mode = 2
-albedo_color = Color(1.2, 1, 0.7, 1)
-albedo_texture = SubResource("NoiseTexture_uv2tn")
-uv1_scale = Vector3(3, 2, 1)
+albedo_texture = SubResource("GradientTexture2D_ufeca")
+uv1_scale = Vector3(12, 8, 1)
 texture_filter = 5
 
 [sub_resource type="SphereMesh" id="SphereMesh_kfkna"]
@@ -507,13 +539,13 @@ environment = SubResource("11")
 script = ExtResource("18")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-autoplay = "move"
 libraries = {
 "": SubResource("AnimationLibrary_ecfcr")
 }
+autoplay = "move"
 
 [node name="Plane" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -34)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -38)
 layers = 2
 mesh = SubResource("14")
 
@@ -540,17 +572,23 @@ fov = 70.0
 [node name="StaticObject" type="Node3D" parent="Testers"]
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Testers/StaticObject"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 0.5, 0)
 mesh = SubResource("BoxMesh_gwe28")
 surface_material_override/0 = SubResource("StandardMaterial3D_x42ya")
 
 [node name="MeshInstance3D2" type="MeshInstance3D" parent="Testers/StaticObject"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 0.5, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 0.5, 0)
 mesh = SubResource("BoxMesh_gwe28")
 surface_material_override/0 = SubResource("StandardMaterial3D_6yfdy")
 
 [node name="ThinLines" parent="Testers" instance=ExtResource("3_5ehjl")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -4)
+
+[node name="Plane" type="MeshInstance3D" parent="Testers/ThinLines"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.002, 0)
+mesh = SubResource("PlaneMesh_nllvr")
+skeleton = NodePath("../../TransparencyAlphaBlend")
+surface_material_override/0 = SubResource("StandardMaterial3D_bjmm1")
 
 [node name="TransparencyAlphaBlend" type="Node3D" parent="Testers"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -8)
@@ -560,6 +598,11 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.501, 0)
 mesh = SubResource("BoxMesh_gwe28")
 surface_material_override/0 = SubResource("StandardMaterial3D_qcf1j")
 
+[node name="Plane" type="MeshInstance3D" parent="Testers/TransparencyAlphaBlend"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.002, 0)
+mesh = SubResource("PlaneMesh_nllvr")
+surface_material_override/0 = SubResource("StandardMaterial3D_bjmm1")
+
 [node name="TransparencyAlphaScissor" type="Node3D" parent="Testers"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -12)
 
@@ -568,27 +611,73 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.501, 0)
 mesh = SubResource("BoxMesh_gwe28")
 surface_material_override/0 = SubResource("StandardMaterial3D_xbqpl")
 
-[node name="TransparencyAlphaHash" type="Node3D" parent="Testers"]
+[node name="Plane2" type="MeshInstance3D" parent="Testers/TransparencyAlphaScissor"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.002, 0)
+mesh = SubResource("PlaneMesh_nllvr")
+skeleton = NodePath("../../TransparencyAlphaBlend")
+surface_material_override/0 = SubResource("StandardMaterial3D_bjmm1")
+
+[node name="TransparencyAlphaScissorAntialiasingBlend" type="Node3D" parent="Testers"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -16)
+
+[node name="MeshInstance3D3" type="MeshInstance3D" parent="Testers/TransparencyAlphaScissorAntialiasingBlend"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.501, 0)
+mesh = SubResource("BoxMesh_gwe28")
+surface_material_override/0 = SubResource("StandardMaterial3D_txrd8")
+
+[node name="Plane3" type="MeshInstance3D" parent="Testers/TransparencyAlphaScissorAntialiasingBlend"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.002, 0)
+mesh = SubResource("PlaneMesh_nllvr")
+skeleton = NodePath("../../TransparencyAlphaBlend")
+surface_material_override/0 = SubResource("StandardMaterial3D_bjmm1")
+
+[node name="TransparencyAlphaScissorAntialiasingClip" type="Node3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -20)
+
+[node name="MeshInstance3D3" type="MeshInstance3D" parent="Testers/TransparencyAlphaScissorAntialiasingClip"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.501, 0)
+mesh = SubResource("BoxMesh_gwe28")
+surface_material_override/0 = SubResource("StandardMaterial3D_xhqpm")
+
+[node name="Plane4" type="MeshInstance3D" parent="Testers/TransparencyAlphaScissorAntialiasingClip"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.002, 0)
+mesh = SubResource("PlaneMesh_nllvr")
+skeleton = NodePath("../../TransparencyAlphaBlend")
+surface_material_override/0 = SubResource("StandardMaterial3D_bjmm1")
+
+[node name="TransparencyAlphaHash" type="Node3D" parent="Testers"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -24)
 
 [node name="MeshInstance3D3" type="MeshInstance3D" parent="Testers/TransparencyAlphaHash"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.501, 0)
 mesh = SubResource("BoxMesh_gwe28")
 surface_material_override/0 = SubResource("StandardMaterial3D_mjkwh")
 
+[node name="Plane5" type="MeshInstance3D" parent="Testers/TransparencyAlphaHash"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.002, 0)
+mesh = SubResource("PlaneMesh_nllvr")
+skeleton = NodePath("../../TransparencyAlphaBlend")
+surface_material_override/0 = SubResource("StandardMaterial3D_bjmm1")
+
 [node name="TransparencyDepthPrepass" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -20)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -28)
 
 [node name="MeshInstance3D3" type="MeshInstance3D" parent="Testers/TransparencyDepthPrepass"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.501, 0)
 mesh = SubResource("BoxMesh_gwe28")
 surface_material_override/0 = SubResource("StandardMaterial3D_f4l4p")
 
+[node name="Plane6" type="MeshInstance3D" parent="Testers/TransparencyDepthPrepass"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.002, 0)
+mesh = SubResource("PlaneMesh_nllvr")
+skeleton = NodePath("../../TransparencyAlphaBlend")
+surface_material_override/0 = SubResource("StandardMaterial3D_bjmm1")
+
 [node name="ComplexObject" parent="Testers" instance=ExtResource("3_fa2bl")]
-transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0.35, -24)
+transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0.35, -32)
 
 [node name="PointRendering" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -28)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -36)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Testers/PointRendering"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
@@ -596,7 +685,7 @@ mesh = SubResource("SphereMesh_kfkna")
 surface_material_override/0 = SubResource("StandardMaterial3D_rfedc")
 
 [node name="MovingObject" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -32)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -40)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Testers/MovingObject"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
@@ -604,7 +693,7 @@ mesh = SubResource("BoxMesh_gwe28")
 surface_material_override/0 = SubResource("StandardMaterial3D_x42ya")
 
 [node name="RotatingObject" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -36)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -44)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Testers/RotatingObject"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
@@ -612,7 +701,7 @@ mesh = SubResource("BoxMesh_gwe28")
 surface_material_override/0 = SubResource("StandardMaterial3D_x42ya")
 
 [node name="ScalingObject" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -40)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -48)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Testers/ScalingObject"]
 transform = Transform3D(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.5, 0)
@@ -620,7 +709,7 @@ mesh = SubResource("BoxMesh_gwe28")
 surface_material_override/0 = SubResource("StandardMaterial3D_x42ya")
 
 [node name="StaticCPUParticles" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -44)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -52)
 
 [node name="CPUParticles3D" type="CPUParticles3D" parent="Testers/StaticCPUParticles"]
 amount = 100
@@ -650,7 +739,7 @@ scale_amount_max = 2.5
 scale_amount_curve = SubResource("Curve_sutnd")
 
 [node name="MovingCPUParticles" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -48)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -56)
 
 [node name="CPUParticles3D" type="CPUParticles3D" parent="Testers/MovingCPUParticles"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
@@ -681,7 +770,7 @@ initial_velocity_max = 2.5
 scale_amount_curve = SubResource("Curve_sutnd")
 
 [node name="StaticGPUParticles" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -52)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -60)
 
 [node name="GPUParticles3D" type="GPUParticles3D" parent="Testers/StaticGPUParticles"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2, 0)
@@ -698,7 +787,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0)
 size = Vector3(4, 2, 4)
 
 [node name="MovingGPUParticles" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -56)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -64)
 
 [node name="GPUParticles3D" type="GPUParticles3D" parent="Testers/MovingGPUParticles"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2, 0)
@@ -716,18 +805,18 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0)
 size = Vector3(4, 2, 4)
 
 [node name="MovingDecal" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -60)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -68)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Testers/MovingDecal"]
 mesh = SubResource("SphereMesh_v4x6x")
 
 [node name="Decal" type="Decal" parent="Testers/MovingDecal"]
-transform = Transform3D(-0.707104, -1.00986e-06, -0.707109, 0.183013, 0.965926, -0.183013, 0.683015, -0.258819, -0.68301, 1, 1, 1)
+transform = Transform3D(-0.707104, -1.01328e-06, -0.707109, 0.183013, 0.965926, -0.183013, 0.683015, -0.258819, -0.68301, 1, 1, 1)
 texture_albedo = ExtResource("3_2nulf")
 texture_normal = ExtResource("4_fdfpv")
 
 [node name="ScrollingUVAnimation" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -64)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -72)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Testers/ScrollingUVAnimation"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
@@ -735,7 +824,7 @@ mesh = SubResource("CylinderMesh_5qy8k")
 surface_material_override/0 = SubResource("StandardMaterial3D_53dqy")
 
 [node name="ScrollingUVCustomShader" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -68)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -76)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Testers/ScrollingUVCustomShader"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
@@ -743,7 +832,7 @@ mesh = SubResource("CylinderMesh_5qy8k")
 surface_material_override/0 = SubResource("ShaderMaterial_ltvd2")
 
 [node name="CustomShaderVertexMovement" type="Node3D" parent="Testers"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -72)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -80)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Testers/CustomShaderVertexMovement"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
@@ -911,7 +1000,6 @@ size_flags_vertical = 4
 size_flags_stretch_ratio = 3.0
 max_value = 300.0
 step = 10.0
-value = 1.0
 
 [node name="Value" type="Label" parent="Antialiasing/LimitFPSContainer"]
 layout_mode = 2

--- a/3d/antialiasing/project.godot
+++ b/3d/antialiasing/project.godot
@@ -14,7 +14,7 @@ config/name="3D Anti-Aliasing"
 config/description="This project showcases the various 3D antialiasing techniques supported by Godot."
 config/tags=PackedStringArray("3d", "demo", "official")
 run/main_scene="res://anti_aliasing.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.webp"
 
 [display]


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/8481 (can be merged independently).

___

- Add colored planes below some examples to make antialiasing differences easier to see.
- Change various textures to make antialiasing differences easier to see.

## Preview

![image](https://github.com/godotengine/godot-demo-projects/assets/180032/5818a356-4a6f-4834-b76d-314e540e4ea7)