### PR TITLE
Add FSR 2.2, exclusive fullscreen and ultra quality SSAO and SSIL to graphics settings demo

### DIFF
--- a/3d/graphics_settings/control.tscn
+++ b/3d/graphics_settings/control.tscn
@@ -169,12 +169,14 @@ text = "Display Filter:"
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
-item_count = 2
+item_count = 3
 selected = 0
 popup/item_0/text = "Bilinear (Fastest)"
 popup/item_0/id = 0
 popup/item_1/text = "FSR 1.0 (Fast)"
 popup/item_1/id = 1
+popup/item_2/text = "FSR 2.2 (Slow)"
+popup/item_2/id = 2
 
 [node name="FSRSharpnessLabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
 unique_name_in_owner = true

--- a/3d/graphics_settings/control.tscn
+++ b/3d/graphics_settings/control.tscn
@@ -206,12 +206,14 @@ text = "Fullscreen:"
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
-item_count = 2
+item_count = 3
 selected = 0
 popup/item_0/text = "Disabled"
 popup/item_0/id = 0
 popup/item_1/text = "Enabled"
 popup/item_1/id = 1
+popup/item_2/text = "Exclusive"
+popup/item_2/id = 2
 
 [node name="VsyncLabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
 layout_mode = 2

--- a/3d/graphics_settings/control.tscn
+++ b/3d/graphics_settings/control.tscn
@@ -461,7 +461,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
-item_count = 5
+item_count = 6
 selected = 0
 popup/item_0/text = "Disabled (Fastest)"
 popup/item_0/id = 0
@@ -473,6 +473,8 @@ popup/item_3/text = "Medium (Average)"
 popup/item_3/id = 3
 popup/item_4/text = "High (Slow)"
 popup/item_4/id = 4
+popup/item_5/text = "Ultra (Slower)"
+popup/item_5/id = 5
 
 [node name="SSReflectionsLabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/Environment"]
 layout_mode = 2
@@ -507,7 +509,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
-item_count = 5
+item_count = 6
 selected = 0
 popup/item_0/text = "Disabled (Fastest)"
 popup/item_0/id = 0
@@ -519,6 +521,8 @@ popup/item_3/text = "Medium (Slow)"
 popup/item_3/id = 3
 popup/item_4/text = "High (Slower)"
 popup/item_4/id = 4
+popup/item_5/text = "Ultra (Slowest)"
+popup/item_5/id = 5
 
 [node name="VolumetricFogLabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/Environment"]
 layout_mode = 2

--- a/3d/graphics_settings/control.tscn
+++ b/3d/graphics_settings/control.tscn
@@ -443,12 +443,14 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
-item_count = 2
+item_count = 3
 selected = 0
 popup/item_0/text = "Disabled (Fastest)"
 popup/item_0/id = 0
-popup/item_1/text = "Enabled (Fast)"
+popup/item_1/text = "Low (Fast)"
 popup/item_1/id = 1
+popup/item_2/text = "High (Average)"
+popup/item_2/id = 2
 
 [node name="SSAOLabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/Environment"]
 layout_mode = 2

--- a/3d/graphics_settings/control.tscn
+++ b/3d/graphics_settings/control.tscn
@@ -443,14 +443,12 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
-item_count = 3
+item_count = 2
 selected = 0
 popup/item_0/text = "Disabled (Fastest)"
 popup/item_0/id = 0
-popup/item_1/text = "Low (Fast)"
+popup/item_1/text = "Enabled (Fast)"
 popup/item_1/id = 1
-popup/item_2/text = "High (Average)"
-popup/item_2/id = 2
 
 [node name="SSAOLabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/Environment"]
 layout_mode = 2

--- a/3d/graphics_settings/settings.gd
+++ b/3d/graphics_settings/settings.gd
@@ -83,12 +83,17 @@ func _on_filter_option_button_item_selected(index: int) -> void:
 	# Viewport scale mode setting.
 	if index == 0: # Bilinear (Fastest)
 		get_viewport().scaling_3d_mode = Viewport.SCALING_3D_MODE_BILINEAR
-		# FSR Sharpness is only effective when the scaling mode is FSR 1.0.
+		# FSR Sharpness is only effective when the scaling mode is FSR 1.0 or 2.2.
 		%FSRSharpnessLabel.visible = false
 		%FSRSharpnessSlider.visible = false
 	elif index == 1: # FSR 1.0 (Fast)
 		get_viewport().scaling_3d_mode = Viewport.SCALING_3D_MODE_FSR
-		# FSR Sharpness is only effective when the scaling mode is FSR 1.0.
+		# FSR Sharpness is only effective when the scaling mode is FSR 1.0 or 2.2.
+		%FSRSharpnessLabel.visible = true
+		%FSRSharpnessSlider.visible = true
+	elif index == 2: # FSR 2.2 (Fast)
+		get_viewport().scaling_3d_mode = Viewport.SCALING_3D_MODE_FSR2
+		# FSR Sharpness is only effective when the scaling mode is FSR 1.0 or 2.2.
 		%FSRSharpnessLabel.visible = true
 		%FSRSharpnessSlider.visible = true
 

--- a/3d/graphics_settings/settings.gd
+++ b/3d/graphics_settings/settings.gd
@@ -264,7 +264,7 @@ func _on_ssao_option_button_item_selected(index: int) -> void:
 		RenderingServer.environment_set_ssao_quality(RenderingServer.ENV_SSAO_QUALITY_VERY_LOW, true, 0.5, 2, 50, 300)
 	if index == 2: # Low
 		world_environment.environment.ssao_enabled = true
-		RenderingServer.environment_set_ssao_quality(RenderingServer.ENV_SSAO_QUALITY_VERY_LOW, true, 0.5, 2, 50, 300)
+		RenderingServer.environment_set_ssao_quality(RenderingServer.ENV_SSAO_QUALITY_LOW, true, 0.5, 2, 50, 300)
 	if index == 3: # Medium
 		world_environment.environment.ssao_enabled = true
 		RenderingServer.environment_set_ssao_quality(RenderingServer.ENV_SSAO_QUALITY_MEDIUM, true, 0.5, 2, 50, 300)

--- a/3d/graphics_settings/settings.gd
+++ b/3d/graphics_settings/settings.gd
@@ -271,6 +271,9 @@ func _on_ssao_option_button_item_selected(index: int) -> void:
 	if index == 4: # High
 		world_environment.environment.ssao_enabled = true
 		RenderingServer.environment_set_ssao_quality(RenderingServer.ENV_SSAO_QUALITY_HIGH, true, 0.5, 2, 50, 300)
+	if index == 5: # Ultra
+		world_environment.environment.ssao_enabled = true
+		RenderingServer.environment_set_ssao_quality(RenderingServer.ENV_SSAO_QUALITY_ULTRA, true, 0.5, 2, 50, 300)
 
 
 func _on_ssil_option_button_item_selected(index: int) -> void:
@@ -291,6 +294,9 @@ func _on_ssil_option_button_item_selected(index: int) -> void:
 	if index == 4: # High
 		world_environment.environment.ssil_enabled = true
 		RenderingServer.environment_set_ssil_quality(RenderingServer.ENV_SSIL_QUALITY_HIGH, true, 0.5, 4, 50, 300)
+	if index == 5: # Ultra
+		world_environment.environment.ssil_enabled = true
+		RenderingServer.environment_set_ssil_quality(RenderingServer.ENV_SSIL_QUALITY_ULTRA, true, 0.5, 4, 50, 300)
 
 
 func _on_sdfgi_option_button_item_selected(index: int) -> void:

--- a/3d/graphics_settings/settings.gd
+++ b/3d/graphics_settings/settings.gd
@@ -313,9 +313,7 @@ func _on_glow_option_button_item_selected(index: int) -> void:
 	# then be sure to run this function again to make the setting effective.
 	if index == 0: # Disabled (default)
 		world_environment.environment.glow_enabled = false
-	if index == 1: # Low
-		world_environment.environment.glow_enabled = true
-	if index == 2: # High
+	if index == 1: # Enabled
 		world_environment.environment.glow_enabled = true
 
 

--- a/3d/graphics_settings/settings.gd
+++ b/3d/graphics_settings/settings.gd
@@ -415,7 +415,7 @@ func _on_high_preset_pressed() -> void:
 	%ShadowFilterOptionButton.selected = 3
 	%MeshLODOptionButton.selected = 2
 	%SDFGIOptionButton.selected = 1
-	%GlowOptionButton.selected = 2
+	%GlowOptionButton.selected = 1
 	%SSAOOptionButton.selected = 2
 	%SSReflectionsOptionButton.selected = 2
 	%SSILOptionButton.selected = 2
@@ -431,7 +431,7 @@ func _on_ultra_preset_pressed() -> void:
 	%ShadowFilterOptionButton.selected = 4
 	%MeshLODOptionButton.selected = 3
 	%SDFGIOptionButton.selected = 2
-	%GlowOptionButton.selected = 2
+	%GlowOptionButton.selected = 1
 	%SSAOOptionButton.selected = 3
 	%SSReflectionsOptionButton.selected = 3
 	%SSILOptionButton.selected = 3

--- a/3d/graphics_settings/settings.gd
+++ b/3d/graphics_settings/settings.gd
@@ -319,8 +319,12 @@ func _on_glow_option_button_item_selected(index: int) -> void:
 	# then be sure to run this function again to make the setting effective.
 	if index == 0: # Disabled (default)
 		world_environment.environment.glow_enabled = false
-	if index == 1: # Enabled
+	if index == 1: # Low
 		world_environment.environment.glow_enabled = true
+		RenderingServer.environment_glow_set_use_bicubic_upscale(false)
+	if index == 2: # High
+		world_environment.environment.glow_enabled = true
+		RenderingServer.environment_glow_set_use_bicubic_upscale(true)
 
 
 func _on_volumetric_fog_option_button_item_selected(index: int) -> void:
@@ -415,7 +419,7 @@ func _on_high_preset_pressed() -> void:
 	%ShadowFilterOptionButton.selected = 3
 	%MeshLODOptionButton.selected = 2
 	%SDFGIOptionButton.selected = 1
-	%GlowOptionButton.selected = 1
+	%GlowOptionButton.selected = 2
 	%SSAOOptionButton.selected = 2
 	%SSReflectionsOptionButton.selected = 2
 	%SSILOptionButton.selected = 2
@@ -431,7 +435,7 @@ func _on_ultra_preset_pressed() -> void:
 	%ShadowFilterOptionButton.selected = 4
 	%MeshLODOptionButton.selected = 3
 	%SDFGIOptionButton.selected = 2
-	%GlowOptionButton.selected = 1
+	%GlowOptionButton.selected = 2
 	%SSAOOptionButton.selected = 3
 	%SSReflectionsOptionButton.selected = 3
 	%SSILOptionButton.selected = 3


### PR DESCRIPTION
FSR 2.2 was added in 4.2 and this demo only has the option to use FSR 1.0, this adds an option to use it.
The exclusive fullscreen option had code to be enabled but not an item in the option button, this PR adds the missing item.     
Bloom had a redundant high option, which did the exact same thing as the low option. This PR renames low to enabled and removes high.  
SSAO and SSIL quality enums also have a value for ultra quality, which weren't used. This PR adds them as options.