### PR TITLE
Wait until `_ready` function to init previous_position to prevent errors

### DIFF
--- a/3d/truck_town/vehicles/follow_camera.gd
+++ b/3d/truck_town/vehicles/follow_camera.gd
@@ -24,7 +24,7 @@ var base_fov := fov
 var desired_fov := fov
 
 # Position on the last physics frame (used to measure speed).
-var previous_position: Vector3
+@onready var previous_position := global_position
 
 enum CameraType {
 	EXTERIOR,
@@ -34,7 +34,6 @@ enum CameraType {
 }
 
 func _ready():
-	previous_position = global_position
 	update_camera()
 
 

--- a/3d/truck_town/vehicles/follow_camera.gd
+++ b/3d/truck_town/vehicles/follow_camera.gd
@@ -24,7 +24,7 @@ var base_fov := fov
 var desired_fov := fov
 
 # Position on the last physics frame (used to measure speed).
-var previous_position := global_position
+var previous_position: Vector3
 
 enum CameraType {
 	EXTERIOR,
@@ -34,6 +34,7 @@ enum CameraType {
 }
 
 func _ready():
+	previous_position = global_position
 	update_camera()
 
 


### PR DESCRIPTION
Upon starting the project and selecting a truck, this error is always emitted:

```
E 0:00:22:0996   follow_camera.gd:27 @ @implicit_new(): Condition "!is_inside_tree()" is true. Returning: Transform3D()
  <C++ Source>   scene\3d\node_3d.cpp:346 @ Node3D::get_global_transform()
  <Stack Trace>  follow_camera.gd:27 @ @implicit_new()
                 car_select.gd:15 @ _load_scene()
                 car_select.gd:39 @ _on_mini_van_pressed()
```

This also happens if you go back and pick a different truck.

I believe this is caused by attempting to assign `global_position` to a variable before the scene has initialized.

Waiting until the `_ready()` function to assign the variable for the first time appears to solve this issue.

Other fixes I tried fixed the initial error, but the error persisted if you went "Back" and selected a different truck. This fix covers that case too.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
