### PR TITLE
Fixed typo in start vr script for selecting refresh rate

### DIFF
--- a/xr/openxr_character_centric_movement/start_vr.gd
+++ b/xr/openxr_character_centric_movement/start_vr.gd
@@ -54,7 +54,7 @@ func _on_openxr_session_begun() -> void:
 		new_rate = available_rates[0]
 	else:
 		for rate in available_rates:
-			if rate > new_rate and rate < maximum_refresh_rate:
+			if rate > new_rate and rate <= maximum_refresh_rate:
 				new_rate = rate
 
 	# Did we find a better rate?

--- a/xr/openxr_origin_centric_movement/start_vr.gd
+++ b/xr/openxr_origin_centric_movement/start_vr.gd
@@ -54,7 +54,7 @@ func _on_openxr_session_begun() -> void:
 		new_rate = available_rates[0]
 	else:
 		for rate in available_rates:
-			if rate > new_rate and rate < maximum_refresh_rate:
+			if rate > new_rate and rate <= maximum_refresh_rate:
 				new_rate = rate
 
 	# Did we find a better rate?


### PR DESCRIPTION
This was a small typo I found in the start VR script of our two XR examples. If you set the desired headset framerate to say 90fps. It would only select a lower one. Now it will select 90 if available.