### PR TITLE
Improve Material Testers demo project

### DIFF
--- a/3d/material_testers/material_tester.tscn
+++ b/3d/material_testers/material_tester.tscn
@@ -55,142 +55,246 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -36, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/White Plastic"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 2
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("8")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/White Plastic/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147483645
+reflection_mask = 2
+
 [node name="Mirror" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -30, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Mirror"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 4
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("9")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Mirror/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147483643
+reflection_mask = 4
+
 [node name="Dark Wood" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -24, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Dark Wood"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 8
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("10")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Dark Wood/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147483639
+reflection_mask = 8
+
 [node name="Cheese" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -18, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Cheese"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 16
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("16")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Cheese/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147483631
+reflection_mask = 16
+
 [node name="Stones" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Stones"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 32
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("11")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Stones/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147483615
+reflection_mask = 32
+
 [node name="Brick" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Brick"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 64
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("12")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Brick/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147483583
+reflection_mask = 64
+
 [node name="Wool" parent="Testers" instance=ExtResource("3")]
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Wool"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 128
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("13")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Wool/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147483519
+reflection_mask = 128
+
 [node name="Aluminium" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Aluminium"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 256
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("14")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Aluminium/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147483391
+reflection_mask = 256
+
 [node name="Marble" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Marble"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 512
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("15")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Marble/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147483135
+reflection_mask = 512
+
 [node name="Wet Sand" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 18, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Wet Sand"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 1024
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("17")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Wet Sand/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147482623
+reflection_mask = 1024
+
 [node name="Rock" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 24, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Rock"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 2048
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("18")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Rock/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147481599
+reflection_mask = 2048
+
 [node name="Ice" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 30, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Ice"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 4096
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("19")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
 
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Ice/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147479551
+reflection_mask = 4096
+
 [node name="Toon" parent="Testers" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 36, 0, 0)
 
 [node name="GodotBall" type="MeshInstance3D" parent="Testers/Toon"]
 transform = Transform3D(0.8, 0, 0, 0, 0.8, 0, 0, 0, 0.8, 0, 0.5, -4)
+layers = 8192
 mesh = ExtResource("4_7al4s")
 surface_material_override/0 = ExtResource("20")
 surface_material_override/1 = ExtResource("6")
 surface_material_override/2 = ExtResource("5")
 surface_material_override/3 = ExtResource("7")
+
+[node name="ReflectionProbe" type="ReflectionProbe" parent="Testers/Toon/GodotBall" groups=["reflection_probe"]]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 3, 0)
+size = Vector3(256, 256, 256)
+enable_shadows = true
+cull_mask = 2147475455
+reflection_mask = 8192
 
 [node name="CameraHolder" type="Node3D" parent="."]
 transform = Transform3D(0.877582, 0, -0.479427, 0, 1, 0, 0.479427, 0, 0.877582, -36, 2.8, -4)
@@ -219,6 +323,21 @@ offset_top = 16.0
 offset_right = 30.0
 offset_bottom = 36.0
 focus_mode = 0
+
+[node name="ReflectionProbes" type="OptionButton" parent="UI"]
+layout_mode = 0
+offset_left = 16.0
+offset_top = 56.0
+offset_right = 233.0
+offset_bottom = 87.0
+focus_mode = 0
+selected = 2
+item_count = 3
+popup/item_0/text = "No Reflection Probes"
+popup/item_1/text = "Reflection Probes (Reflection only)"
+popup/item_1/id = 1
+popup/item_2/text = "Reflection Probes (Reflection + Ambient)"
+popup/item_2/id = 2
 
 [node name="Previous" type="Button" parent="UI"]
 layout_mode = 1
@@ -281,6 +400,8 @@ focus_mode = 0
 text = "Quit"
 
 [connection signal="item_selected" from="UI/Background" to="." method="_on_bg_item_selected"]
+[connection signal="item_selected" from="UI/ReflectionProbes" to="." method="_on_reflection_probes_item_selected"]
+[connection signal="toggled" from="UI/ReflectionProbes" to="." method="_on_use_reflection_probes_toggled"]
 [connection signal="pressed" from="UI/Previous" to="." method="_on_previous_pressed"]
 [connection signal="pressed" from="UI/Next" to="." method="_on_next_pressed"]
 [connection signal="pressed" from="UI/Quit" to="." method="_on_quit_pressed"]

--- a/3d/material_testers/models/test_bed/large_material.tres
+++ b/3d/material_testers/models/test_bed/large_material.tres
@@ -5,6 +5,3 @@ cull_mode = 1
 albedo_color = Color(0.78327, 0.78327, 0.78327, 1)
 metallic = 0.1
 roughness = 0.6
-distance_fade_mode = 2
-distance_fade_min_distance = 2.0
-distance_fade_max_distance = 3.0

--- a/3d/material_testers/models/test_bed/small_material.tres
+++ b/3d/material_testers/models/test_bed/small_material.tres
@@ -3,6 +3,3 @@
 [resource]
 albedo_color = Color(0.054902, 0.329412, 0.329412, 1)
 metallic = 0.1
-distance_fade_mode = 2
-distance_fade_min_distance = 2.0
-distance_fade_max_distance = 3.0

--- a/3d/material_testers/project.godot
+++ b/3d/material_testers/project.godot
@@ -17,7 +17,7 @@ for the purpose of showcasing Godot's rendering capabilities.
 This demo was featured at the beginning of the Godot 3.0 trailer."
 config/tags=PackedStringArray("3d", "demo", "official", "rendering")
 run/main_scene="res://material_tester.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.webp"
 
 [debug]
@@ -33,6 +33,23 @@ window/stretch/aspect="expand"
 
 import/blender/enabled=false
 
+[layer_names]
+
+3d_render/layer_1="World"
+3d_render/layer_2="Tester 1"
+3d_render/layer_3="Tester 2"
+3d_render/layer_4="Tester 3"
+3d_render/layer_5="Tester 4"
+3d_render/layer_6="Tester 5"
+3d_render/layer_7="Tester 6"
+3d_render/layer_8="Tester 7"
+3d_render/layer_9="Tester 8"
+3d_render/layer_10="Tester 9"
+3d_render/layer_11="Tester 10"
+3d_render/layer_12="Tester 11"
+3d_render/layer_13="Tester 12"
+3d_render/layer_14="Tester 13"
+
 [memory]
 
 multithread/thread_rid_pool_prealloc=60
@@ -40,6 +57,7 @@ multithread/thread_rid_pool_prealloc=60
 [rendering]
 
 lights_and_shadows/positional_shadow/soft_shadow_filter_quality=3
+reflections/reflection_atlas/reflection_count=16
 textures/default_filters/anisotropic_filtering_level=4
 anti_aliasing/quality/msaa_3d=2
 anti_aliasing/quality/use_debanding=true

--- a/3d/material_testers/test_materials/aluminium_albedo.png.import
+++ b/3d/material_testers/test_materials/aluminium_albedo.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dsb01xyn6yui5"
-path.s3tc="res://.godot/imported/aluminium_albedo.png-a68e22c8a951430ab431b2a7307e8bc7.s3tc.ctex"
+path="res://.godot/imported/aluminium_albedo.png-a68e22c8a951430ab431b2a7307e8bc7.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/aluminium_albedo.png"
-dest_files=["res://.godot/imported/aluminium_albedo.png-a68e22c8a951430ab431b2a7307e8bc7.s3tc.ctex"]
+dest_files=["res://.godot/imported/aluminium_albedo.png-a68e22c8a951430ab431b2a7307e8bc7.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/aluminium_flow.png.import
+++ b/3d/material_testers/test_materials/aluminium_flow.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cqlianda7xhoy"
-path.s3tc="res://.godot/imported/aluminium_flow.png-93fdac7ed0fa884674e32e5ec0c6d690.s3tc.ctex"
+path="res://.godot/imported/aluminium_flow.png-93fdac7ed0fa884674e32e5ec0c6d690.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/aluminium_flow.png"
-dest_files=["res://.godot/imported/aluminium_flow.png-93fdac7ed0fa884674e32e5ec0c6d690.s3tc.ctex"]
+dest_files=["res://.godot/imported/aluminium_flow.png-93fdac7ed0fa884674e32e5ec0c6d690.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/aluminium_normal.png.import
+++ b/3d/material_testers/test_materials/aluminium_normal.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://ds1h5kb3sbtqq"
-path.s3tc="res://.godot/imported/aluminium_normal.png-ff9bf84211f307b1d9e8bf86ebea04b1.s3tc.ctex"
+path="res://.godot/imported/aluminium_normal.png-ff9bf84211f307b1d9e8bf86ebea04b1.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/aluminium_normal.png"
-dest_files=["res://.godot/imported/aluminium_normal.png-ff9bf84211f307b1d9e8bf86ebea04b1.s3tc.ctex"]
+dest_files=["res://.godot/imported/aluminium_normal.png-ff9bf84211f307b1d9e8bf86ebea04b1.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/ice.tres
+++ b/3d/material_testers/test_materials/ice.tres
@@ -5,14 +5,14 @@
 [ext_resource type="Texture2D" uid="uid://cyvm2mj4ibl0" path="res://test_materials/rock_metal.jpg" id="3"]
 
 [resource]
-albedo_color = Color(1, 1, 1, 0)
+albedo_color = Color(4.5, 6, 8, 0.02)
 albedo_texture = ExtResource("2")
-metallic = 1.0
-roughness = 0.62
+metallic_specular = 1.0
+roughness = 0.5
 normal_enabled = true
 normal_texture = ExtResource("3")
 ao_enabled = true
 ao_texture = ExtResource("1")
 refraction_enabled = true
-refraction_scale = 0.04
+refraction_scale = 0.03
 texture_filter = 5

--- a/3d/material_testers/test_materials/marble_albedo.png.import
+++ b/3d/material_testers/test_materials/marble_albedo.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d1lj5qylojp6o"
-path.s3tc="res://.godot/imported/marble_albedo.png-47e5ec5352a78eb204ccaf317de65697.s3tc.ctex"
+path="res://.godot/imported/marble_albedo.png-47e5ec5352a78eb204ccaf317de65697.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/marble_albedo.png"
-dest_files=["res://.godot/imported/marble_albedo.png-47e5ec5352a78eb204ccaf317de65697.s3tc.ctex"]
+dest_files=["res://.godot/imported/marble_albedo.png-47e5ec5352a78eb204ccaf317de65697.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/rock_albedo.jpg.import
+++ b/3d/material_testers/test_materials/rock_albedo.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://hul3jcu52o8g"
-path.s3tc="res://.godot/imported/rock_albedo.jpg-65fe78b8c7d44da07721bb783fdef67a.s3tc.ctex"
+path="res://.godot/imported/rock_albedo.jpg-65fe78b8c7d44da07721bb783fdef67a.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/rock_albedo.jpg"
-dest_files=["res://.godot/imported/rock_albedo.jpg-65fe78b8c7d44da07721bb783fdef67a.s3tc.ctex"]
+dest_files=["res://.godot/imported/rock_albedo.jpg-65fe78b8c7d44da07721bb783fdef67a.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/rock_ao.jpg.import
+++ b/3d/material_testers/test_materials/rock_ao.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cjiwyepmfaa2d"
-path.s3tc="res://.godot/imported/rock_ao.jpg-7578b4ab1e595c076d796172ca68cfa6.s3tc.ctex"
+path="res://.godot/imported/rock_ao.jpg-7578b4ab1e595c076d796172ca68cfa6.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/rock_ao.jpg"
-dest_files=["res://.godot/imported/rock_ao.jpg-7578b4ab1e595c076d796172ca68cfa6.s3tc.ctex"]
+dest_files=["res://.godot/imported/rock_ao.jpg-7578b4ab1e595c076d796172ca68cfa6.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/rock_depth.jpg.import
+++ b/3d/material_testers/test_materials/rock_depth.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bh3iv3ep28dsq"
-path.s3tc="res://.godot/imported/rock_depth.jpg-4080fbc6202f837d0b0deef2c981bad4.s3tc.ctex"
+path="res://.godot/imported/rock_depth.jpg-4080fbc6202f837d0b0deef2c981bad4.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/rock_depth.jpg"
-dest_files=["res://.godot/imported/rock_depth.jpg-4080fbc6202f837d0b0deef2c981bad4.s3tc.ctex"]
+dest_files=["res://.godot/imported/rock_depth.jpg-4080fbc6202f837d0b0deef2c981bad4.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/rock_metal.jpg.import
+++ b/3d/material_testers/test_materials/rock_metal.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cyvm2mj4ibl0"
-path.s3tc="res://.godot/imported/rock_metal.jpg-8defa2e9d8169c7a08962c4d1f3e6354.s3tc.ctex"
+path="res://.godot/imported/rock_metal.jpg-8defa2e9d8169c7a08962c4d1f3e6354.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/rock_metal.jpg"
-dest_files=["res://.godot/imported/rock_metal.jpg-8defa2e9d8169c7a08962c4d1f3e6354.s3tc.ctex"]
+dest_files=["res://.godot/imported/rock_metal.jpg-8defa2e9d8169c7a08962c4d1f3e6354.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/rock_rough.jpg.import
+++ b/3d/material_testers/test_materials/rock_rough.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d28x4upsru550"
-path.s3tc="res://.godot/imported/rock_rough.jpg-a18116680c5cb62b9f0632460fe30f62.s3tc.ctex"
+path="res://.godot/imported/rock_rough.jpg-a18116680c5cb62b9f0632460fe30f62.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/rock_rough.jpg"
-dest_files=["res://.godot/imported/rock_rough.jpg-a18116680c5cb62b9f0632460fe30f62.s3tc.ctex"]
+dest_files=["res://.godot/imported/rock_rough.jpg-a18116680c5cb62b9f0632460fe30f62.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/sand_albedo.jpg.import
+++ b/3d/material_testers/test_materials/sand_albedo.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://8ccausxvepx"
-path.s3tc="res://.godot/imported/sand_albedo.jpg-c03140f13a9e6c9b1c6fe52f92bc0e1b.s3tc.ctex"
+path="res://.godot/imported/sand_albedo.jpg-c03140f13a9e6c9b1c6fe52f92bc0e1b.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/sand_albedo.jpg"
-dest_files=["res://.godot/imported/sand_albedo.jpg-c03140f13a9e6c9b1c6fe52f92bc0e1b.s3tc.ctex"]
+dest_files=["res://.godot/imported/sand_albedo.jpg-c03140f13a9e6c9b1c6fe52f92bc0e1b.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/sand_metal.jpg.import
+++ b/3d/material_testers/test_materials/sand_metal.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d1cw5asi5uuhm"
-path.s3tc="res://.godot/imported/sand_metal.jpg-bc79f66c3e18060c7cbaa67c44681910.s3tc.ctex"
+path="res://.godot/imported/sand_metal.jpg-bc79f66c3e18060c7cbaa67c44681910.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/sand_metal.jpg"
-dest_files=["res://.godot/imported/sand_metal.jpg-bc79f66c3e18060c7cbaa67c44681910.s3tc.ctex"]
+dest_files=["res://.godot/imported/sand_metal.jpg-bc79f66c3e18060c7cbaa67c44681910.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/sand_normal.jpg.import
+++ b/3d/material_testers/test_materials/sand_normal.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cukid0fpw2pn0"
-path.s3tc="res://.godot/imported/sand_normal.jpg-7a18b411efc93de1cffd09e24f6336b4.s3tc.ctex"
+path="res://.godot/imported/sand_normal.jpg-7a18b411efc93de1cffd09e24f6336b4.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/sand_normal.jpg"
-dest_files=["res://.godot/imported/sand_normal.jpg-7a18b411efc93de1cffd09e24f6336b4.s3tc.ctex"]
+dest_files=["res://.godot/imported/sand_normal.jpg-7a18b411efc93de1cffd09e24f6336b4.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/sand_rough.jpg.import
+++ b/3d/material_testers/test_materials/sand_rough.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dn11j7g5oa50e"
-path.s3tc="res://.godot/imported/sand_rough.jpg-14616e257ba8a3726af90b2162c4ea2b.s3tc.ctex"
+path="res://.godot/imported/sand_rough.jpg-14616e257ba8a3726af90b2162c4ea2b.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/sand_rough.jpg"
-dest_files=["res://.godot/imported/sand_rough.jpg-14616e257ba8a3726af90b2162c4ea2b.s3tc.ctex"]
+dest_files=["res://.godot/imported/sand_rough.jpg-14616e257ba8a3726af90b2162c4ea2b.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_bricks.jpg.import
+++ b/3d/material_testers/test_materials/texture_bricks.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d4l8oj2cmq330"
-path.s3tc="res://.godot/imported/texture_bricks.jpg-c5a7a817bf05cfd9e63ae7aecdfad44c.s3tc.ctex"
+path="res://.godot/imported/texture_bricks.jpg-c5a7a817bf05cfd9e63ae7aecdfad44c.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_bricks.jpg"
-dest_files=["res://.godot/imported/texture_bricks.jpg-c5a7a817bf05cfd9e63ae7aecdfad44c.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_bricks.jpg-c5a7a817bf05cfd9e63ae7aecdfad44c.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_bricks_ao.jpg.import
+++ b/3d/material_testers/test_materials/texture_bricks_ao.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cmin1t2jofd3o"
-path.s3tc="res://.godot/imported/texture_bricks_ao.jpg-b6772c3eac21780de75b61fb29d8df6b.s3tc.ctex"
+path="res://.godot/imported/texture_bricks_ao.jpg-b6772c3eac21780de75b61fb29d8df6b.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_bricks_ao.jpg"
-dest_files=["res://.godot/imported/texture_bricks_ao.jpg-b6772c3eac21780de75b61fb29d8df6b.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_bricks_ao.jpg-b6772c3eac21780de75b61fb29d8df6b.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_bricks_depth.jpg.import
+++ b/3d/material_testers/test_materials/texture_bricks_depth.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dyyjfu431yi7r"
-path.s3tc="res://.godot/imported/texture_bricks_depth.jpg-fed037b05656973f46c8d8fc0dae33d5.s3tc.ctex"
+path="res://.godot/imported/texture_bricks_depth.jpg-fed037b05656973f46c8d8fc0dae33d5.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_bricks_depth.jpg"
-dest_files=["res://.godot/imported/texture_bricks_depth.jpg-fed037b05656973f46c8d8fc0dae33d5.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_bricks_depth.jpg-fed037b05656973f46c8d8fc0dae33d5.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_bricks_metal.jpg.import
+++ b/3d/material_testers/test_materials/texture_bricks_metal.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://4t1ufkncfbs3"
-path.s3tc="res://.godot/imported/texture_bricks_metal.jpg-0cfc783b7a5646c7f79c1bfc856a0169.s3tc.ctex"
+path="res://.godot/imported/texture_bricks_metal.jpg-0cfc783b7a5646c7f79c1bfc856a0169.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_bricks_metal.jpg"
-dest_files=["res://.godot/imported/texture_bricks_metal.jpg-0cfc783b7a5646c7f79c1bfc856a0169.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_bricks_metal.jpg-0cfc783b7a5646c7f79c1bfc856a0169.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_bricks_normal.jpg.import
+++ b/3d/material_testers/test_materials/texture_bricks_normal.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cn6yat4b4mngn"
-path.s3tc="res://.godot/imported/texture_bricks_normal.jpg-605ba8666210a56b09eb0b2392bd6355.s3tc.ctex"
+path="res://.godot/imported/texture_bricks_normal.jpg-605ba8666210a56b09eb0b2392bd6355.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_bricks_normal.jpg"
-dest_files=["res://.godot/imported/texture_bricks_normal.jpg-605ba8666210a56b09eb0b2392bd6355.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_bricks_normal.jpg-605ba8666210a56b09eb0b2392bd6355.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_cheese_albedo.png.import
+++ b/3d/material_testers/test_materials/texture_cheese_albedo.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bbei0af7fjhkn"
-path.s3tc="res://.godot/imported/texture_cheese_albedo.png-47db78359d020535d042fccfe547c563.s3tc.ctex"
+path="res://.godot/imported/texture_cheese_albedo.png-47db78359d020535d042fccfe547c563.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_cheese_albedo.png"
-dest_files=["res://.godot/imported/texture_cheese_albedo.png-47db78359d020535d042fccfe547c563.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_cheese_albedo.png-47db78359d020535d042fccfe547c563.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_cheese_ao.png.import
+++ b/3d/material_testers/test_materials/texture_cheese_ao.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cwpdpjj628we6"
-path.s3tc="res://.godot/imported/texture_cheese_ao.png-db37cd87a9560149bf42629f84a8517d.s3tc.ctex"
+path="res://.godot/imported/texture_cheese_ao.png-db37cd87a9560149bf42629f84a8517d.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_cheese_ao.png"
-dest_files=["res://.godot/imported/texture_cheese_ao.png-db37cd87a9560149bf42629f84a8517d.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_cheese_ao.png-db37cd87a9560149bf42629f84a8517d.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_cheese_depth.png.import
+++ b/3d/material_testers/test_materials/texture_cheese_depth.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://ckyituyfs02mo"
-path.s3tc="res://.godot/imported/texture_cheese_depth.png-71cbe5ab2c9f4e2343f1082a376b299f.s3tc.ctex"
+path="res://.godot/imported/texture_cheese_depth.png-71cbe5ab2c9f4e2343f1082a376b299f.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_cheese_depth.png"
-dest_files=["res://.godot/imported/texture_cheese_depth.png-71cbe5ab2c9f4e2343f1082a376b299f.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_cheese_depth.png-71cbe5ab2c9f4e2343f1082a376b299f.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_cheese_normal.png.import
+++ b/3d/material_testers/test_materials/texture_cheese_normal.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://drcrcryt6g6al"
-path.s3tc="res://.godot/imported/texture_cheese_normal.png-cfbb1f914512de34b962a84fd60e3641.s3tc.ctex"
+path="res://.godot/imported/texture_cheese_normal.png-cfbb1f914512de34b962a84fd60e3641.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_cheese_normal.png"
-dest_files=["res://.godot/imported/texture_cheese_normal.png-cfbb1f914512de34b962a84fd60e3641.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_cheese_normal.png-cfbb1f914512de34b962a84fd60e3641.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_rock_albedo.png.import
+++ b/3d/material_testers/test_materials/texture_rock_albedo.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://chkhlqxtypsgd"
-path.s3tc="res://.godot/imported/texture_rock_albedo.png-02df27b2a7e2344422e9ac7cdaec70ee.s3tc.ctex"
+path="res://.godot/imported/texture_rock_albedo.png-02df27b2a7e2344422e9ac7cdaec70ee.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_rock_albedo.png"
-dest_files=["res://.godot/imported/texture_rock_albedo.png-02df27b2a7e2344422e9ac7cdaec70ee.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_rock_albedo.png-02df27b2a7e2344422e9ac7cdaec70ee.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_rock_ao.png.import
+++ b/3d/material_testers/test_materials/texture_rock_ao.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cyqj8mjgx816d"
-path.s3tc="res://.godot/imported/texture_rock_ao.png-b7008000c4f1458c49be4996848f1a6e.s3tc.ctex"
+path="res://.godot/imported/texture_rock_ao.png-b7008000c4f1458c49be4996848f1a6e.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_rock_ao.png"
-dest_files=["res://.godot/imported/texture_rock_ao.png-b7008000c4f1458c49be4996848f1a6e.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_rock_ao.png-b7008000c4f1458c49be4996848f1a6e.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_rock_depth.png.import
+++ b/3d/material_testers/test_materials/texture_rock_depth.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://c3x34kbl5riq5"
-path.s3tc="res://.godot/imported/texture_rock_depth.png-e02f2dbd984045ed2373ac9f5ad46460.s3tc.ctex"
+path="res://.godot/imported/texture_rock_depth.png-e02f2dbd984045ed2373ac9f5ad46460.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_rock_depth.png"
-dest_files=["res://.godot/imported/texture_rock_depth.png-e02f2dbd984045ed2373ac9f5ad46460.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_rock_depth.png-e02f2dbd984045ed2373ac9f5ad46460.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_rock_metal.png.import
+++ b/3d/material_testers/test_materials/texture_rock_metal.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://drf5vk54emlea"
-path.s3tc="res://.godot/imported/texture_rock_metal.png-53fdacd914e7bfa258d07a88f0644507.s3tc.ctex"
+path="res://.godot/imported/texture_rock_metal.png-53fdacd914e7bfa258d07a88f0644507.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_rock_metal.png"
-dest_files=["res://.godot/imported/texture_rock_metal.png-53fdacd914e7bfa258d07a88f0644507.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_rock_metal.png-53fdacd914e7bfa258d07a88f0644507.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_rock_normal.png.import
+++ b/3d/material_testers/test_materials/texture_rock_normal.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://vmfa0wdc1t8n"
-path.s3tc="res://.godot/imported/texture_rock_normal.png-c5ae054e70e4a6414518c2178ea9b0b7.s3tc.ctex"
+path="res://.godot/imported/texture_rock_normal.png-c5ae054e70e4a6414518c2178ea9b0b7.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_rock_normal.png"
-dest_files=["res://.godot/imported/texture_rock_normal.png-c5ae054e70e4a6414518c2178ea9b0b7.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_rock_normal.png-c5ae054e70e4a6414518c2178ea9b0b7.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/texture_wood.png.import
+++ b/3d/material_testers/test_materials/texture_wood.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://c8gaxgw81rn5m"
-path.s3tc="res://.godot/imported/texture_wood.png-e3109b4e15fb09c6edce5029c4f30771.s3tc.ctex"
+path="res://.godot/imported/texture_wood.png-e3109b4e15fb09c6edce5029c4f30771.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/texture_wood.png"
-dest_files=["res://.godot/imported/texture_wood.png-e3109b4e15fb09c6edce5029c4f30771.s3tc.ctex"]
+dest_files=["res://.godot/imported/texture_wood.png-e3109b4e15fb09c6edce5029c4f30771.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/wool_albedo.png.import
+++ b/3d/material_testers/test_materials/wool_albedo.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bmdw1rtlv8ij3"
-path.s3tc="res://.godot/imported/wool_albedo.png-a41e4f37762b4ccb66c8b36c42febef1.s3tc.ctex"
+path="res://.godot/imported/wool_albedo.png-a41e4f37762b4ccb66c8b36c42febef1.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/wool_albedo.png"
-dest_files=["res://.godot/imported/wool_albedo.png-a41e4f37762b4ccb66c8b36c42febef1.s3tc.ctex"]
+dest_files=["res://.godot/imported/wool_albedo.png-a41e4f37762b4ccb66c8b36c42febef1.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/wool_depth.png.import
+++ b/3d/material_testers/test_materials/wool_depth.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bayryamoxiov5"
-path.s3tc="res://.godot/imported/wool_depth.png-47d3fa1d6b4aa0857f735cbad6b1556e.s3tc.ctex"
+path="res://.godot/imported/wool_depth.png-47d3fa1d6b4aa0857f735cbad6b1556e.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/wool_depth.png"
-dest_files=["res://.godot/imported/wool_depth.png-47d3fa1d6b4aa0857f735cbad6b1556e.s3tc.ctex"]
+dest_files=["res://.godot/imported/wool_depth.png-47d3fa1d6b4aa0857f735cbad6b1556e.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/test_materials/wool_normal.png.import
+++ b/3d/material_testers/test_materials/wool_normal.png.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b0t0oeh8bp1iv"
-path.s3tc="res://.godot/imported/wool_normal.png-e7a5ef7bc0ad8d444a32a136bf5d4f12.s3tc.ctex"
+path="res://.godot/imported/wool_normal.png-e7a5ef7bc0ad8d444a32a136bf5d4f12.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://test_materials/wool_normal.png"
-dest_files=["res://.godot/imported/wool_normal.png-e7a5ef7bc0ad8d444a32a136bf5d4f12.s3tc.ctex"]
+dest_files=["res://.godot/imported/wool_normal.png-e7a5ef7bc0ad8d444a32a136bf5d4f12.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/3d/material_testers/tester.gd
+++ b/3d/material_testers/tester.gd
@@ -52,6 +52,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		# Compensate motion speed to be resolution-independent (based on the window height).
 		var relative_motion: Vector2 = event.relative * DisplayServer.window_get_size().y / base_height
 		rot_y -= relative_motion.x * ROT_SPEED
+		rot_y = clamp(rot_y, -1.95, 1.95)
 		rot_x -= relative_motion.y * ROT_SPEED
 		rot_x = clamp(rot_x, -1.4, 0.45)
 		camera_holder.transform.basis = Basis.from_euler(Vector3(0, rot_y, 0))
@@ -91,6 +92,27 @@ func _on_bg_item_selected(index: int) -> void:
 	var sky_material: PanoramaSkyMaterial = $WorldEnvironment.environment.sky.sky_material
 
 	sky_material.panorama = load(backgrounds[index].path)
+
+	# Force reflection probes to update by moving them slightly.
+	for reflection_probe: ReflectionProbe in get_tree().get_nodes_in_group(&"reflection_probe"):
+		reflection_probe.position.y += randf_range(-0.0001, 0.0001)
+
+
+func _on_reflection_probes_item_selected(index: int) -> void:
+	match index:
+		0:  # No Reflection Probes
+			for reflection_probe: ReflectionProbe in get_tree().get_nodes_in_group(&"reflection_probe"):
+				reflection_probe.visible = false
+
+		1:  # Reflection Probes (Reflection only)
+			for reflection_probe: ReflectionProbe in get_tree().get_nodes_in_group(&"reflection_probe"):
+				reflection_probe.visible = true
+				reflection_probe.ambient_mode = ReflectionProbe.AMBIENT_DISABLED
+
+		2:  # Reflection Probes (Reflection + Ambient)
+			for reflection_probe: ReflectionProbe in get_tree().get_nodes_in_group(&"reflection_probe"):
+				reflection_probe.visible = true
+				reflection_probe.ambient_mode = ReflectionProbe.AMBIENT_ENVIRONMENT
 
 
 func _on_quit_pressed() -> void:


### PR DESCRIPTION
- Add reflection probes for each test sphere, which can be toggled using a new dropdown with 3 options (no reflection probe, reflection only, reflection + ambient). The cull and reflection masks are configured on each reflection probe so that spheres don't self-reflect, but other spheres still appear in each sphere's reflections. Probe extents are made very large to prevent any visible fading, and the test beds don't receive the reflection probe's ambient or reflection.
- Improve ice material visuals by giving it some opacity.
- Use lossless compression on all textures, as their relatively low resolution and count by today's standards makes them not use much VRAM anyway.

Don't cherry-pick to 4.2, as this will only work in 4.3 since this requires https://github.com/godotengine/godot/pull/86073 to look correct.

## Preview

![No Reflection Probes](https://github.com/godotengine/godot-demo-projects/assets/180032/0632b32f-b253-4002-b196-34cb4889abcc)

![Reflection Probes (Reflection only)](https://github.com/godotengine/godot-demo-projects/assets/180032/79d5e0b1-d038-459b-aef4-10be93c35c0b)

![Reflection Probes (Reflection + Ambient)](https://github.com/godotengine/godot-demo-projects/assets/180032/7f39dfdb-6b26-4ea1-bd2b-f445201bc6c4)
