### PR TITLE
Add JetBrains IDE files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ mono_crash.*.json
 .DS_Store
 *~
 *.blend1
+
+# Jetbrains IDE files
+.idea/


### PR DESCRIPTION
For reference, this exists in other godotengine repositories. Examples:

* https://github.com/godotengine/godot/blob/master/.gitignore#L157
* https://github.com/godotengine/godot-docs/blob/master/.gitignore#L52

