### PR TITLE
Switch to single safe threaded model in TextureRD demo

### DIFF
--- a/compute/texture/project.godot
+++ b/compute/texture/project.godot
@@ -14,7 +14,3 @@ config/name="TestCustomTextures"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.2")
 config/icon="res://icon.svg"
-
-[rendering]
-
-driver/threads/thread_model=2


### PR DESCRIPTION
Avoids the bug in https://github.com/godotengine/godot/issues/90363

Multithreaded rendering is not safe in 4.2, so it should not be used in our official demos