### PR TITLE
Use higher shadow filtering quality settings in 3D demos

### DIFF
--- a/3d/antialiasing/project.godot
+++ b/3d/antialiasing/project.godot
@@ -28,5 +28,6 @@ window/stretch/aspect="expand"
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4
 textures/decals/filter=4

--- a/3d/decals/project.godot
+++ b/3d/decals/project.godot
@@ -35,5 +35,6 @@ place_decal={
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4
 textures/decals/filter=5

--- a/3d/global_illumination/project.godot
+++ b/3d/global_illumination/project.godot
@@ -80,5 +80,7 @@ toggle_mouse_capture={
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
+lights_and_shadows/positional_shadow/soft_shadow_filter_quality=3
 anti_aliasing/quality/screen_space_aa=1
 anti_aliasing/quality/use_debanding=true

--- a/3d/global_illumination/test.tscn
+++ b/3d/global_illumination/test.tscn
@@ -91,6 +91,7 @@ transform = Transform3D(0.889832, -0.251497, 0.380722, 0, 0.834387, 0.551179, -0
 shadow_enabled = true
 shadow_bias = 0.04
 shadow_blur = 2.0
+directional_shadow_blend_splits = true
 directional_shadow_fade_start = 1.0
 directional_shadow_max_distance = 75.0
 

--- a/3d/kinematic_character/project.godot
+++ b/3d/kinematic_character/project.godot
@@ -87,5 +87,6 @@ common/physics_ticks_per_second=120
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4
 anti_aliasing/quality/msaa_3d=2

--- a/3d/labels_and_texts/project.godot
+++ b/3d/labels_and_texts/project.godot
@@ -33,4 +33,5 @@ theme/default_font_generate_mipmaps=true
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4

--- a/3d/material_testers/project.godot
+++ b/3d/material_testers/project.godot
@@ -39,6 +39,7 @@ multithread/thread_rid_pool_prealloc=60
 
 [rendering]
 
+lights_and_shadows/positional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4
 anti_aliasing/quality/msaa_3d=2
 anti_aliasing/quality/use_debanding=true

--- a/3d/navigation/project.godot
+++ b/3d/navigation/project.godot
@@ -30,4 +30,5 @@ common/physics_ticks_per_second=120
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 anti_aliasing/quality/msaa_3d=2

--- a/3d/occlusion_culling_mesh_lod/project.godot
+++ b/3d/occlusion_culling_mesh_lod/project.godot
@@ -91,6 +91,7 @@ toggle_vsync={
 
 [rendering]
 
+lights_and_shadows/positional_shadow/soft_shadow_filter_quality=3
 anti_aliasing/quality/msaa_3d=2
 anti_aliasing/quality/use_debanding=true
 occlusion_culling/use_occlusion_culling=true

--- a/3d/particles/project.godot
+++ b/3d/particles/project.godot
@@ -28,4 +28,5 @@ window/stretch/aspect="expand"
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4

--- a/3d/physical_light_camera_units/test.tscn
+++ b/3d/physical_light_camera_units/test.tscn
@@ -106,7 +106,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 max_value = 1410.0
-step = 15.0
 value = 840.0
 
 [node name="Value" type="Label" parent="Options/Light/TimeOfDay"]

--- a/3d/procedural_materials/project.godot
+++ b/3d/procedural_materials/project.godot
@@ -28,6 +28,7 @@ window/stretch/aspect="expand"
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4
 environment/defaults/default_clear_color=Color(0.301961, 0.301961, 0.301961, 1)
 anti_aliasing/quality/msaa_3d=2

--- a/3d/rigidbody_character/project.godot
+++ b/3d/rigidbody_character/project.godot
@@ -87,5 +87,6 @@ common/physics_ticks_per_second=120
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4
 anti_aliasing/quality/msaa_3d=2

--- a/3d/squash_the_creeps/project.godot
+++ b/3d/squash_the_creeps/project.godot
@@ -15,10 +15,10 @@ config/description="In this game, your goal is to chase and kick out the creeps!
 
 This is a finished version of the game featured in the \"Your first 3D game\"
 tutorial in the official documentation."
+config/tags=PackedStringArray("3d", "demo", "official")
 run/main_scene="res://Main.tscn"
 config/features=PackedStringArray("4.2")
 config/icon="res://icon.webp"
-config/tags=PackedStringArray("3d", "demo", "official")
 
 [autoload]
 
@@ -83,4 +83,5 @@ common/physics_ticks_per_second=120
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 anti_aliasing/quality/msaa_3d=2

--- a/3d/variable_rate_shading/project.godot
+++ b/3d/variable_rate_shading/project.godot
@@ -31,6 +31,7 @@ window/vsync/vsync_mode=0
 
 [rendering]
 
+lights_and_shadows/positional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4
 vrs/mode=1
 vrs/texture="res://vrs_texture.png"

--- a/3d/volumetric_fog/project.godot
+++ b/3d/volumetric_fog/project.godot
@@ -93,6 +93,8 @@ decrease_volumetric_fog_quality={
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
+lights_and_shadows/positional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4
 anti_aliasing/quality/msaa_3d=2
 anti_aliasing/quality/use_debanding=true

--- a/3d/voxel/menu/ingame/pause_menu.tscn
+++ b/3d/voxel/menu/ingame/pause_menu.tscn
@@ -132,6 +132,10 @@ vertical_alignment = 1
 [node name="Options" parent="." instance=ExtResource("3")]
 layout_mode = 0
 anchors_preset = 0
+anchor_right = 0.0
+anchor_bottom = 0.0
+grow_horizontal = 1
+grow_vertical = 1
 
 [connection signal="pressed" from="Pause/ButtonHolder/MainButtons/Resume" to="." method="_on_Resume_pressed"]
 [connection signal="pressed" from="Pause/ButtonHolder/MainButtons/Options" to="." method="_on_Options_pressed"]

--- a/3d/voxel/project.godot
+++ b/3d/voxel/project.godot
@@ -153,5 +153,6 @@ common/physics_ticks_per_second=120
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 anti_aliasing/quality/msaa_3d=2
 anti_aliasing/quality/use_debanding=true

--- a/3d/voxel/world/world.tscn
+++ b/3d/voxel/world/world.tscn
@@ -52,6 +52,6 @@ script = ExtResource("4")
 [node name="Sun" type="DirectionalLight3D" parent="Environment"]
 transform = Transform3D(-0.866025, -0.433013, 0.25, 0, 0.5, 0.866026, -0.5, 0.75, -0.433013, 0, 0, 0)
 shadow_enabled = true
-shadow_bias = 0.04
+shadow_bias = 0.06
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]

--- a/3d/waypoints/main.tscn
+++ b/3d/waypoints/main.tscn
@@ -130,4 +130,6 @@ transform = Transform3D(-0.866025, -0.433013, 0.25, 0, 0.5, 0.866026, -0.5, 0.75
 shadow_enabled = true
 shadow_bias = 0.04
 shadow_blur = 1.5
+directional_shadow_mode = 0
+directional_shadow_fade_start = 1.0
 directional_shadow_max_distance = 40.0

--- a/3d/waypoints/project.godot
+++ b/3d/waypoints/project.godot
@@ -70,5 +70,6 @@ toggle_mouse_capture={
 
 [rendering]
 
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 anti_aliasing/quality/msaa_3d=2
 anti_aliasing/quality/use_debanding=true

--- a/misc/large_world_coordinates/project.godot
+++ b/misc/large_world_coordinates/project.godot
@@ -35,8 +35,7 @@ common/physics_ticks_per_second=120
 [rendering]
 
 renderer/rendering_method="mobile"
-lights_and_shadows/directional_shadow/size=2048
-lights_and_shadows/directional_shadow/size.mobile=1024
+lights_and_shadows/directional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4
 anti_aliasing/quality/msaa_3d=2
 lights_and_shadows/positional_shadow/atlas_size=2048

--- a/misc/large_world_coordinates/test.tscn
+++ b/misc/large_world_coordinates/test.tscn
@@ -239,7 +239,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 7)
 
 [node name="GPUParticles3D" type="GPUParticles3D" parent="Move"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 13, 0)
-amount = 1000
+amount = 500
 lifetime = 3.0
 fixed_fps = 0
 interpolate = false

--- a/viewport/3d_scaling/project.godot
+++ b/viewport/3d_scaling/project.godot
@@ -45,4 +45,5 @@ toggle_filtering={
 
 [rendering]
 
+lights_and_shadows/positional_shadow/soft_shadow_filter_quality=3
 textures/default_filters/anisotropic_filtering_level=4


### PR DESCRIPTION
The 3D demos aren't very demanding and Godot has been optimized a bit since 4.0's release, so we can afford using higher quality shadow settings for less noisy shadow filtering.

This also tweaks shadow bias to reduce shadow acne in the Voxel demo.

The time slider in the Physical Light and Camera units demo now allows for more precise adjustments.

## Preview

*Click to view at full size.*

### Before

![Screenshot_20240605_223655 png webp](https://github.com/godotengine/godot-demo-projects/assets/180032/c3ad31fe-048d-4c71-8317-43ad1bfedb0f)

### After *(this PR)*

![Screenshot_20240605_223659 png webp](https://github.com/godotengine/godot-demo-projects/assets/180032/f6deb3cd-6421-4e53-9b09-81eb49aac565)