### PR TITLE
Use `InputEventMouseMotion.screen_relative` for resolution-independent mouselook

### DIFF
--- a/3d/antialiasing/anti_aliasing.gd
+++ b/3d/antialiasing/anti_aliasing.gd
@@ -9,7 +9,6 @@ var tester_index = 0
 var rot_x = -TAU / 16  # This must be kept in sync with RotationX.
 var rot_y = TAU / 8  # This must be kept in sync with CameraHolder.
 var camera_distance = 2.0
-var base_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 
 @onready var testers = $Testers
 @onready var camera_holder = $CameraHolder # Has a position and rotates on Y.
@@ -43,7 +42,7 @@ func _unhandled_input(event):
 
 	if event is InputEventMouseMotion and event.button_mask & MAIN_BUTTONS:
 		# Compensate motion speed to be resolution-independent (based on the window height).
-		var relative_motion = event.relative * DisplayServer.window_get_size().y / base_height
+		var relative_motion = event.screen_relative
 		rot_y -= relative_motion.x * ROT_SPEED
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clamp(rot_x, -1.57, 0)

--- a/3d/csg/csg.gd
+++ b/3d/csg/csg.gd
@@ -8,7 +8,6 @@ var tester_index = 0
 var rot_x = -TAU / 16  # This must be kept in sync with RotationX.
 var rot_y = TAU / 8  # This must be kept in sync with CameraHolder.
 var camera_distance = 4.0
-var base_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 
 @onready var testers = $Testers
 @onready var camera_holder = $CameraHolder # Has a position and rotates on Y.
@@ -37,7 +36,7 @@ func _unhandled_input(event):
 
 	if event is InputEventMouseMotion and event.button_mask & MAIN_BUTTONS:
 		# Compensate motion speed to be resolution-independent (based on the window height).
-		var relative_motion = event.relative * DisplayServer.window_get_size().y / base_height
+		var relative_motion = event.screen_relative
 		rot_y -= relative_motion.x * ROT_SPEED
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clamp(rot_x, -1.57, 0)

--- a/3d/decals/tester.gd
+++ b/3d/decals/tester.gd
@@ -8,7 +8,6 @@ var tester_index = 0
 var rot_x = deg_to_rad(-22.5)  # This must be kept in sync with RotationX.
 var rot_y = deg_to_rad(90)  # This must be kept in sync with CameraHolder.
 var zoom = 1.5
-var base_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 
 @onready var testers = $Testers
 @onready var camera_holder = $CameraHolder # Has a position and rotates on Y.
@@ -50,7 +49,7 @@ func _unhandled_input(event):
 
 	if event is InputEventMouseMotion and event.button_mask & MAIN_BUTTONS:
 		# Compensate motion speed to be resolution-independent (based on the window height).
-		var relative_motion = event.relative * DisplayServer.window_get_size().y / base_height
+		var relative_motion = event.screen_relative
 		rot_y -= relative_motion.x * ROT_SPEED
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clampf(rot_x, deg_to_rad(-90), 0)

--- a/3d/global_illumination/camera.gd
+++ b/3d/global_illumination/camera.gd
@@ -15,9 +15,9 @@ func _input(event):
 	# Mouse look (only if the mouse is captured).
 	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
 		# Horizontal mouse look.
-		rot.y -= event.relative.x * MOUSE_SENSITIVITY
+		rot.y -= event.screen_relative.x * MOUSE_SENSITIVITY
 		# Vertical mouse look.
-		rot.x = clamp(rot.x - event.relative.y * MOUSE_SENSITIVITY, -1.57, 1.57)
+		rot.x = clamp(rot.x - event.screen_relative.y * MOUSE_SENSITIVITY, -1.57, 1.57)
 		transform.basis = Basis.from_euler(rot)
 
 	if event.is_action_pressed("toggle_mouse_capture"):

--- a/3d/ik/fps/example_player.gd
+++ b/3d/ik/fps/example_player.gd
@@ -213,8 +213,8 @@ func _input(event):
 
 	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
 
-		rotate_y(deg2rad(event.relative.x * MOUSE_SENSITIVITY * -1))
-		camera_holder.rotate_x(deg2rad(event.relative.y * MOUSE_SENSITIVITY))
+		rotate_y(deg2rad(event.screen_relative.x * MOUSE_SENSITIVITY * -1))
+		camera_holder.rotate_x(deg2rad(event.screen_relative.y * MOUSE_SENSITIVITY))
 
 		# We need to clamp the camera's rotation so we cannot rotate ourselves upside down
 		var camera_rot = camera_holder.rotation_degrees

--- a/3d/labels_and_texts/3d_labels_and_texts.gd
+++ b/3d/labels_and_texts/3d_labels_and_texts.gd
@@ -8,7 +8,6 @@ var tester_index = 0
 var rot_x = -TAU / 16  # This must be kept in sync with RotationX.
 var rot_y = TAU / 8  # This must be kept in sync with CameraHolder.
 var camera_distance = 2.0
-var base_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 
 @onready var testers = $Testers
 @onready var camera_holder = $CameraHolder # Has a position and rotates on Y.
@@ -37,7 +36,7 @@ func _unhandled_input(event):
 
 	if event is InputEventMouseMotion and event.button_mask & MAIN_BUTTONS:
 		# Compensate motion speed to be resolution-independent (based on the window height).
-		var relative_motion = event.relative * DisplayServer.window_get_size().y / base_height
+		var relative_motion = event.screen_relative
 		rot_y -= relative_motion.x * ROT_SPEED
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clamp(rot_x, -1.57, 0)

--- a/3d/lights_and_shadows/tester.gd
+++ b/3d/lights_and_shadows/tester.gd
@@ -8,7 +8,6 @@ var tester_index = 0
 var rot_x = deg_to_rad(-22.5)  # This must be kept in sync with RotationX.
 var rot_y = deg_to_rad(90)  # This must be kept in sync with CameraHolder.
 var zoom = 2.5
-var base_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 
 @onready var testers = $Testers
 @onready var camera_holder = $CameraHolder # Has a position and rotates on Y.
@@ -37,7 +36,7 @@ func _unhandled_input(event):
 
 	if event is InputEventMouseMotion and event.button_mask & MAIN_BUTTONS:
 		# Compensate motion speed to be resolution-independent (based on the window height).
-		var relative_motion = event.relative * DisplayServer.window_get_size().y / base_height
+		var relative_motion = event.screen_relative
 		rot_y -= relative_motion.x * ROT_SPEED
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clamp(rot_x, deg_to_rad(-90), 0)

--- a/3d/material_testers/tester.gd
+++ b/3d/material_testers/tester.gd
@@ -10,7 +10,6 @@ var tester_index = 0
 var rot_x = -0.5  # This must be kept in sync with RotationX.
 var rot_y = -0.5  # This must be kept in sync with CameraHolder.
 var zoom = 5
-var base_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 
 var backgrounds = [
 	{ path = "res://backgrounds/schelde.hdr", name = "Riverside" },
@@ -50,7 +49,7 @@ func _unhandled_input(event):
 
 	if event is InputEventMouseMotion and event.button_mask & MAIN_BUTTONS:
 		# Compensate motion speed to be resolution-independent (based on the window height).
-		var relative_motion = event.relative * DisplayServer.window_get_size().y / base_height
+		var relative_motion = event.screen_relative
 		rot_y -= relative_motion.x * ROT_SPEED
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clamp(rot_x, -1.4, 0.45)

--- a/3d/navigation/navmesh.gd
+++ b/3d/navigation/navmesh.gd
@@ -26,5 +26,5 @@ func _unhandled_input(event: InputEvent):
 
 	elif event is InputEventMouseMotion:
 		if event.button_mask & (MOUSE_BUTTON_MASK_MIDDLE + MOUSE_BUTTON_MASK_RIGHT):
-			_cam_rotation += event.relative.x * 0.005
+			_cam_rotation += event.screen_relative.x * 0.005
 			$CameraBase.set_rotation(Vector3.UP * _cam_rotation)

--- a/3d/occlusion_culling_mesh_lod/camera.gd
+++ b/3d/occlusion_culling_mesh_lod/camera.gd
@@ -15,9 +15,9 @@ func _input(event):
 	# Mouse look (only if the mouse is captured).
 	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
 		# Horizontal mouse look.
-		rot.y -= event.relative.x * MOUSE_SENSITIVITY
+		rot.y -= event.screen_relative.x * MOUSE_SENSITIVITY
 		# Vertical mouse look.
-		rot.x = clamp(rot.x - event.relative.y * MOUSE_SENSITIVITY, -1.57, 1.57)
+		rot.x = clamp(rot.x - event.screen_relative.y * MOUSE_SENSITIVITY, -1.57, 1.57)
 		transform.basis = Basis.from_euler(rot)
 
 	if event.is_action_pressed("toggle_mouse_capture"):

--- a/3d/particles/tester.gd
+++ b/3d/particles/tester.gd
@@ -8,7 +8,6 @@ var tester_index = 0
 var rot_x = deg_to_rad(-22.5)  # This must be kept in sync with RotationX.
 var rot_y = deg_to_rad(90)  # This must be kept in sync with CameraHolder.
 var zoom = 2.5
-var base_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 
 @onready var testers = $Testers
 @onready var camera_holder = $CameraHolder # Has a position and rotates on Y.
@@ -37,7 +36,7 @@ func _unhandled_input(event):
 
 	if event is InputEventMouseMotion and event.button_mask & MAIN_BUTTONS:
 		# Compensate motion speed to be resolution-independent (based on the window height).
-		var relative_motion = event.relative * DisplayServer.window_get_size().y / base_height
+		var relative_motion = event.screen_relative
 		rot_y -= relative_motion.x * ROT_SPEED
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clamp(rot_x, deg_to_rad(-90), 0)

--- a/3d/physics_tests/utils/camera_orbit.gd
+++ b/3d/physics_tests/utils/camera_orbit.gd
@@ -23,7 +23,7 @@ func _unhandled_input(event):
 
 	var mouse_motion_event = event as InputEventMouseMotion
 	if mouse_motion_event:
-		var rotation_delta = mouse_motion_event.relative.x
+		var rotation_delta = mouse_motion_event.screen_relative.x
 		_rotation_pivot.rotate(Vector3.UP, -rotation_delta * ROTATION_COEFF)
 
 

--- a/3d/procedural_materials/tester.gd
+++ b/3d/procedural_materials/tester.gd
@@ -8,7 +8,6 @@ var tester_index = 0
 var rot_x = deg_to_rad(-22.5)  # This must be kept in sync with RotationX.
 var rot_y = deg_to_rad(90)  # This must be kept in sync with CameraHolder.
 var zoom = 2.5
-var base_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 
 @onready var testers = $Testers
 @onready var camera_holder = $CameraHolder # Has a position and rotates on Y.
@@ -37,7 +36,7 @@ func _unhandled_input(event):
 
 	if event is InputEventMouseMotion and event.button_mask & MAIN_BUTTONS:
 		# Compensate motion speed to be resolution-independent (based on the window height).
-		var relative_motion = event.relative * DisplayServer.window_get_size().y / base_height
+		var relative_motion = event.screen_relative
 		rot_y -= relative_motion.x * ROT_SPEED
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clamp(rot_x, deg_to_rad(-90), 0)

--- a/3d/volumetric_fog/camera.gd
+++ b/3d/volumetric_fog/camera.gd
@@ -37,9 +37,9 @@ func _input(event):
 	# Mouse look (only if the mouse is captured).
 	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
 		# Horizontal mouse look.
-		rot.y -= event.relative.x * MOUSE_SENSITIVITY
+		rot.y -= event.screen_relative.x * MOUSE_SENSITIVITY
 		# Vertical mouse look.
-		rot.x = clamp(rot.x - event.relative.y * MOUSE_SENSITIVITY, -1.57, 1.57)
+		rot.x = clamp(rot.x - event.screen_relative.y * MOUSE_SENSITIVITY, -1.57, 1.57)
 		transform.basis = Basis.from_euler(rot)
 
 	if event.is_action_pressed("toggle_mouse_capture"):

--- a/3d/voxel/player/player.gd
+++ b/3d/voxel/player/player.gd
@@ -1,5 +1,7 @@
 extends CharacterBody3D
 
+const MOUSE_SENSITIVITY = 2.0
+
 const EYE_HEIGHT_STAND = 1.6
 const EYE_HEIGHT_CROUCH = 1.4
 
@@ -103,7 +105,7 @@ func _physics_process(delta):
 func _input(event):
 	if event is InputEventMouseMotion:
 		if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
-			_mouse_motion += event.relative
+			_mouse_motion += event.screen_relative * MOUSE_SENSITIVITY
 
 
 func chunk_pos():

--- a/3d/waypoints/camera.gd
+++ b/3d/waypoints/camera.gd
@@ -15,9 +15,9 @@ func _input(event):
 	# Mouse look (only if the mouse is captured).
 	if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
 		# Horizontal mouse look.
-		rot.y -= event.relative.x * MOUSE_SENSITIVITY
+		rot.y -= event.screen_relative.x * MOUSE_SENSITIVITY
 		# Vertical mouse look.
-		rot.x = clamp(rot.x - event.relative.y * MOUSE_SENSITIVITY, -1.57, 1.57)
+		rot.x = clamp(rot.x - event.screen_relative.y * MOUSE_SENSITIVITY, -1.57, 1.57)
 		transform.basis = Basis.from_euler(rot)
 
 	if event.is_action_pressed("toggle_mouse_capture"):

--- a/misc/large_world_coordinates/controls.gd
+++ b/misc/large_world_coordinates/controls.gd
@@ -11,8 +11,6 @@ const MAIN_BUTTONS = MOUSE_BUTTON_MASK_LEFT | MOUSE_BUTTON_MASK_MIDDLE | MOUSE_B
 @export var rigid_body: RigidBody3D
 
 @onready var zoom := camera.position.z
-var base_height: int = ProjectSettings.get_setting("display/window/size/viewport_height")
-
 @onready var rot_x := rotation_x.rotation.x
 @onready var rot_y := camera_holder.rotation.y
 
@@ -42,7 +40,7 @@ func _input(event: InputEvent) -> void:
 
 	if event is InputEventMouseMotion and event.button_mask & MAIN_BUTTONS:
 		# Compensate motion speed to be resolution-independent (based on the window height).
-		var relative_motion: Vector2 = event.relative * DisplayServer.window_get_size().y / base_height
+		var relative_motion: Vector2 = event.screen_relative
 		rot_y -= relative_motion.x * ROT_SPEED
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clampf(rot_x, -1.4, 0.16)

--- a/misc/window_management/observer/observer.gd
+++ b/misc/window_management/observer/observer.gd
@@ -2,11 +2,10 @@ extends CharacterBody3D
 
 const STATE_MENU = 0
 const STATE_GRAB = 1
+const MOUSE_SENSITIVITY = 2.0
 
 var r_pos = Vector2()
 var state = STATE_MENU
-
-var initial_viewport_height = ProjectSettings.get_setting("display/window/size/viewport_height")
 
 @onready var camera = $Camera3D
 
@@ -28,9 +27,7 @@ func _process(delta):
 
 func _input(event):
 	if event is InputEventMouseMotion:
-		# Scale mouse sensitivity according to resolution, so that effective mouse sensitivity
-		# doesn't change depending on the viewport size.
-		r_pos = -event.relative * (get_viewport().size.y / initial_viewport_height)
+		r_pos = -event.screen_relative * MOUSE_SENSITIVITY
 
 	if event.is_action("ui_cancel") and event.is_pressed() and not event.is_echo():
 		if state == STATE_GRAB:

--- a/viewport/dynamic_split_screen/camera_controller.gd
+++ b/viewport/dynamic_split_screen/camera_controller.gd
@@ -32,8 +32,6 @@ extends Node3D
 @onready var camera1 = viewport1.get_node(^"Camera1")
 @onready var camera2 = viewport2.get_node(^"Camera2")
 
-var viewport_base_height = ProjectSettings.get_setting("display/window/size/viewport_height")
-
 func _ready():
 	_on_size_changed()
 	_update_splitscreen()


### PR DESCRIPTION
This avoids lengthy workarounds to ensure mouselook sensitivity doesn't change based on resolution.

As a bonus, this also fixes mouse sensitivity being too high on aspect ratios narrower than the project's default.

Mouse sensitivity was also increased in some projects for consistency with other projects.

All demos were tested.

**Do not merge before 4.3 is released** as this relies on a [feature only present in 4.3](https://github.com/godotengine/godot/pull/82800).
