### PR TITLE
Fixed minor Godot 3 bit in "gui_in_3d" demo's billboard specific code

### DIFF
--- a/viewport/gui_in_3d/gui_3d.gd
+++ b/viewport/gui_in_3d/gui_3d.gd
@@ -110,7 +110,7 @@ func _mouse_input_event(_camera: Camera3D, event: InputEvent, event_position: Ve
 
 
 func rotate_area_to_billboard():
-	var billboard_mode = node_quad.get_surface_override_material(0).params_billboard_mode
+	var billboard_mode = node_quad.get_surface_override_material(0).billboard_mode
 
 	# Try to match the area with the material's billboard setting, if enabled.
 	if billboard_mode > 0:


### PR DESCRIPTION
- Godot 3's SpatialMaterial has a "params_billboard_mode" property:
https://docs.godotengine.org/en/3.6/classes/class_spatialmaterial.html#class-spatialmaterial-property-params-billboard-mode
- but Godot 4's BaseMaterial3D instead has a "billboard_mode" property:
https://docs.godotengine.org/en/stable/classes/class_basematerial3d.html#class-basematerial3d-property-billboard-mode

But I guess nobody needed any convincing since that change has already been made at line 20:
`if node_quad.get_surface_override_material(0).billboard_mode == BaseMaterial3D.BillboardMode.BILLBOARD_DISABLED:`