### PR TITLE
Add full license info for voxel textures

### DIFF
--- a/3d/voxel/README.md
+++ b/3d/voxel/README.md
@@ -66,7 +66,8 @@ https://creativecommons.org/publicdomain/zero/1.0/
 
 Font is "TinyUnicode" by DuffsDevice. Copyright &copy; DuffsDevice, CC-BY (Attribution) http://www.pentacom.jp/pentacom/bitfontmaker2/gallery/?id=468
 
-### Copyright info for textures reused from Minetest Game
+### Copyright information for textures reused from Minetest Game
+
 While most textures are under CC BY-SA 3.0, some are under CC0 1.0
 
 Cisoun's texture pack (CC BY-SA 3.0):

--- a/3d/voxel/README.md
+++ b/3d/voxel/README.md
@@ -54,7 +54,102 @@ use Zylann's voxel module instead: https://github.com/Zylann/godot_voxel
 
 ## Licenses
 
-Textures are from [Minetest](https://www.minetest.net/). Copyright &copy; 2010-2018 Minetest contributors, CC BY-SA 3.0 Unported (Attribution-ShareAlike)
+Textures are from [Minetest Game](https://github.com/minetest/minetest_game).
+
+Some textures Copyright &copy; 2010-2018 Minetest contributors,
+ CC BY-SA 3.0 Unported (Attribution-ShareAlike)
 http://creativecommons.org/licenses/by-sa/3.0/
 
+Some textures Copyright &copy; 2010-2018 Minetest contributors,
+ CC0 1.0 "No rights reserved"
+https://creativecommons.org/publicdomain/zero/1.0/
+
 Font is "TinyUnicode" by DuffsDevice. Copyright &copy; DuffsDevice, CC-BY (Attribution) http://www.pentacom.jp/pentacom/bitfontmaker2/gallery/?id=468
+
+### Copyright info for textures reused from Minetest Game
+While most textures are under CC BY-SA 3.0, some are under CC0 1.0
+
+Cisoun's texture pack (CC BY-SA 3.0):
+
+  * default\_stone.png
+  * default\_leaves.png
+  * default\_leaves\_simple.png
+  * default\_tree.png
+  * default\_tree\_top.png
+
+celeron55, Perttu Ahola <celeron55@gmail.com> (CC BY-SA 3.0)
+
+  * default\_mineral\_iron.png
+  * default\_mineral\_coal.png
+  * default\_bookshelf.png
+
+VanessaE (CC BY-SA 3.0):
+
+  * default\_sand.png
+
+Calinou (CC BY-SA 3.0):
+
+  * default\_brick.png
+
+PilzAdam (CC BY-SA 3.0):
+
+  * default\_mineral\_gold.png
+
+jojoa1997 (CC BY-SA 3.0):
+
+  * default\_obsidian.png
+
+InfinityProject (CC BY-SA 3.0):
+
+  * default\_mineral\_diamond.png
+
+Zeg9 (CC BY-SA 3.0):
+
+  * default\_coal\_block.png
+
+paramat (CC BY-SA 3.0):
+
+  * default\_bush\_stem.png
+  * default\_grass\_side.png -- Derived from a texture by TumeniNodes (CC-BY-SA 3.0)
+  * default\_mese\_block.png
+
+TumeniNodes (CC BY-SA 3.0):
+
+  * default\_grass.png
+
+Blockmen (CC BY-SA 3.0):
+
+  * default\_wood.png
+
+sofar (CC0 1.0):
+
+  * default\_gravel.png -- Derived from Gambit's PixelBOX texture pack light gravel
+
+Neuromancer (CC BY-SA 3.0):
+
+  * default\_furnace\_bottom.png
+  * default\_furnace\_side.png
+  * default\_cobble.png, based on texture by Brane praefect
+  * default\_mossycobble.png, based on texture by Brane praefect
+
+Gambit (CC BY-SA 3.0):
+
+  * default\_diamond\_block.png
+
+kilbith (CC BY-SA 3.0):
+
+  * default\_steel\_block.png
+  * default\_gold\_block.png
+  * default\_mineral\_tin.png
+
+Mossmanikin (CC BY-SA 3.0):
+
+  * default\_fern\_3.png
+
+random-geek (CC BY-SA 3.0):
+
+  * default\_dirt.png -- Derived from a texture by Neuromancer (CC BY-SA 3.0)
+
+Krock (CC0 1.0):
+
+  * default\_glass.png


### PR DESCRIPTION
Add full license info for voxel textures

Hello,

The textures in the Voxel Demo were included from [Minetest Game](https://github.com/minetest/minetest_game/) ("MTG") for [Minetest](minetest.net/) without "full" attribution of the authors. The attribution information needs to be present since the files are under CC BY-SA 3.0.

Although a general attribution was given to the "Minetest Contributors", I thought it was worth noting the original authors of each file that was used, and noting that some are actually under CC0. This info was supplied in a [README](https://github.com/minetest/minetest_game/blob/master/mods/default/README.txt).

Although CC0 is compatible with CC BY-SA 3.0 and the whole work can be received under CC BY-SA 3.0, it would be good for people to know there are parts they can reuse with less restriction. I think the current wording and linking to "MTG" makes it clear enough if someone wants to attempt such reuse.