### PR TITLE
Fix class name and extends

### DIFF
--- a/3d/navigation/line3d.gd
+++ b/3d/navigation/line3d.gd
@@ -1,5 +1,5 @@
-class_name MeshInstance3D
-extends Line3D
+class_name Line3D
+extends MeshInstance3D
 
 func _ready() -> void:
 	mesh = ImmediateMesh.new()


### PR DESCRIPTION
Pretty straightforward - those were swapped during conversion to strict typing and caused the 3d navigation demo to crash on startup.
