### PR TITLE
Fix dodge the creeps vertical movement

### DIFF
--- a/2d/dodge_the_creeps/Player.gd
+++ b/2d/dodge_the_creeps/Player.gd
@@ -37,11 +37,12 @@ func _process(delta):
 		$AnimatedSprite2D.flip_h = velocity.x < 0
 	elif velocity.y != 0:
 		$AnimatedSprite2D.animation = &"up"
-		$AnimatedSprite2D.flip_v = velocity.y > 0
-		$Trail.rotation = PI if velocity.y > 0 else 0
+		rotation = PI if velocity.y > 0 else 0
+
 
 func start(pos):
 	position = pos
+	rotation = 0
 	show()
 	$CollisionShape2D.disabled = false
 

--- a/2d/dodge_the_creeps/project.godot
+++ b/2d/dodge_the_creeps/project.godot
@@ -19,7 +19,7 @@ tutorial in the documentation. For more details, consider
 following the tutorial in the documentation."
 config/tags=PackedStringArray("2d", "demo", "official")
 run/main_scene="res://Main.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.webp"
 
 [debug]


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
using rotation in the player node instead of flipping vertically, by doing so the trail is also rotated