### PR TITLE
KinematicBody2D → CharacterBody2D in README.md

### DIFF
--- a/2d/platformer/README.md
+++ b/2d/platformer/README.md
@@ -23,7 +23,7 @@ Check out this demo on the asset library: https://godotengine.org/asset-library/
 
 ## Features
 
-- Side-scrolling player controller using [`KinematicBody2D`](https://docs.godotengine.org/en/latest/classes/class_kinematicbody2d.html).
+- Side-scrolling player controller using [`CharacterBody2D`](https://docs.godotengine.org/en/stable/classes/class_characterbody2d.html).
     - Can walk on and snap to slopes.
     - Can shoot, including while jumping.
 - Enemies that crawl on the floor and change direction when they encounter an obstacle.


### PR DESCRIPTION
Changed the reference from [`KinematicBody2D`](https://docs.godotengine.org/en/latest/classes/class_kinematicbody2d.html) to [`CharacterBody2D`](https://docs.godotengine.org/en/stable/classes/class_characterbody2d.html) in README.md.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
