### PR TITLE
Remove MSAA to fix #1028

### DIFF
--- a/2d/dynamic_tilemap_layers/project.godot
+++ b/2d/dynamic_tilemap_layers/project.godot
@@ -64,4 +64,3 @@ common/physics_ticks_per_second=120
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
 environment/defaults/default_clear_color=Color(0.156863, 0.133333, 0.25098, 1)
-anti_aliasing/quality/msaa_2d=2


### PR DESCRIPTION
Remove MSAA 2D 4x (Slow) Anti Aliasing, as that is not compatible with the switch to using Compatibility mode for the demo.

Fixes #1028 