### PR TITLE
Update Mono Pong

### DIFF
--- a/mono/pong/Logic/Ball.cs
+++ b/mono/pong/Logic/Ball.cs
@@ -1,10 +1,12 @@
+using System;
 using Godot;
 
 public partial class Ball : Area2D
 {
+    private readonly Random _random = new();
     private const int DefaultSpeed = 100;
 
-    public Vector2 direction = Vector2.Left;
+    public Vector2 direction;
 
     private Vector2 _initialPos;
     private double _speed = DefaultSpeed;
@@ -12,18 +14,24 @@ public partial class Ball : Area2D
     public override void _Ready()
     {
         _initialPos = Position;
+        direction = this.NewRandomDirection();
     }
 
     public override void _Process(double delta)
     {
-        _speed += delta * 2;
+        _speed += delta * 5;
         Position += (float)(_speed * delta) * direction;
     }
 
     public void Reset()
     {
-        direction = Vector2.Left;
+        direction = this.NewRandomDirection();
         Position = _initialPos;
         _speed = DefaultSpeed;
+    }
+
+    public Vector2 NewRandomDirection()
+    {
+        return new Vector2((float)(this._random.NextDouble() * 2f - 1f), (float)(this._random.NextDouble() * 2f - 1f)).Normalized();
     }
 }

--- a/mono/pong/Logic/Ball.cs
+++ b/mono/pong/Logic/Ball.cs
@@ -19,7 +19,7 @@ public partial class Ball : Area2D
 
     public override void _Process(double delta)
     {
-        _speed += delta * 5;
+        _speed += delta * 4;
         Position += (float)(_speed * delta) * direction;
     }
 

--- a/mono/pong/Logic/Ball.cs
+++ b/mono/pong/Logic/Ball.cs
@@ -6,7 +6,7 @@ public partial class Ball : Area2D
     private readonly Random _random = new();
     private const int DefaultSpeed = 100;
 
-    public Vector2 direction;
+    public Vector2 Direction { get; set; }
 
     private Vector2 _initialPos;
     private double _speed = DefaultSpeed;
@@ -14,24 +14,24 @@ public partial class Ball : Area2D
     public override void _Ready()
     {
         _initialPos = Position;
-        direction = this.NewRandomDirection();
+        Direction = this.NewRandomDirection();
     }
 
     public override void _Process(double delta)
     {
         _speed += delta * 4;
-        Position += (float)(_speed * delta) * direction;
+        Position += (float)(_speed * delta) * Direction;
     }
 
     public void Reset()
     {
-        direction = this.NewRandomDirection();
+        Direction = this.NewRandomDirection();
         Position = _initialPos;
         _speed = DefaultSpeed;
     }
 
     public Vector2 NewRandomDirection()
     {
-        return new Vector2((float)(this._random.NextDouble() * 2f - 1f), (float)(this._random.NextDouble() * 2f - 1f)).Normalized();
+        return new Vector2(this._random.NextSingle() * 2f - 1f, this._random.NextSingle() * 2f - 1f).Normalized();
     }
 }

--- a/mono/pong/Logic/CeilingFloor.cs
+++ b/mono/pong/Logic/CeilingFloor.cs
@@ -6,7 +6,7 @@ public partial class CeilingFloor : Area2D
 	{
 		if (area is Ball ball)
 		{
-			ball.direction = new Vector2(ball.direction.X, -ball.direction.Y);
+			ball.Direction = new Vector2(ball.Direction.X, -ball.Direction.Y);
 		}
 	}
 }

--- a/mono/pong/Logic/CeilingFloor.cs
+++ b/mono/pong/Logic/CeilingFloor.cs
@@ -2,14 +2,11 @@ using Godot;
 
 public partial class CeilingFloor : Area2D
 {
-    [Export]
-    private int _bounceDirection = 1;
-
-    public void OnAreaEntered(Area2D area)
-    {
-        if (area is Ball ball)
-        {
-            ball.direction = (ball.direction + new Vector2(0, _bounceDirection)).Normalized();
-        }
-    }
+	public void OnAreaEntered(Area2D area)
+	{
+		if (area is Ball ball)
+		{
+			ball.direction = new Vector2(ball.direction.X, -ball.direction.Y);
+		}
+	}
 }

--- a/mono/pong/Logic/Paddle.cs
+++ b/mono/pong/Logic/Paddle.cs
@@ -3,37 +3,39 @@ using System;
 
 public partial class Paddle : Area2D
 {
-    private const int MoveSpeed = 100;
+	private const int MoveSpeed = 150;
 
-    // All three of these change for each paddle.
-    private int _ballDir;
-    private string _up;
-    private string _down;
+	// All three of these change for each paddle.
+	private int _ballDir;
+	private string _up;
+	private string _down;
 
-    public override void _Ready()
-    {
-        string name = Name.ToString().ToLower();
-        _up = name + "_move_up";
-        _down = name + "_move_down";
-        _ballDir = name == "left" ? 1 : -1;
-    }
+	public override void _Ready()
+	{
+		string name = Name.ToString().ToLower();
+		_up = name + "_move_up";
+		_down = name + "_move_down";
+		_ballDir = name == "left" ? 1 : -1;
+	}
 
-    public override void _Process(double delta)
-    {
-        // Move up and down based on input.
-        float input = Input.GetActionStrength(_down) - Input.GetActionStrength(_up);
-        Vector2 position = Position; // Required so that we can modify position.y.
-        position += new Vector2(0, input * MoveSpeed * (float)delta);
-        position = new(position.X, Mathf.Clamp(position.Y, 16, GetViewportRect().Size.X - 16));
-        Position = position;
-    }
+	public override void _Process(double delta)
+	{
+		// Move up and down based on input.
+		float input = Input.GetActionStrength(_down) - Input.GetActionStrength(_up);
+		Vector2 position = Position; // Required so that we can modify position.y.
+		position += new Vector2(0, input * MoveSpeed * (float)delta);
+		position = new(position.X, Mathf.Clamp(position.Y, 16, GetViewportRect().Size.Y - 16));
+		Position = position;
+	}
 
-    public void OnAreaEntered(Area2D area)
-    {
-        if (area is Ball ball)
-        {
-            // Assign new direction
-            ball.direction = new Vector2(_ballDir, ((float)new Random().NextDouble()) * 2 - 1).Normalized();
-        }
-    }
+	public void OnAreaEntered(Area2D area)
+	{
+		if (area is Ball ball)
+		{
+			float diff = ball.GlobalPosition.Y - this.GlobalPosition.Y;
+			diff /= this.ShapeOwnerGetShape(0, 0).GetRect().Size.Y / 2;
+			// Assign new direction
+			ball.direction = new Vector2(_ballDir, diff).Normalized();
+		}
+	}
 }

--- a/mono/pong/Logic/Paddle.cs
+++ b/mono/pong/Logic/Paddle.cs
@@ -3,39 +3,39 @@ using System;
 
 public partial class Paddle : Area2D
 {
-	private const int MoveSpeed = 150;
+    private const int MoveSpeed = 150;
 
-	// All three of these change for each paddle.
-	private int _ballDir;
-	private string _up;
-	private string _down;
+    // All three of these change for each paddle.
+    private int _ballDir;
+    private string _up;
+    private string _down;
 
-	public override void _Ready()
-	{
-		string name = Name.ToString().ToLower();
-		_up = name + "_move_up";
-		_down = name + "_move_down";
-		_ballDir = name == "left" ? 1 : -1;
-	}
+    public override void _Ready()
+    {
+        string name = Name.ToString().ToLower();
+        _up = name + "_move_up";
+        _down = name + "_move_down";
+        _ballDir = name == "left" ? 1 : -1;
+    }
 
-	public override void _Process(double delta)
-	{
-		// Move up and down based on input.
-		float input = Input.GetActionStrength(_down) - Input.GetActionStrength(_up);
-		Vector2 position = Position; // Required so that we can modify position.y.
-		position += new Vector2(0, input * MoveSpeed * (float)delta);
-		position = new(position.X, Mathf.Clamp(position.Y, 16, GetViewportRect().Size.Y - 16));
-		Position = position;
-	}
+    public override void _Process(double delta)
+    {
+        // Move up and down based on input.
+        float input = Input.GetActionStrength(_down) - Input.GetActionStrength(_up);
+        Vector2 position = Position; // Required so that we can modify position.y.
+        position += new Vector2(0, input * MoveSpeed * (float)delta);
+        position = new(position.X, Mathf.Clamp(position.Y, 16, GetViewportRect().Size.Y - 16));
+        Position = position;
+    }
 
-	public void OnAreaEntered(Area2D area)
-	{
-		if (area is Ball ball)
-		{
-			float diff = ball.GlobalPosition.Y - this.GlobalPosition.Y;
-			diff /= this.ShapeOwnerGetShape(0, 0).GetRect().Size.Y / 2;
-			// Assign new direction
-			ball.direction = new Vector2(_ballDir, diff).Normalized();
-		}
-	}
+    public void OnAreaEntered(Area2D area)
+    {
+        if (area is Ball ball)
+        {
+            float diff = ball.GlobalPosition.Y - this.GlobalPosition.Y;
+            diff /= this.ShapeOwnerGetShape(0, 0).GetRect().Size.Y / 2;
+            // Assign new direction
+            ball.Direction = new Vector2(_ballDir, diff).Normalized();
+        }
+    }
 }

--- a/mono/pong/pong.tscn
+++ b/mono/pong/pong.tscn
@@ -9,16 +9,16 @@
 [ext_resource type="Script" path="res://Logic/CeilingFloor.cs" id="8"]
 
 [sub_resource type="RectangleShape2D" id="1"]
-size = Vector2(4, 16)
+size = Vector2(8, 32)
 
-[sub_resource type="RectangleShape2D" id="2"]
-size = Vector2(4, 4)
+[sub_resource type="CircleShape2D" id="CircleShape2D_syhn3"]
+radius = 4.0
 
 [sub_resource type="RectangleShape2D" id="3"]
-size = Vector2(10, 200)
+size = Vector2(10, 400)
 
 [sub_resource type="RectangleShape2D" id="4"]
-size = Vector2(320, 10)
+size = Vector2(640, 9)
 
 [node name="Pong" type="Node2D"]
 
@@ -57,7 +57,7 @@ script = ExtResource("4")
 texture = ExtResource("5")
 
 [node name="Collision" type="CollisionShape2D" parent="Ball"]
-shape = SubResource("2")
+shape = SubResource("CircleShape2D_syhn3")
 
 [node name="Separator" type="Sprite2D" parent="."]
 position = Vector2(320, 200)
@@ -70,6 +70,7 @@ position = Vector2(-10, 200)
 script = ExtResource("7")
 
 [node name="Collision" type="CollisionShape2D" parent="LeftWall"]
+position = Vector2(5, 0)
 shape = SubResource("3")
 
 [node name="RightWall" type="Area2D" parent="."]
@@ -77,6 +78,7 @@ position = Vector2(650, 200)
 script = ExtResource("7")
 
 [node name="Collision" type="CollisionShape2D" parent="RightWall"]
+position = Vector2(-5, 0)
 shape = SubResource("3")
 
 [node name="Ceiling" type="Area2D" parent="."]
@@ -84,14 +86,15 @@ position = Vector2(320, -10)
 script = ExtResource("8")
 
 [node name="Collision" type="CollisionShape2D" parent="Ceiling"]
+position = Vector2(0, 5)
 shape = SubResource("4")
 
 [node name="Floor" type="Area2D" parent="."]
 position = Vector2(320, 410)
 script = ExtResource("8")
-_bounceDirection = -1
 
 [node name="Collision" type="CollisionShape2D" parent="Floor"]
+position = Vector2(0, -6)
 shape = SubResource("4")
 
 [connection signal="area_entered" from="Left" to="Left" method="OnAreaEntered"]


### PR DESCRIPTION
## Scene
The scene had some problems:
All the collision node were twice as small as they should have. Not sure if it's due to an update in the engine.
![image](https://github.com/godotengine/godot-demo-projects/assets/7185104/6e691460-1253-4731-abf3-a7c49c67cb38)
So the collisions are now bigger (2x exactly) to cover the whole sprite, and I've changed the ball collision shape to a sphere.

## Ceiling and Floor
The ceiling was just transposing the angle of the ball by 90°, I've changed it to actually bounce back.

## Paddle
The paddles have been made faster in movement (+50%) and now bounce the ball back based off the position of the collision.

## Ball
Ball now speeds up faster and picks a new random direction and angle when the game starts or resets.