### PR TITLE
Fix VRAM leak in compositor effect demo

### DIFF
--- a/compute/post_shader/post_process_grayscale.gd
+++ b/compute/post_shader/post_process_grayscale.gd
@@ -19,7 +19,7 @@ func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
 		if shader.is_valid():
 			# Freeing our shader will also free any dependents such as the pipeline!
-			RenderingServer.free_rid(shader)
+			rd.free_rid(shader)
 
 
 #region Code in this region runs on the rendering thread.

--- a/compute/post_shader/post_process_shader.gd
+++ b/compute/post_shader/post_process_shader.gd
@@ -58,7 +58,7 @@ func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:
 		if shader.is_valid():
 			# Freeing our shader will also free any dependents such as the pipeline!
-			RenderingServer.free_rid(shader)
+			rd.free_rid(shader)
 
 
 #region Code in this region runs on the rendering thread.


### PR DESCRIPTION
The compositor effect demo was attempting to free data created by a RenderingDevice using the RenderingServer. RenderingDevice RIDs are not the same as RenderingServer RIDs, and can't be freed by the RenderingServer.