### PR TITLE
Fix class name and extends

### DIFF
--- a/misc/2.5d/addons/node25d/y_sort_25d.gd
+++ b/misc/2.5d/addons/node25d/y_sort_25d.gd
@@ -4,8 +4,8 @@
 # sorting is delayed by one frame.
 @tool
 @icon("res://addons/node25d/icons/y_sort_25d_icon.png")
-class_name Node # Note: NOT Node2D, Node25D, or Node2D
-extends YSort25D
+class_name YSort25D
+extends Node # Note: NOT Node2D, Node25D, or Node2D
 
 
 # Whether or not to automatically call sort() in _process().


### PR DESCRIPTION
Those were swapped during conversion to strict typing and caused the 2.5d demo to crash on startup.

- *Production edit: Follow-up to https://github.com/godotengine/godot-demo-projects/pull/1064.*
