### PR TITLE
Correct font setup in Dodge The Creeps 2D.

### DIFF
--- a/2d/dodge_the_creeps/HUD.tscn
+++ b/2d/dodge_the_creeps/HUD.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://ccqoreueuxdb7"]
+[gd_scene load_steps=5 format=3 uid="uid://ccqoreueuxdb7"]
 
 [ext_resource type="Script" path="res://HUD.gd" id="1"]
+[ext_resource type="FontFile" uid="uid://cit6gwe5px1q8" path="res://fonts/Xolonium-Regular.ttf" id="2_2jm3i"]
 
 [sub_resource type="InputEventAction" id="InputEventAction_fopy7"]
 action = &"start_game"
@@ -16,6 +17,7 @@ anchors_preset = 10
 anchor_right = 1.0
 offset_bottom = 78.0
 grow_horizontal = 2
+theme_override_fonts/font = ExtResource("2_2jm3i")
 theme_override_font_sizes/font_size = 60
 text = "0"
 horizontal_alignment = 1
@@ -29,6 +31,7 @@ offset_top = -79.5
 offset_bottom = 79.5
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_fonts/font = ExtResource("2_2jm3i")
 theme_override_font_sizes/font_size = 60
 text = "Dodge the
 Creeps"
@@ -46,6 +49,7 @@ offset_right = 90.0
 offset_bottom = -100.0
 grow_horizontal = 2
 grow_vertical = 0
+theme_override_fonts/font = ExtResource("2_2jm3i")
 theme_override_font_sizes/font_size = 60
 shortcut = SubResource("4")
 text = "Start"

--- a/2d/dodge_the_creeps/fonts/Xolonium-Regular.tres
+++ b/2d/dodge_the_creeps/fonts/Xolonium-Regular.tres
@@ -1,6 +1,0 @@
-[gd_resource type="Font" load_steps=2 format=3 uid="uid://dyjc58f6sdms0"]
-
-[ext_resource type="FontData" uid="uid://cit6gwe5px1q8" path="res://fonts/Xolonium-Regular.ttf" id="1_mnk3h"]
-
-[resource]
-data/0 = ExtResource( "1_mnk3h" )


### PR DESCRIPTION
The fonts were not working in Dodge The Creeps 2D example and there was an error being generated.

This fixes the issue based on how the tutorial explains to set up fronts now
https://docs.godotengine.org/en/latest/getting_started/first_2d_game/06.heads_up_display.html#

I believe the `Xolonium-Regular.tres` file was causing this error:
```
Class 'Font' or its base class cannot be instantiated.
  editor/plugins/editor_preview_plugins.cpp:828 - Condition "sampled_font.is_null()" is true. Returning: Ref<Texture2D>()
```

Which appears in both Godot 4.2 and 4.3, although not as readily in 4.2.

The file does not seem to be necessary so I removed it.