### PR TITLE
3D Inverse Kinematics Godot 4 Conversion (Partial)

### DIFF
--- a/3d/ik/addons/sade/ik_fabrik.gd
+++ b/3d/ik/addons/sade/ik_fabrik.gd
@@ -113,7 +113,7 @@ func _ready():
 			target = Node3D.new()
 			add_child(target)
 
-			if Engine.editor_hint:
+			if Engine.is_editor_hint():
 				if get_tree() != null:
 					if get_tree().edited_scene_root != null:
 						target.set_owner(get_tree().edited_scene_root)
@@ -123,7 +123,7 @@ func _ready():
 			target = $Target
 
 		# If we are in the editor, we want to make a sphere at this node
-		if Engine.editor_hint:
+		if Engine.is_editor_hint():
 			_make_editor_sphere_at_node(target, Color.MAGENTA)
 
 	if middle_joint_target == null:
@@ -131,7 +131,7 @@ func _ready():
 			middle_joint_target = Node3D.new()
 			add_child(middle_joint_target)
 
-			if Engine.editor_hint:
+			if Engine.is_editor_hint():
 				if get_tree() != null:
 					if get_tree().edited_scene_root != null:
 						middle_joint_target.set_owner(get_tree().edited_scene_root)
@@ -141,7 +141,7 @@ func _ready():
 			middle_joint_target = get_node(^"MiddleJoint")
 
 		# If we are in the editor, we want to make a sphere at this node
-		if Engine.editor_hint:
+		if Engine.is_editor_hint():
 			_make_editor_sphere_at_node(middle_joint_target, Color(1, 0.24, 1, 1))
 
 	# Make all of the bone nodes for each bone in the IK chain
@@ -446,7 +446,7 @@ func _make_bone_nodes():
 			bone_nodes[bone] = new_node
 			add_child(bone_nodes[bone])
 
-			if Engine.editor_hint:
+			if Engine.is_editor_hint():
 				if get_tree() != null:
 					if get_tree().edited_scene_root != null:
 						bone_nodes[bone].set_owner(get_tree().edited_scene_root)
@@ -457,5 +457,5 @@ func _make_bone_nodes():
 			bone_nodes[bone] = get_node(bone_name)
 
 		# If we are in the editor, we want to make a sphere at this node
-		if Engine.editor_hint:
+		if Engine.is_editor_hint():
 			_make_editor_sphere_at_node(bone_nodes[bone], Color(0.65, 0, 1, 1))

--- a/3d/ik/button_change_scene.gd
+++ b/3d/ik/button_change_scene.gd
@@ -1,6 +1,6 @@
 extends Button
 
-@export_file var scene_to_change_to: String = null
+@export_file var scene_to_change_to: String = ""
 
 
 func _ready():
@@ -8,5 +8,5 @@ func _ready():
 
 
 func change_scene():
-	if scene_to_change_to != null:
-		get_tree().change_scene(scene_to_change_to)
+	if scene_to_change_to != "":
+		get_tree().change_scene_to_file(scene_to_change_to)

--- a/3d/ik/fabrik_ik.tscn
+++ b/3d/ik/fabrik_ik.tscn
@@ -1,20 +1,18 @@
-[gd_scene load_steps=14 format=3 uid="uid://lm753aby2tb6"]
+[gd_scene load_steps=12 format=3 uid="uid://lm753aby2tb6"]
 
 [ext_resource type="Texture2D" uid="uid://bw3q8aq6gfuof" path="res://addons/sade/editor_gizmo_texture.png" id="1"]
 [ext_resource type="PackedScene" uid="uid://ctssefekxjogg" path="res://model/godot_battle_bot.dae" id="2"]
 [ext_resource type="Material" path="res://model/battle_bot_color.tres" id="3"]
 [ext_resource type="Script" path="res://target_from_mousepos.gd" id="5"]
 [ext_resource type="Script" path="res://addons/sade/ik_look_at.gd" id="6"]
-[ext_resource type="Texture2D" uid="uid://dhgpf3w8mh4ed" path="res://addons/sade/ik_look_at.png" id="7"]
 [ext_resource type="Script" path="res://addons/sade/ik_fabrik.gd" id="8"]
-[ext_resource type="Texture2D" uid="uid://dfojvg0ykx146" path="res://addons/sade/ik_fabrik.png" id="9"]
 [ext_resource type="Script" path="res://button_change_scene.gd" id="10"]
 
 [sub_resource type="PlaneMesh" id="1"]
 size = Vector2(40, 40)
 
 [sub_resource type="StandardMaterial3D" id="2"]
-albedo_texture = ExtResource( "1" )
+albedo_texture = ExtResource("1")
 roughness = 0.2
 uv1_scale = Vector3(0.25, 0.25, 0.25)
 uv1_triplanar = true
@@ -28,21 +26,21 @@ roughness = 0.0
 [node name="FABRIK_IK" type="Node3D"]
 
 [node name="Floor" type="MeshInstance3D" parent="."]
-mesh = SubResource( "1" )
-surface_material_override/0 = SubResource( "2" )
+mesh = SubResource("1")
+surface_material_override/0 = SubResource("2")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.56827, 0.673454, -0.472789, 0, 0.574581, 0.818448, 0.822842, -0.465099, 0.326517, -9.77531, 11.5204, 11.766)
 
-[node name="GodotBattleBot" parent="." instance=ExtResource( "2" )]
+[node name="GodotBattleBot" parent="." instance=ExtResource("2")]
 
 [node name="godot_battle_bot" parent="GodotBattleBot/Armature/Skeleton3D" index="0"]
-surface_material_override/0 = ExtResource( "3" )
+surface_material_override/0 = ExtResource("3")
 
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 11.5, 11)
 fov = 74.0
-script = ExtResource( "5" )
+script = ExtResource("5")
 MOVEMENT_SPEED = -8.0
 flip_axis = true
 
@@ -50,19 +48,13 @@ flip_axis = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -8)
 
 [node name="IK_LookAt_Head" type="Node3D" parent="Camera3D/Targets"]
-script = ExtResource( "6" )
-__meta__ = {
-"_editor_icon": ExtResource( "7" )
-}
+script = ExtResource("6")
 skeleton_path = NodePath("../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Head"
 additional_rotation = Vector3(90, 0, 0)
 
 [node name="IK_FABRIK_Left_Arm" type="Node3D" parent="Camera3D/Targets"]
-script = ExtResource( "8" )
-__meta__ = {
-"_editor_icon": ExtResource( "9" )
-}
+script = ExtResource("8")
 skeleton_path = NodePath("../../../GodotBattleBot/Armature/Skeleton3D")
 bones_in_chain = PackedStringArray("Left_UpperArm", "Left_LowerArm")
 bones_in_chain_lengths = PackedFloat32Array(1.97, 3)
@@ -75,10 +67,7 @@ transform = Transform3D(0.518503, 0, -0.855076, 0, 1, 0, 0.855076, 0, 0.518503, 
 
 [node name="IK_LookAt_LH" type="Node3D" parent="Camera3D/Targets/IK_FABRIK_Left_Arm/Target"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.343393, -0.133381, 0.836605)
-script = ExtResource( "6" )
-__meta__ = {
-"_editor_icon": ExtResource( "7" )
-}
+script = ExtResource("6")
 skeleton_path = NodePath("../../../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Left_Hand"
 additional_rotation = Vector3(0, 0, 90)
@@ -96,10 +85,7 @@ transform = Transform3D(-0.120249, 0.882081, -0.455493, -0.0511926, 0.452703, 0.
 transform = Transform3D(-0.773624, -0.0228999, 0.633231, 2.98023e-08, 0.999347, 0.03614, -0.633645, 0.0279588, -0.773119, 2.94998, 0.10378, -2.37569)
 
 [node name="IK_FABRIK_Right_Arm" type="Node3D" parent="Camera3D/Targets"]
-script = ExtResource( "8" )
-__meta__ = {
-"_editor_icon": ExtResource( "9" )
-}
+script = ExtResource("8")
 skeleton_path = NodePath("../../../GodotBattleBot/Armature/Skeleton3D")
 bones_in_chain = PackedStringArray("Right_UpperArm", "Right_LowerArm", "Right_Hand")
 bones_in_chain_lengths = PackedFloat32Array(1.97, 3, 1.2)
@@ -112,10 +98,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.229958, 0, 0.929313)
 
 [node name="IK_LookAt_RH" type="Node3D" parent="Camera3D/Targets/IK_FABRIK_Right_Arm/Target"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0544824, -0.133381, 0.332403)
-script = ExtResource( "6" )
-__meta__ = {
-"_editor_icon": ExtResource( "7" )
-}
+script = ExtResource("6")
 skeleton_path = NodePath("../../../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Right_Hand"
 additional_rotation = Vector3(0, 0, 90)
@@ -133,67 +116,80 @@ transform = Transform3D(-0.792023, 0.0165711, -0.610266, -1.49012e-08, 0.999631,
 transform = Transform3D(-0.678336, 0.00698721, -0.734719, -2.32831e-09, 0.999955, 0.00950961, 0.734752, 0.00645071, -0.678305, -1.07914, 0.020072, 0.03791)
 
 [node name="1MeterCube" type="MeshInstance3D" parent="Camera3D/Targets"]
-mesh = SubResource( "3" )
-surface_material_override/0 = SubResource( "4" )
+mesh = SubResource("3")
+surface_material_override/0 = SubResource("4")
 
 [node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Panel" type="Panel" parent="Control"]
 modulate = Color(1, 1, 1, 0.784314)
+layout_mode = 1
+anchors_preset = 12
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -2.0
-offset_top = -70.0
+offset_top = -103.0
 offset_right = 4.0
+grow_horizontal = 2
+grow_vertical = 0
 
 [node name="Label" type="Label" parent="Control/Panel"]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 12.0
-offset_top = 10.0
+offset_left = 151.0
+offset_top = 16.0
 offset_right = -18.0
-offset_bottom = -29.0
+offset_bottom = -4.0
+grow_horizontal = 2
+grow_vertical = 2
 text = "F.A.B.R.I.K IK
 Move mouse to move IK targets
 (Using 3 bones in the right hand, only 2 in the left. 3+ recommended)"
 
 [node name="LabelExtra" type="Label" parent="Control/Panel"]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 12.0
-offset_top = 80.0
+offset_top = -106.0
 offset_right = -18.0
-offset_bottom = 58.0
+offset_bottom = 85.0
+grow_horizontal = 2
+grow_vertical = 2
 text = "NOTE: You will get a few errors when saving with FABRIK IK nodes in your scene
 This is a known bug. Please ignore the errors for now, as they do not do anything
 (They're just annoying. If you find a fix, please add it to the demo repository!)"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LabelLeft" type="Label" parent="Control/Panel"]
+layout_mode = 1
+anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = -248.0
-offset_top = 4.0
-offset_right = -135.0
-offset_bottom = 18.0
+offset_left = -476.0
+offset_top = 9.0
+offset_right = -363.0
+offset_bottom = 32.0
+grow_horizontal = 0
 text = "Left Hand"
 
 [node name="LabelRight" type="Label" parent="Control/Panel"]
-offset_left = 136.0
-offset_top = 5.0
-offset_right = 249.0
-offset_bottom = 19.0
+layout_mode = 0
+offset_left = 390.0
+offset_top = 8.0
+offset_right = 503.0
+offset_bottom = 31.0
 text = "Right Hand"
 
 [node name="ButtonNext" type="Button" parent="Control"]
+layout_mode = 0
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -203,10 +199,11 @@ offset_top = -60.0
 offset_right = -5.0
 offset_bottom = -10.0
 text = "Next scene"
-script = ExtResource( "10" )
+script = ExtResource("10")
 scene_to_change_to = "res://skeleton_ik.tscn"
 
 [node name="ButtonPrev" type="Button" parent="Control"]
+layout_mode = 0
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 10.0
@@ -214,10 +211,7 @@ offset_top = -60.0
 offset_right = 129.0
 offset_bottom = -10.0
 text = "Previous scene"
-script = ExtResource( "10" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("10")
 scene_to_change_to = "res://look_at_ik.tscn"
 
 [editable path="GodotBattleBot"]

--- a/3d/ik/fabrik_ik.tscn
+++ b/3d/ik/fabrik_ik.tscn
@@ -125,6 +125,14 @@ anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 
+[node name="LabelExtra" type="Label" parent="Control"]
+layout_mode = 1
+offset_right = 623.0
+offset_bottom = 98.0
+text = "NOTE: You will get a few errors when saving with FABRIK IK nodes in your scene
+This is a known bug. Please ignore the errors for now, as they do not do anything
+(They're just annoying. If you find a fix, please add it to the demo repository!)"
+
 [node name="Panel" type="Panel" parent="Control"]
 modulate = Color(1, 1, 1, 0.784314)
 layout_mode = 1
@@ -133,7 +141,7 @@ anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -2.0
-offset_top = -103.0
+offset_top = -79.0
 offset_right = 4.0
 grow_horizontal = 2
 grow_vertical = 0
@@ -143,50 +151,34 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 151.0
-offset_top = 16.0
-offset_right = -18.0
-offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 text = "F.A.B.R.I.K IK
 Move mouse to move IK targets
 (Using 3 bones in the right hand, only 2 in the left. 3+ recommended)"
-
-[node name="LabelExtra" type="Label" parent="Control/Panel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 12.0
-offset_top = -106.0
-offset_right = -18.0
-offset_bottom = 85.0
-grow_horizontal = 2
-grow_vertical = 2
-text = "NOTE: You will get a few errors when saving with FABRIK IK nodes in your scene
-This is a known bug. Please ignore the errors for now, as they do not do anything
-(They're just annoying. If you find a fix, please add it to the demo repository!)"
+horizontal_alignment = 1
 
 [node name="LabelLeft" type="Label" parent="Control/Panel"]
 layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = -476.0
-offset_top = 9.0
-offset_right = -363.0
-offset_bottom = 32.0
+offset_left = -268.0
+offset_top = 4.0
+offset_right = -155.0
+offset_bottom = 27.0
 grow_horizontal = 0
 text = "Left Hand"
+horizontal_alignment = 1
 
 [node name="LabelRight" type="Label" parent="Control/Panel"]
 layout_mode = 0
-offset_left = 390.0
-offset_top = 8.0
-offset_right = 503.0
-offset_bottom = 31.0
+offset_left = 184.0
+offset_top = 2.0
+offset_right = 297.0
+offset_bottom = 25.0
 text = "Right Hand"
+horizontal_alignment = 1
 
 [node name="ButtonNext" type="Button" parent="Control"]
 layout_mode = 0

--- a/3d/ik/fps/example_player.gd
+++ b/3d/ik/fps/example_player.gd
@@ -4,12 +4,12 @@ extends CharacterBody3D
 const norm_grav = -38.8
 const MAX_SPEED = 22
 const JUMP_SPEED = 26
-const ACCEL= 8.5
+const ACCEL = 8.5
 # Sprinting variables. Similar to the varibles above, just allowing for quicker movement
 const MAX_SPRINT_SPEED = 34
 const SPRINT_ACCEL = 18
 # How fast we slow down, and the steepest angle we can climb.
-const DEACCEL= 28
+const DEACCEL = 28
 const MAX_SLOPE_ANGLE = 40
 # How fast the bullets launch
 const LEFT_MOUSE_FIRE_TIME = 0.15
@@ -20,7 +20,6 @@ var vel = Vector3()
 var dir = Vector3()
 # A boolean to track whether or not we are sprinting
 var is_sprinting = false
-
 
 # You may need to adjust depending on the sensitivity of your mouse
 var MOUSE_SENSITIVITY = 0.08
@@ -43,7 +42,6 @@ var current_anim = "Starter"
 
 # The simple bullet rigidbody
 var simple_bullet = preload("res://fps/simple_bullet.tscn")
-
 
 # We need the camera for getting directional vectors. We rotate ourselves on the Y-axis using
 # the camera_holder to avoid rotating on more than one axis at a time.
@@ -70,7 +68,6 @@ func _physics_process(delta):
 
 
 func process_input(delta):
-
 	# Reset dir, so our previous movement does not effect us
 	dir = Vector3()
 	# Get the camera's global transform so we can use its directional vectors
@@ -122,7 +119,6 @@ func process_input(delta):
 		left_mouse_timer -= delta
 	# ----------------------------------
 
-
 	# ----------------------------------
 	# Sprinting
 	if Input.is_key_pressed(KEY_SHIFT):
@@ -142,7 +138,6 @@ func process_input(delta):
 		jump_button_down = false
 	# ----------------------------------
 
-
 	# ----------------------------------
 	# Leaninng
 	if Input.is_key_pressed(KEY_Q):
@@ -160,7 +155,7 @@ func process_input(delta):
 				lean_value = 0.5
 
 	lean_value = clamp(lean_value, 0, 1)
-	path_follow_node.unit_offset = lean_value
+	path_follow_node.h_offset = lean_value
 	if lean_value < 0.5:
 		var lerp_value = lean_value * 2
 		path_follow_node.rotation_degrees.z = (20 * (1 - lerp_value))
@@ -171,13 +166,12 @@ func process_input(delta):
 
 
 func process_movement(delta):
-
 	var grav = norm_grav
 
 	dir.y = 0
 	dir = dir.normalized()
 
-	vel.y += delta*grav
+	vel.y += delta * grav
 
 	var hvel = vel
 	hvel.y = 0
@@ -188,7 +182,6 @@ func process_movement(delta):
 	else:
 		target *= MAX_SPEED
 
-
 	var accel
 	if dir.dot(hvel) > 0:
 		if not is_sprinting:
@@ -198,7 +191,7 @@ func process_movement(delta):
 	else:
 		accel = DEACCEL
 
-	hvel = hvel.lerp(target, accel*delta)
+	hvel = hvel.lerp(target, accel * delta)
 
 	vel.x = hvel.x
 	vel.z = hvel.z
@@ -210,11 +203,9 @@ func process_movement(delta):
 
 # Mouse based camera movement
 func _input(event):
-
 	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
-
-		rotate_y(deg2rad(event.relative.x * MOUSE_SENSITIVITY * -1))
-		camera_holder.rotate_x(deg2rad(event.relative.y * MOUSE_SENSITIVITY))
+		rotate_y(deg_to_rad(event.relative.x * MOUSE_SENSITIVITY * -1))
+		camera_holder.rotate_x(deg_to_rad(event.relative.y * MOUSE_SENSITIVITY))
 
 		# We need to clamp the camera's rotation so we cannot rotate ourselves upside down
 		var camera_rot = camera_holder.rotation_degrees

--- a/3d/ik/fps/fps_example.tscn
+++ b/3d/ik/fps/fps_example.tscn
@@ -1,64 +1,61 @@
-[gd_scene load_steps=26 format=2]
+[gd_scene load_steps=23 format=3 uid="uid://b04yqi3oajoyp"]
 
-[ext_resource path="res://addons/sade/editor_gizmo_texture.png" type="Texture2D" id=1]
-[ext_resource path="res://button_change_scene.gd" type="Script" id=2]
-[ext_resource path="res://fps/example_player.gd" type="Script" id=3]
-[ext_resource path="res://addons/sade/ik_look_at.gd" type="Script" id=4]
-[ext_resource path="res://addons/sade/ik_look_at.png" type="Texture2D" id=5]
-[ext_resource path="res://addons/sade/ik_fabrik.gd" type="Script" id=6]
-[ext_resource path="res://addons/sade/ik_fabrik.png" type="Texture2D" id=7]
-[ext_resource path="res://fps/weapon_pistol.dae" type="PackedScene" id=8]
-[ext_resource path="res://fps/gun_color.tres" type="Material" id=9]
-[ext_resource path="res://fps/gun_emission.tres" type="Material" id=10]
-[ext_resource path="res://model/godot_battle_bot.dae" type="PackedScene" id=11]
-[ext_resource path="res://model/battle_bot_color.tres" type="Material" id=12]
-[ext_resource path="res://model/battle_bot_emission.tres" type="Material" id=13]
+[ext_resource type="Texture2D" uid="uid://bw3q8aq6gfuof" path="res://addons/sade/editor_gizmo_texture.png" id="1"]
+[ext_resource type="Script" path="res://button_change_scene.gd" id="2"]
+[ext_resource type="Script" path="res://fps/example_player.gd" id="3"]
+[ext_resource type="Script" path="res://addons/sade/ik_look_at.gd" id="4"]
+[ext_resource type="Script" path="res://addons/sade/ik_fabrik.gd" id="6"]
+[ext_resource type="PackedScene" uid="uid://xwg4osrspnrn" path="res://fps/weapon_pistol.dae" id="8"]
+[ext_resource type="Material" path="res://fps/gun_color.tres" id="9"]
+[ext_resource type="PackedScene" uid="uid://ctssefekxjogg" path="res://model/godot_battle_bot.dae" id="11"]
+[ext_resource type="Material" path="res://model/battle_bot_color.tres" id="12"]
 
-[sub_resource type="PlaneMesh" id=1]
+[sub_resource type="PlaneMesh" id="1"]
 size = Vector2(40, 40)
 
-[sub_resource type="StandardMaterial3D" id=2]
-albedo_texture = ExtResource( 1 )
+[sub_resource type="StandardMaterial3D" id="2"]
+albedo_texture = ExtResource("1")
 roughness = 0.2
 uv1_scale = Vector3(0.25, 0.25, 0.25)
 uv1_triplanar = true
 
-[sub_resource type="BoxShape3D" id=3]
-extents = Vector3(20, 1, 20)
+[sub_resource type="BoxShape3D" id="3"]
+size = Vector3(40, 2, 40)
 
-[sub_resource type="BoxMesh" id=4]
+[sub_resource type="BoxMesh" id="4"]
 size = Vector3(4, 4, 4)
 
-[sub_resource type="StandardMaterial3D" id=5]
+[sub_resource type="StandardMaterial3D" id="5"]
 albedo_color = Color(0.148438, 1, 0, 1)
-albedo_texture = ExtResource( 1 )
+albedo_texture = ExtResource("1")
 uv1_triplanar = true
 
-[sub_resource type="BoxShape3D" id=6]
-extents = Vector3(2, 2, 2)
+[sub_resource type="BoxShape3D" id="6"]
+size = Vector3(4, 4, 4)
 
-[sub_resource type="StandardMaterial3D" id=7]
+[sub_resource type="StandardMaterial3D" id="7"]
 albedo_color = Color(0, 0.882813, 1, 1)
-albedo_texture = ExtResource( 1 )
+albedo_texture = ExtResource("1")
 uv1_triplanar = true
 
-[sub_resource type="CapsuleShape3D" id=8]
-radius = 4.0
+[sub_resource type="CapsuleShape3D" id="8"]
+radius = 3.0
 height = 6.0
 
-[sub_resource type="Curve3D" id=9]
+[sub_resource type="Curve3D" id="9"]
 _data = {
 "points": PackedVector3Array(0, 0, 0, 0, 0, 0, -2.43129, -0.955339, 0, 0, 0, 0, 0, 0, 0, -0.670561, 0.183959, 0, 0, 0, 0, 0, 0, 0, 0.64629, 0.228347, 0, 0, 0, 0, 0, 0, 0, 2.31825, -0.925747, 0),
 "tilts": PackedFloat32Array(0, 0, 0, 0)
 }
+point_count = 4
 
-[sub_resource type="Animation" id=10]
+[sub_resource type="Animation" id="10"]
 tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0, 1),
 "transitions": PackedFloat32Array(1, 1),
@@ -66,11 +63,11 @@ tracks/0/keys = {
 "values": [Vector3(0.570504, -2.2654, 2.93826), Vector3(0, -1.36445, 3.78817)]
 }
 tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos:rotation_degrees")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
 "times": PackedFloat32Array(0, 1),
 "transitions": PackedFloat32Array(1, 1),
@@ -78,11 +75,11 @@ tracks/1/keys = {
 "values": [Vector3(0, -2, 0), Vector3(0, 0, 0)]
 }
 tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("LeanPath/PathFollow3D/IK_LookAt_Chest/Camera3D:fov")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
 "times": PackedFloat32Array(0, 1),
 "transitions": PackedFloat32Array(1, 1),
@@ -90,13 +87,13 @@ tracks/2/keys = {
 "values": [80.0, 60.0]
 }
 
-[sub_resource type="Animation" id=11]
+[sub_resource type="Animation" id="11"]
 tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("LeanPath/PathFollow3D/IK_LookAt_Chest/Camera3D:fov")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0, 1),
 "transitions": PackedFloat32Array(1, 1),
@@ -104,11 +101,11 @@ tracks/0/keys = {
 "values": [60.0, 80.0]
 }
 tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos:position")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
 "times": PackedFloat32Array(0, 1),
 "transitions": PackedFloat32Array(1, 1),
@@ -116,11 +113,11 @@ tracks/1/keys = {
 "values": [Vector3(0, -1.36445, 3.78817), Vector3(0.570504, -2.2654, 2.93826)]
 }
 tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos:rotation_degrees")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
 "times": PackedFloat32Array(0, 1),
 "transitions": PackedFloat32Array(1, 1),
@@ -128,13 +125,13 @@ tracks/2/keys = {
 "values": [Vector3(0, 0, 0), Vector3(0, -2, 0)]
 }
 
-[sub_resource type="Animation" id=12]
+[sub_resource type="Animation" id="12"]
 tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
@@ -142,11 +139,11 @@ tracks/0/keys = {
 "values": [Vector3(0.570504, -2.2654, 2.93826)]
 }
 tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos:rotation_degrees")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
@@ -154,16 +151,23 @@ tracks/1/keys = {
 "values": [Vector3(0, -2, 0)]
 }
 tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("LeanPath/PathFollow3D/IK_LookAt_Chest/Camera3D:fov")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
 "values": [80.0]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_grvc3"]
+_data = {
+"Aiming": SubResource("10"),
+"Idle": SubResource("11"),
+"Start": SubResource("12")
 }
 
 [node name="FPSExample" type="Node3D"]
@@ -172,206 +176,206 @@ tracks/2/keys = {
 
 [node name="Floor" type="MeshInstance3D" parent="Level"]
 transform = Transform3D(2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0)
-mesh = SubResource( 1 )
-surface_material_override/0 = SubResource( 2 )
+mesh = SubResource("1")
+surface_material_override/0 = SubResource("2")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Floor"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Floor/StaticBody3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.956119, 0)
-shape = SubResource( 3 )
+shape = SubResource("3")
 
 [node name="Walls" type="Node3D" parent="Level"]
 
 [node name="LargeWall" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(1, 0, 0, 0, 10, 0, 0, 0, 10, -39.9997, 20.0003, 20.0002)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 5 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("5")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/LargeWall"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/LargeWall/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="LargeWall2" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(1, 0, 0, 0, 10, 0, 0, 0, 10, -39.9997, 20.0003, -19.9998)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 5 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("5")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/LargeWall2"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/LargeWall2/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="LargeWall3" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(-4.37114e-08, 0, -10, 0, 10, 0, 1, 0, -4.37114e-07, -18.9997, 20.0003, -40.9998)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 5 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("5")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/LargeWall3"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/LargeWall3/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="LargeWall4" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(-4.37114e-08, 0, -10, 0, 10, 0, 1, 0, -4.37114e-07, 21.0003, 20.0003, -40.9998)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 5 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("5")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/LargeWall4"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/LargeWall4/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="LargeWall5" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(-1, 0, 8.74228e-07, 0, 10, 0, -8.74228e-08, 0, -10, 41.0003, 20.0003, -19.9998)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 5 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("5")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/LargeWall5"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/LargeWall5/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="LargeWall6" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(-1, 0, 8.74228e-07, 0, 10, 0, -8.74228e-08, 0, -10, 41.0003, 20.0003, 20.0002)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 5 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("5")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/LargeWall6"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/LargeWall6/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="LargeWall7" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(1.31134e-07, 0, 10, 0, 10, 0, -1, 0, 1.31134e-06, 21.0003, 20.0003, 40.0002)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 5 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("5")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/LargeWall7"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/LargeWall7/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="LargeWall8" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(1.31134e-07, 0, 10, 0, 10, 0, -1, 0, 1.31134e-06, -18.9997, 20.0003, 40.0002)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 5 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("5")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/LargeWall8"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/LargeWall8/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(7.54979e-08, 0, 4, 0, 4, 0, -1, 0, 3.01992e-07, -9.9997, 8.00032, 22.0005)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall2" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(1, 0, -4.76837e-07, 0, 4, 0, 1.19209e-07, 0, 4, -19.9997, 8.00032, 16.0005)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall2"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall2/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall3" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(1, 0, -3.57627e-07, 0, 4, 0, 1.19209e-07, 0, 3, -19.9997, 8.00032, 2.00049)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall3"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall3/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall4" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(1, 0, -4.76837e-07, 0, 4, 0, 1.19209e-07, 0, 4, -19.9997, 8.00032, -21.9995)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall4"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall4/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall5" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(-1.62921e-07, 0, -4, 0, 4, 0, 1, 0, -6.51683e-07, -9.9997, 8.00032, -27.9995)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall5"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall5/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall6" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(-1, 0, 8.26528e-07, 0, 4, 0, -2.06632e-07, 0, -4, 0.000319004, 8.00032, -21.9995)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall6"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall6/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall7" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(-1.62921e-07, 0, -4, 0, 4, 0, 1, 0, -6.51683e-07, 10.0003, 8.00032, -15.9995)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall7"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall7/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall9" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(1, 0, -4.76837e-07, 0, 4, 0, 1.19209e-07, 0, 4, 25.0003, 8.00032, -25.9995)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall9"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall9/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall10" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(0.573577, 0, 3.27661, 0, 4, 0, -0.819152, 0, 2.29431, 23.0003, 8.00032, 3.00049)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall10"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall10/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall11" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(-0.819152, 0, 2.29431, 0, 4, 0, -0.573577, 0, -3.27661, 22.2126, 8.00032, 14.7123)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall11"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall11/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="Wall12" type="MeshInstance3D" parent="Level/Walls"]
 transform = Transform3D(-0.627507, 2.10616, 2.29431, 0.642788, 3.06418, 0, -0.439385, 1.47475, -3.27661, 14.8402, 8.00032, 9.55015)
-mesh = SubResource( 4 )
-surface_material_override/0 = SubResource( 7 )
+mesh = SubResource("4")
+surface_material_override/0 = SubResource("7")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Level/Walls/Wall12"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Level/Walls/Wall12/StaticBody3D"]
-shape = SubResource( 6 )
+shape = SubResource("6")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.388878, -0.754027, 0.529355, 0, 0.574581, 0.818448, -0.921289, -0.318277, 0.223442, -9.77531, 11.5204, 11.766)
@@ -380,32 +384,41 @@ shadow_enabled = true
 directional_shadow_mode = 0
 
 [node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 
 [node name="Panel" type="Panel" parent="Control"]
 modulate = Color(1, 1, 1, 0.784314)
+layout_mode = 1
+anchors_preset = 12
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -2.0
-offset_top = -70.0
+offset_top = -94.0
 offset_right = 4.0
+grow_horizontal = 2
+grow_vertical = 0
 
 [node name="Label" type="Label" parent="Control/Panel"]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 12.0
+offset_left = 174.0
 offset_top = 10.0
 offset_right = -18.0
-offset_bottom = -29.0
+offset_bottom = 15.0
+grow_horizontal = 2
+grow_vertical = 2
 text = "F.A.B.R.I.K IK Example use case: Dynamic FPS Animations
 Controls: WASD/Arrows to move, left click to fire, right click to look down sights, Q/E to lean left/right
 Escape to free/lock mouse cursor"
-align = 1
-valign = 1
 
 [node name="ButtonPrev" type="Button" parent="Control"]
+layout_mode = 0
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 10.0
@@ -413,14 +426,12 @@ offset_top = -60.0
 offset_right = 129.0
 offset_bottom = -10.0
 text = "Previous scene"
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("2")
 scene_to_change_to = "res://skeleton_ik.tscn"
 
 [node name="Crosshair" type="Control" parent="Control"]
 modulate = Color(1, 1, 1, 0.784314)
+anchors_preset = 0
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -429,19 +440,15 @@ offset_left = -20.0
 offset_top = -20.0
 offset_right = 20.0
 offset_bottom = 20.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ColorRect" type="ColorRect" parent="Control/Crosshair"]
+layout_mode = 0
 offset_left = 19.0
 offset_right = 21.0
 offset_bottom = 40.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ColorRect2" type="ColorRect" parent="Control/Crosshair"]
+layout_mode = 0
 offset_left = 40.0
 offset_top = 18.0
 offset_right = 42.0
@@ -449,30 +456,26 @@ offset_bottom = 58.0
 rotation = 90.0
 
 [node name="CharacterBody3D" type="CharacterBody3D" parent="."]
-script = ExtResource( 3 )
+script = ExtResource("3")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="CharacterBody3D"]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 7, 0)
-shape = SubResource( 8 )
+shape = SubResource("8")
 
 [node name="CameraHolder" type="Node3D" parent="CharacterBody3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 13, 0)
 
 [node name="LeanPath" type="Path3D" parent="CharacterBody3D/CameraHolder"]
-curve = SubResource( 9 )
+curve = SubResource("9")
 
 [node name="PathFollow3D" type="PathFollow3D" parent="CharacterBody3D/CameraHolder/LeanPath"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0412404, 0.205172, 0)
-offset = 2.71865
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.43129, -0.955339, 0)
 rotation_mode = 0
 loop = false
 
 [node name="IK_LookAt_Chest" type="Node3D" parent="CharacterBody3D/CameraHolder/LeanPath/PathFollow3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.451559, 0)
-script = ExtResource( 4 )
-__meta__ = {
-"_editor_icon": ExtResource( 5 )
-}
+script = ExtResource("4")
 skeleton_path = NodePath("../../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Chest"
 look_at_axis = 2
@@ -486,10 +489,7 @@ fov = 74.0
 transform = Transform3D(0.999391, 0, -0.0348995, 0, 1, 0, 0.0348995, 0, 0.999391, 0.570504, -2.2654, 2.93826)
 
 [node name="IK_FABRIK" type="Node3D" parent="CharacterBody3D/CameraHolder/LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos"]
-script = ExtResource( 6 )
-__meta__ = {
-"_editor_icon": ExtResource( 7 )
-}
+script = ExtResource("6")
 skeleton_path = NodePath("../../../../../../GodotBattleBot/Armature/Skeleton3D")
 bones_in_chain = PackedStringArray("Left_UpperArm", "Left_LowerArm", "Left_Hand")
 bones_in_chain_lengths = PackedFloat32Array(1.97, 3, 0.1)
@@ -501,10 +501,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.54883, -0.0335302, -0.93414
 
 [node name="IK_LookAt" type="Node3D" parent="CharacterBody3D/CameraHolder/LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos/IK_FABRIK/Target"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.300601, 0, 0.714191)
-script = ExtResource( 4 )
-__meta__ = {
-"_editor_icon": ExtResource( 5 )
-}
+script = ExtResource("4")
 skeleton_path = NodePath("../../../../../../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Left_Hand"
 use_negative_our_rot = true
@@ -523,10 +520,7 @@ transform = Transform3D(-0.980952, 0.0992109, 0.167001, 0.116307, 0.988573, 0.09
 transform = Transform3D(-0.962426, 0.0909643, 0.255854, 0.128209, 0.982809, 0.132853, -0.23937, 0.160664, -0.957543, 0.737802, -2.14957, -1.27378)
 
 [node name="IK_FABRIK_RightArm" type="Node3D" parent="CharacterBody3D/CameraHolder/LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos"]
-script = ExtResource( 6 )
-__meta__ = {
-"_editor_icon": ExtResource( 7 )
-}
+script = ExtResource("6")
 skeleton_path = NodePath("../../../../../../GodotBattleBot/Armature/Skeleton3D")
 bones_in_chain = PackedStringArray("Right_UpperArm", "Right_LowerArm", "Right_Hand")
 bones_in_chain_lengths = PackedFloat32Array(1.97, 3, 0.1)
@@ -539,10 +533,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.285662, -0.0335302, -1.052
 
 [node name="IK_LookAt" type="Node3D" parent="CharacterBody3D/CameraHolder/LeanPath/PathFollow3D/IK_LookAt_Chest/AimPos/IK_FABRIK_RightArm/Target"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00396007, 0, 0.834561)
-script = ExtResource( 4 )
-__meta__ = {
-"_editor_icon": ExtResource( 5 )
-}
+script = ExtResource("4")
 skeleton_path = NodePath("../../../../../../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Right_Hand"
 use_negative_our_rot = true
@@ -564,38 +555,32 @@ remote_path = NodePath("../../../../../Weapon/Pistol")
 
 [node name="IK_LookAt_Head" type="Node3D" parent="CharacterBody3D/CameraHolder/LeanPath/PathFollow3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -3.14041, -2.57003)
-script = ExtResource( 4 )
-__meta__ = {
-"_editor_icon": ExtResource( 5 )
-}
+script = ExtResource("4")
 skeleton_path = NodePath("../../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Head"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="CharacterBody3D/CameraHolder"]
+libraries = {
+"": SubResource("AnimationLibrary_grvc3")
+}
 autoplay = "Start"
-playback_speed = 4.0
-anims/Aiming = SubResource( 10 )
-anims/Idle = SubResource( 11 )
-anims/Start = SubResource( 12 )
 
 [node name="Weapon" type="Node3D" parent="CharacterBody3D/CameraHolder"]
 
-[node name="Pistol" parent="CharacterBody3D/CameraHolder/Weapon" instance=ExtResource( 8 )]
-transform = Transform3D(0.999391, 0, -0.0348995, 0, 1, 0, 0.0348995, 0, 0.999391, 0.519895, -1.10362, 3.20654)
+[node name="Pistol" parent="CharacterBody3D/CameraHolder/Weapon" instance=ExtResource("8")]
+transform = Transform3D(0.999391, 0, -0.0348995, 0, 1, 0, 0.0348995, 0, 0.999391, -1.87015, -2.26413, 3.20654)
 
 [node name="Pistol_textured" parent="CharacterBody3D/CameraHolder/Weapon/Pistol" index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
-surface_material_override/0 = ExtResource( 9 )
-material/1 = ExtResource( 10 )
+surface_material_override/0 = ExtResource("9")
 
 [node name="PistolEnd" type="Node3D" parent="CharacterBody3D/CameraHolder/Weapon/Pistol"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0161836, 0.315914, 1.41329)
 
-[node name="GodotBattleBot" parent="CharacterBody3D" instance=ExtResource( 11 )]
+[node name="GodotBattleBot" parent="CharacterBody3D" instance=ExtResource("11")]
 
 [node name="godot_battle_bot" parent="CharacterBody3D/GodotBattleBot/Armature/Skeleton3D" index="0"]
-surface_material_override/0 = ExtResource( 12 )
-material/1 = ExtResource( 13 )
+surface_material_override/0 = ExtResource("12")
 
 [editable path="CharacterBody3D/CameraHolder/Weapon/Pistol"]
 [editable path="CharacterBody3D/GodotBattleBot"]

--- a/3d/ik/fps/fps_example.tscn
+++ b/3d/ik/fps/fps_example.tscn
@@ -407,15 +407,12 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 174.0
-offset_top = 10.0
-offset_right = -18.0
-offset_bottom = 15.0
 grow_horizontal = 2
 grow_vertical = 2
 text = "F.A.B.R.I.K IK Example use case: Dynamic FPS Animations
 Controls: WASD/Arrows to move, left click to fire, right click to look down sights, Q/E to lean left/right
 Escape to free/lock mouse cursor"
+horizontal_alignment = 1
 
 [node name="ButtonPrev" type="Button" parent="Control"]
 layout_mode = 0

--- a/3d/ik/fps/simple_bullet.gd
+++ b/3d/ik/fps/simple_bullet.gd
@@ -1,4 +1,4 @@
-extends RigidDynamicBody3D
+extends RigidBody3D
 
 const DESPAWN_TIME = 5
 

--- a/3d/ik/fps/simple_bullet.tscn
+++ b/3d/ik/fps/simple_bullet.tscn
@@ -16,7 +16,7 @@ emission_energy = 1.8
 [sub_resource type="SphereShape3D" id="4"]
 radius = 0.4
 
-[node name="SimpleBullet" type="RigidDynamicBody3D"]
+[node name="SimpleBullet" type="RigidBody3D"]
 mass = 2.0
 physics_material_override = SubResource( "1" )
 gravity_scale = 3.0

--- a/3d/ik/look_at_ik.tscn
+++ b/3d/ik/look_at_ik.tscn
@@ -1,18 +1,17 @@
-[gd_scene load_steps=10 format=3 uid="uid://dyhjvb7q0b3j"]
+[gd_scene load_steps=9 format=3 uid="uid://dyhjvb7q0b3j"]
 
 [ext_resource type="Texture2D" uid="uid://bw3q8aq6gfuof" path="res://addons/sade/editor_gizmo_texture.png" id="1"]
 [ext_resource type="PackedScene" uid="uid://ctssefekxjogg" path="res://model/godot_battle_bot.dae" id="2"]
 [ext_resource type="Material" path="res://model/battle_bot_color.tres" id="3"]
 [ext_resource type="Script" path="res://target_from_mousepos.gd" id="5"]
 [ext_resource type="Script" path="res://addons/sade/ik_look_at.gd" id="6"]
-[ext_resource type="Texture2D" uid="uid://dhgpf3w8mh4ed" path="res://addons/sade/ik_look_at.png" id="7"]
 [ext_resource type="Script" path="res://button_change_scene.gd" id="8"]
 
 [sub_resource type="PlaneMesh" id="1"]
 size = Vector2(40, 40)
 
 [sub_resource type="StandardMaterial3D" id="2"]
-albedo_texture = ExtResource( "1" )
+albedo_texture = ExtResource("1")
 roughness = 0.2
 uv1_scale = Vector3(0.25, 0.25, 0.25)
 uv1_triplanar = true
@@ -21,72 +20,61 @@ texture_filter = 0
 [node name="LookAtIK" type="Node3D"]
 
 [node name="Floor" type="MeshInstance3D" parent="."]
-mesh = SubResource( "1" )
-surface_material_override/0 = SubResource( "2" )
+mesh = SubResource("1")
+surface_material_override/0 = SubResource("2")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.56827, 0.673454, -0.472789, 0, 0.574581, 0.818448, 0.822842, -0.465099, 0.326517, -9.77531, 11.5204, 11.766)
 
-[node name="GodotBattleBot" parent="." instance=ExtResource( "2" )]
+[node name="GodotBattleBot" parent="." instance=ExtResource("2")]
 
 [node name="godot_battle_bot" parent="GodotBattleBot/Armature/Skeleton3D" index="0"]
-surface_material_override/0 = ExtResource( "3" )
+surface_material_override/0 = ExtResource("3")
 
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 11.501, 11)
 fov = 74.0
-script = ExtResource( "5" )
+script = ExtResource("5")
 MOVEMENT_SPEED = -3.0
 flip_axis = true
 
 [node name="Targets" type="Node3D" parent="Camera3D"]
 
 [node name="IK_LookAt_Head" type="Node3D" parent="Camera3D/Targets"]
-script = ExtResource( "6" )
-__meta__ = {
-"_editor_icon": ExtResource( "7" )
-}
+script = ExtResource("6")
 skeleton_path = NodePath("../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Head"
 additional_rotation = Vector3(90, 0, 0)
 
 [node name="IK_LookAt_LeftArm" type="Node3D" parent="Camera3D/Targets"]
-script = ExtResource( "6" )
-__meta__ = {
-"_editor_icon": ExtResource( "7" )
-}
+script = ExtResource("6")
 skeleton_path = NodePath("../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Left_UpperArm"
 
 [node name="IK_LookAt_RightArm" type="Node3D" parent="Camera3D/Targets"]
-script = ExtResource( "6" )
-__meta__ = {
-"_editor_icon": ExtResource( "7" )
-}
+script = ExtResource("6")
 skeleton_path = NodePath("../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Right_UpperArm"
 additional_rotation = Vector3(0, 0, 180)
 
 [node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Panel" type="Panel" parent="Control"]
 modulate = Color(1, 1, 1, 0.784314)
+layout_mode = 0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -2.0
 offset_top = -70.0
 offset_right = 4.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label" type="Label" parent="Control/Panel"]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 12.0
@@ -95,11 +83,10 @@ offset_right = -18.0
 offset_bottom = -29.0
 text = "LookAt IK
 Move mouse to move IK targets"
-__meta__ = {
-"_edit_use_anchors_": false
-}
+horizontal_alignment = 1
 
 [node name="ButtonNext" type="Button" parent="Control"]
+layout_mode = 0
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -109,10 +96,7 @@ offset_top = -60.0
 offset_right = -5.0
 offset_bottom = -10.0
 text = "Next scene"
-script = ExtResource( "8" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("8")
 scene_to_change_to = "res://fabrik_ik.tscn"
 
 [editable path="GodotBattleBot"]

--- a/3d/ik/skeleton_ik.tscn
+++ b/3d/ik/skeleton_ik.tscn
@@ -103,7 +103,7 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 172.0
+offset_left = 24.0
 offset_top = 10.0
 offset_right = -18.0
 offset_bottom = -11.0
@@ -111,6 +111,7 @@ grow_horizontal = 2
 grow_vertical = 2
 text = "SkeletonIK3D node
 Move mouse to move IK targets"
+horizontal_alignment = 1
 
 [node name="ButtonNext" type="Button" parent="Control"]
 layout_mode = 0

--- a/3d/ik/skeleton_ik.tscn
+++ b/3d/ik/skeleton_ik.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=13 format=3 uid="uid://5x7yswntc63m"]
+[gd_scene load_steps=12 format=3 uid="uid://5x7yswntc63m"]
 
 [ext_resource type="Script" path="res://skeleton_ik_runner.gd" id="1"]
-[ext_resource type="Texture2D" uid="uid://dhgpf3w8mh4ed" path="res://addons/sade/ik_look_at.png" id="2"]
 [ext_resource type="Texture2D" uid="uid://bw3q8aq6gfuof" path="res://addons/sade/editor_gizmo_texture.png" id="3"]
 [ext_resource type="PackedScene" uid="uid://ctssefekxjogg" path="res://model/godot_battle_bot.dae" id="4"]
 [ext_resource type="Script" path="res://target_from_mousepos.gd" id="5"]
@@ -13,7 +12,7 @@
 size = Vector2(40, 40)
 
 [sub_resource type="StandardMaterial3D" id="2"]
-albedo_texture = ExtResource( "3" )
+albedo_texture = ExtResource("3")
 roughness = 0.2
 uv1_scale = Vector3(0.25, 0.25, 0.25)
 uv1_triplanar = true
@@ -27,8 +26,8 @@ roughness = 0.0
 [node name="SkeletonIK3D" type="Node3D"]
 
 [node name="Floor" type="MeshInstance3D" parent="."]
-mesh = SubResource( "1" )
-surface_material_override/0 = SubResource( "2" )
+mesh = SubResource("1")
+surface_material_override/0 = SubResource("2")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.56827, 0.673454, -0.472789, 0, 0.574581, 0.818448, 0.822842, -0.465099, 0.326517, -9.77531, 11.5204, 11.766)
@@ -36,7 +35,7 @@ transform = Transform3D(0.56827, 0.673454, -0.472789, 0, 0.574581, 0.818448, 0.8
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 11.5, 11)
 fov = 74.0
-script = ExtResource( "5" )
+script = ExtResource("5")
 MOVEMENT_SPEED = -8.0
 flip_axis = true
 
@@ -44,28 +43,25 @@ flip_axis = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -8)
 
 [node name="IK_LookAt_Head" type="Node3D" parent="Camera3D/Targets"]
-script = ExtResource( "9" )
-__meta__ = {
-"_editor_icon": ExtResource( "2" )
-}
+script = ExtResource("9")
 skeleton_path = NodePath("../../../GodotBattleBot/Armature/Skeleton3D")
 bone_name = "Head"
 additional_rotation = Vector3(90, 0, 0)
 
 [node name="1MeterCube" type="MeshInstance3D" parent="Camera3D/Targets"]
-mesh = SubResource( "3" )
-surface_material_override/0 = SubResource( "4" )
+mesh = SubResource("3")
+surface_material_override/0 = SubResource("4")
 
-[node name="TargetLeft" type="Position3D" parent="Camera3D/Targets"]
+[node name="TargetLeft" type="Marker3D" parent="Camera3D/Targets"]
 transform = Transform3D(-0.179447, 0.98366, -0.0145678, 0.981822, 0.178142, -0.0654973, -0.0618319, -0.0260563, -0.997746, 0.653517, -0.112305, -0.760886)
 
-[node name="TargetRight" type="Position3D" parent="Camera3D/Targets"]
+[node name="TargetRight" type="Marker3D" parent="Camera3D/Targets"]
 transform = Transform3D(-0.0217688, 0.998559, -0.0490576, 0.992503, 0.0274873, 0.119085, 0.120262, -0.0460975, -0.991671, -0.683053, 0.0251284, -0.811513)
 
-[node name="GodotBattleBot" parent="." instance=ExtResource( "4" )]
+[node name="GodotBattleBot" parent="." instance=ExtResource("4")]
 
 [node name="godot_battle_bot" parent="GodotBattleBot/Armature/Skeleton3D" index="0"]
-surface_material_override/0 = ExtResource( "6" )
+surface_material_override/0 = ExtResource("6")
 
 [node name="SkeletonIK_Left" type="SkeletonIK3D" parent="GodotBattleBot/Armature/Skeleton3D" index="1"]
 process_priority = 1
@@ -74,7 +70,7 @@ tip_bone = &"Left_Hand"
 use_magnet = true
 magnet = Vector3(8, 6, 0)
 target_node = NodePath("../../../../Camera3D/Targets/TargetLeft")
-script = ExtResource( "1" )
+script = ExtResource("1")
 
 [node name="SkeletonIK_Right" type="SkeletonIK3D" parent="GodotBattleBot/Armature/Skeleton3D" index="2"]
 process_priority = 1
@@ -83,41 +79,41 @@ tip_bone = &"Right_Hand"
 use_magnet = true
 magnet = Vector3(-8, 6, 0)
 target_node = NodePath("../../../../Camera3D/Targets/TargetRight")
-script = ExtResource( "1" )
+script = ExtResource("1")
 
 [node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Panel" type="Panel" parent="Control"]
 modulate = Color(1, 1, 1, 0.784314)
+layout_mode = 1
+anchors_preset = 12
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -2.0
 offset_top = -70.0
 offset_right = 4.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label" type="Label" parent="Control/Panel"]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 12.0
+offset_left = 172.0
 offset_top = 10.0
 offset_right = -18.0
-offset_bottom = -29.0
+offset_bottom = -11.0
+grow_horizontal = 2
+grow_vertical = 2
 text = "SkeletonIK3D node
 Move mouse to move IK targets"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ButtonNext" type="Button" parent="Control"]
+layout_mode = 0
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
@@ -127,13 +123,11 @@ offset_top = -60.0
 offset_right = -5.0
 offset_bottom = -10.0
 text = "Next scene"
-script = ExtResource( "8" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("8")
 scene_to_change_to = "res://fps/fps_example.tscn"
 
 [node name="ButtonPrev" type="Button" parent="Control"]
+layout_mode = 0
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 10.0
@@ -141,10 +135,7 @@ offset_top = -60.0
 offset_right = 129.0
 offset_bottom = -10.0
 text = "Previous scene"
-script = ExtResource( "8" )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource("8")
 scene_to_change_to = "res://fabrik_ik.tscn"
 
 [editable path="GodotBattleBot"]

--- a/3d/ik/target_from_mousepos.gd
+++ b/3d/ik/target_from_mousepos.gd
@@ -7,7 +7,9 @@ extends Camera3D
 
 
 func _process(_delta):
-	var mouse_to_world = project_local_ray_normal(get_viewport().get_mouse_position()) * MOVEMENT_SPEED
+	var mouse_to_world = (
+		project_local_ray_normal(get_viewport().get_mouse_position()) * MOVEMENT_SPEED
+	)
 
 	if flip_axis:
 		mouse_to_world = -mouse_to_world


### PR DESCRIPTION
This is an initial attempt to convert the 3D Inverse Kinematics demo, related to updating all Demos to Godot 4 Issue #697

The project doesn't entirely work yet, but it runs. I am still working on making it work fully, but at least it starts now instead of crashing and you can cycle through the scenes and read all of the text.

I'll keep updating this when I make more parts work. I leave it up to you if you want to merge it now or wait until I have made it more functional.

I hit some of the files with my code formatter, if white-space updates are not wanted I can remove those.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
