### PR TITLE
Fixed bug in pong demo where ball does not reset to center.

### DIFF
--- a/mono/pong/Logic/Ball.cs
+++ b/mono/pong/Logic/Ball.cs
@@ -11,7 +11,7 @@ public partial class Ball : Area2D
 
     public override void _Ready()
     {
-        _initialPos = Position;
+        _initialPos =  new Vector2(Position.X, Position.Y);
     }
 
     public override void _Process(double delta)


### PR DESCRIPTION
The initial position is set as the vector2 of Position but Position is a pointer so it updates meaning the initial position is the current position of the ball

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
