### PR TITLE
Fix Web platform checks in WebRTC signaling demo

### DIFF
--- a/networking/webrtc_signaling/demo/main.gd
+++ b/networking/webrtc_signaling/demo/main.gd
@@ -9,7 +9,7 @@ func _enter_tree():
 		)
 
 func _ready():
-	if OS.get_name() == "HTML5":
+	if OS.get_name() == "Web":
 		$VBoxContainer/Signaling.hide()
 
 

--- a/networking/webrtc_signaling/server/ws_webrtc_server.gd
+++ b/networking/webrtc_signaling/server/ws_webrtc_server.gd
@@ -103,6 +103,9 @@ func _process(delta):
 
 
 func listen(port):
+	if OS.get_name() == "Web":
+		OS.alert("Cannot create WebSocket servers in Web exports due to browsers' limitations.")
+		return
 	stop()
 	rand.seed = Time.get_unix_time_from_system()
 	tcp_server.listen(port)


### PR DESCRIPTION
The check to hide the "Listen" button on Web platforms was not updated from the old 3.x name (HTML5).