### PR TITLE
Only print MIDI device list if any are found.

### DIFF
--- a/audio/midi_piano/piano.gd
+++ b/audio/midi_piano/piano.gd
@@ -29,7 +29,8 @@ func _ready():
 	if white_keys.get_child_count() != black_keys.get_child_count():
 		_add_placeholder_key(black_keys)
 	OS.open_midi_inputs()
-	print(OS.get_connected_midi_inputs())
+	if len(OS.get_connected_midi_inputs()) > 0:
+		print(OS.get_connected_midi_inputs())
 
 
 func _input(input_event):


### PR DESCRIPTION
This is a silly "fix", but it prevents an empty `[]` from being printed every time this demo is run without a MIDI device plugged into the computer.

The MIDI devices list is printed if one is plugged into the computer, which I have tested.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
