### PR TITLE
Fix squash_the_creeps hitboxes

### DIFF
--- a/3d/squash_the_creeps/Mob.tscn
+++ b/3d/squash_the_creeps/Mob.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=6 format=3 uid="uid://ha0ar5s2c3m4"]
+[gd_scene load_steps=7 format=3 uid="uid://ha0ar5s2c3m4"]
 
 [ext_resource type="Script" path="res://Mob.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://bicorb7we351t" path="res://art/mob.glb" id="2"]
 
 [sub_resource type="BoxShape3D" id="1"]
 size = Vector3(1.35822, 1.08835, 2.20058)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_vll1l"]
+size = Vector3(0.418579, 0.569824, 0.833984)
 
 [sub_resource type="Animation" id="2"]
 length = 1.2
@@ -53,14 +56,30 @@ transform = Transform3D(1, 0, 0, 0, 0.996145, 0.0877225, 0, -0.0877225, 0.996145
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.52793, 0)
 shape = SubResource("1")
 
+[node name="CollisionShape2" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.861631, 0.783785, 0.180726)
+shape = SubResource("BoxShape3D_vll1l")
+
+[node name="CollisionShape3" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.889494, 0.783785, 0.180726)
+shape = SubResource("BoxShape3D_vll1l")
+
+[node name="CollisionShape4" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.889494, 0.783785, 1.43697)
+shape = SubResource("BoxShape3D_vll1l")
+
+[node name="CollisionShape5" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.887008, 0.783785, 1.43697)
+shape = SubResource("BoxShape3D_vll1l")
+
 [node name="VisibleOnScreenNotifier3D" type="VisibleOnScreenNotifier3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.062134, 0.331645)
 aabb = AABB(-1.19986, 0.251327, -1.57098, 2.41047, 1.09305, 3.17223)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-autoplay = "float"
 libraries = {
 "": SubResource("AnimationLibrary_5n6vs")
 }
+autoplay = "float"
 
 [connection signal="screen_exited" from="VisibleOnScreenNotifier3D" to="." method="_on_visible_on_screen_notifier_screen_exited"]

--- a/3d/squash_the_creeps/Player.gd
+++ b/3d/squash_the_creeps/Player.gd
@@ -27,7 +27,7 @@ func _physics_process(delta):
 		# In the lines below, we turn the character when moving and make the animation play faster.
 		direction = direction.normalized()
 		# Setting the basis property will affect the rotation of the node.
-		$Pivot.basis = Basis.looking_at(direction)
+		basis = Basis.looking_at(direction)
 		$AnimationPlayer.speed_scale = 4
 	else:
 		$AnimationPlayer.speed_scale = 1
@@ -62,7 +62,7 @@ func _physics_process(delta):
 				break
 
 	# This makes the character follow a nice arc when jumping
-	$Pivot.rotation.x = PI / 6 * velocity.y / jump_impulse
+	rotation.x = PI / 6 * velocity.y / jump_impulse
 
 
 func die():

--- a/3d/squash_the_creeps/Player.tscn
+++ b/3d/squash_the_creeps/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://dp478jyugrn7o"]
+[gd_scene load_steps=8 format=3 uid="uid://dp478jyugrn7o"]
 
 [ext_resource type="Script" path="res://Player.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://d0ypm0v45pwdv" path="res://art/player.glb" id="2"]
@@ -9,6 +9,10 @@ radius = 0.792278
 [sub_resource type="CylinderShape3D" id="2"]
 height = 0.1438
 radius = 0.907607
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_76fa1"]
+height = 0.144
+radius = 0.2
 
 [sub_resource type="Animation" id="3"]
 length = 1.2
@@ -49,7 +53,7 @@ script = ExtResource("1")
 [node name="Pivot" type="Node3D" parent="."]
 
 [node name="Character" parent="Pivot" instance=ExtResource("2")]
-transform = Transform3D(1, 0, 0, 0, 0.996145, 0.0877225, 0, -0.0877225, 0.996145, 0, 0.329753, 0)
+transform = Transform3D(1, 0, 0, 0, 0.984808, 0.173648, 0, -0.173648, 0.984808, 0, 0.349734, 0)
 
 [node name="CollisionShape" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.771765, 0)
@@ -64,10 +68,26 @@ monitorable = false
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.06491, 0)
 shape = SubResource("2")
 
+[node name="CollisionShape2" type="CollisionShape3D" parent="MobDetector"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.455268, 0.95, 1.1423)
+shape = SubResource("CylinderShape3D_76fa1")
+
+[node name="CollisionShape3" type="CollisionShape3D" parent="MobDetector"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.716365, 0.95, 1.71889)
+shape = SubResource("CylinderShape3D_76fa1")
+
+[node name="CollisionShape4" type="CollisionShape3D" parent="MobDetector"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.730546, 0.95, 1.69713)
+shape = SubResource("CylinderShape3D_76fa1")
+
+[node name="CollisionShape5" type="CollisionShape3D" parent="MobDetector"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.45857, 0.95, 1.15318)
+shape = SubResource("CylinderShape3D_76fa1")
+
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-autoplay = "float"
 libraries = {
 "": SubResource("AnimationLibrary_aq6tr")
 }
+autoplay = "float"
 
 [connection signal="body_entered" from="MobDetector" to="." method="_on_MobDetector_body_entered"]


### PR DESCRIPTION
I added CollisionShapes for the player and the enemy to fix the bug of the enemy passing through the player.
![image](https://github.com/godotengine/godot-demo-projects/assets/116561933/36bb9940-528a-4c00-b3b2-a261d46bb472)
![image](https://github.com/godotengine/godot-demo-projects/assets/116561933/7e1573d7-e598-48dd-86d1-d9fc9693b166)
