### PR TITLE
Fix player and mob animations not looping in Squash the Creeps

### DIFF
--- a/3d/squash_the_creeps/Main.tscn
+++ b/3d/squash_the_creeps/Main.tscn
@@ -129,7 +129,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 curve = SubResource("5")
 
 [node name="SpawnLocation" type="PathFollow3D" parent="SpawnPath"]
-transform = Transform3D(-4.37113e-08, 0, -0.999999, 0, 1, 0, 0.999999, 0, -4.37113e-08, 14, 0, -15)
+transform = Transform3D(-4.37113e-08, 0, 0.999999, 0, 1, 0, -0.999999, 0, -4.37113e-08, 14, 0, -15)
 rotation_mode = 1
 cubic_interp = false
 loop = false

--- a/3d/squash_the_creeps/Mob.tscn
+++ b/3d/squash_the_creeps/Mob.tscn
@@ -8,6 +8,7 @@ size = Vector3(1.35822, 1.08835, 2.20058)
 
 [sub_resource type="Animation" id="2"]
 length = 1.2
+loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -58,9 +59,9 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.062134, 0.331645)
 aabb = AABB(-1.19986, 0.251327, -1.57098, 2.41047, 1.09305, 3.17223)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-autoplay = "float"
 libraries = {
 "": SubResource("AnimationLibrary_5n6vs")
 }
+autoplay = "float"
 
 [connection signal="screen_exited" from="VisibleOnScreenNotifier3D" to="." method="_on_visible_on_screen_notifier_screen_exited"]

--- a/3d/squash_the_creeps/Player.tscn
+++ b/3d/squash_the_creeps/Player.tscn
@@ -12,6 +12,7 @@ radius = 0.907607
 
 [sub_resource type="Animation" id="3"]
 length = 1.2
+loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -65,9 +66,9 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.06491, 0)
 shape = SubResource("2")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-autoplay = "float"
 libraries = {
 "": SubResource("AnimationLibrary_aq6tr")
 }
+autoplay = "float"
 
 [connection signal="body_entered" from="MobDetector" to="." method="_on_MobDetector_body_entered"]


### PR DESCRIPTION
This was missed in the upgrade to 4.0, which reset loop mode properties in Animation.

## Preview

### Before

https://github.com/godotengine/godot-demo-projects/assets/180032/6b4fab77-3dc1-40f0-a8a1-0668d740cadd

### After *(this PR)*

*Mob animation fix isn't shown on the video, as it was recorded before I pushed an update to this PR.*

https://github.com/godotengine/godot-demo-projects/assets/180032/eabd68b6-a048-4310-8f6f-6ac7c1a07ced
