### PR TITLE
Improve Operating System Testing demo

### DIFF
--- a/misc/os_test/CSharpTest.cs
+++ b/misc/os_test/CSharpTest.cs
@@ -6,22 +6,16 @@ public partial class CSharpTest : Node
     {
 #if GODOT_WINDOWS
         return "Windows";
-#elif GODOT_LINUXBSD || GODOT_X11
-        return "Linux (or BSD)";
-#elif GODOT_SERVER
-        return "Server (Linux or BSD)";
-#elif GODOT_MACOS || GODOT_OSX
+#elif GODOT_LINUXBSD
+        return "Linux/*BSD";
+#elif GODOT_MACOS
         return "macOS";
 #elif GODOT_ANDROID
         return "Android";
 #elif GODOT_IOS
         return "iOS";
-#elif GODOT_HTML5
-        return "HTML5";
-#elif GODOT_HAIKU
-        return "Haiku";
-#elif GODOT_UWP
-        return "UWP (Windows 10)";
+#elif GODOT_WEB
+        return "Web";
 #elif GODOT
         return "Other";
 #else

--- a/misc/os_test/actions.gd
+++ b/misc/os_test/actions.gd
@@ -14,7 +14,7 @@ func _on_open_shell_folder_pressed() -> void:
 		# MacOS-specific.
 		path = "file://" + path
 
-	OS.shell_open(path)
+	OS.shell_show_in_file_manager(path)
 
 
 func _on_change_window_title_pressed() -> void:

--- a/misc/os_test/os_test.gd
+++ b/misc/os_test/os_test.gd
@@ -3,6 +3,10 @@ extends Node
 @onready var rtl: RichTextLabel = $HBoxContainer/Features
 @onready var csharp_test: Node = $CSharpTest
 
+# Line number for alternate line coloring. Incremented by 1 each time a line is added
+# (ignoring headers).
+var line_count := 0
+
 # Returns a human-readable string from a date and time, date, or time dictionary.
 func datetime_to_string(date: Dictionary) -> void:
 	if (
@@ -38,7 +42,11 @@ func datetime_to_string(date: Dictionary) -> void:
 		})
 
 
-func scan_midi_devices() -> String:
+func scan_midi_inputs() -> String:
+	if DisplayServer.get_name() == "headless":
+		# Workaround for <https://github.com/godotengine/godot/issues/52821>.
+		return ""
+
 	OS.open_midi_inputs()
 	var devices := ", ".join(OS.get_connected_midi_inputs())
 	OS.close_midi_inputs()
@@ -46,19 +54,36 @@ func scan_midi_devices() -> String:
 
 
 func add_header(header: String) -> void:
-	rtl.append_text("\n[font_size=24][color=#6df]{header}[/color][/font_size]\n\n".format({
+	rtl.append_text("\n[font_size=24][color=#5cf]{header}[/color][/font_size]\n[font_size=1]\n[/font_size]".format({
 		header = header,
 	}))
 
+	# Also print to the terminal for easy copy-pasting and headless usage.
+	print_rich("\n[b][u][color=blue]{header}[/color][/u][/b]\n".format({
+		header = header,
+	}))
 
 func add_line(key: String, value: Variant) -> void:
-	if typeof(value) == TYPE_BOOL:
+	line_count += 1
+	var original_value: Variant = value
+	if typeof(original_value) == TYPE_BOOL:
 		# Colorize boolean values.
-		value = "[color=8f8]true[/color]" if value else "[color=#f88]false[/color]"
+		value = "[color=6f7]true[/color]" if original_value else "[color=#f76]false[/color]"
 
-	rtl.append_text("[color=#adf]{key}:[/color] {value}\n".format({
+	rtl.append_text("{bgcolor}[color=#9df]{key}:[/color] {value}{bgcolor_end}\n".format({
 		key = key,
 		value = value if str(value) != "" else "[color=#fff8](empty)[/color]",
+		bgcolor = "[bgcolor=#8883]" if line_count % 2 == 0 else "",
+		bgcolor_end = "[/bgcolor]" if line_count % 2 == 0 else "",
+	}))
+	if typeof(original_value) == TYPE_BOOL:
+		# Colorize boolean values (`print_rich()`-friendly version, using basic colors only).
+		value = "[color=green]true[/color]" if original_value else "[color=red]false[/color]"
+
+	# Also print to the terminal for easy copy-pasting and headless usage.
+	print_rich("[b][color=cyan]{key}:[/color][/b] {value}".format({
+		key = key,
+		value = value if str(value) != "" else "[code](empty)[/code]",
 	}))
 
 
@@ -71,8 +96,9 @@ func _ready() -> void:
 	add_line("Output latency", "%f ms" % (AudioServer.get_output_latency() * 1000))
 	add_line("Output device list", ", ".join(AudioServer.get_output_device_list()))
 	add_line("Capture device list", ", ".join(AudioServer.get_input_device_list()))
+	add_line("Connected MIDI inputs", scan_midi_inputs())
 
-	add_header("Date")
+	add_header("Date and time")
 	add_line("Date and time (local)", Time.get_datetime_string_from_system(false, true))
 	add_line("Date and time (UTC)", Time.get_datetime_string_from_system(true, true))
 	add_line("Date (local)", Time.get_date_string_from_system(false))
@@ -103,14 +129,22 @@ func _ready() -> void:
 
 	add_header("Engine")
 	add_line("Version", Engine.get_version_info()["string"])
+	add_line("Compiled for architecture", Engine.get_architecture_name())
 	add_line("Command-line arguments", str(OS.get_cmdline_args()))
 	add_line("Is debug build", OS.is_debug_build())
 	add_line("Executable path", OS.get_executable_path())
 	add_line("User data directory", OS.get_user_data_dir())
 	add_line("Filesystem is persistent", OS.is_userfs_persistent())
+	add_line("Process ID (PID)", OS.get_process_id())
+	add_line("Main thread ID", OS.get_main_thread_id())
+	add_line("Thread caller ID", OS.get_thread_caller_id())
+	add_line("Memory information", OS.get_memory_info())
+	add_line("Static memory usage", OS.get_static_memory_usage())
+	add_line("Static memory peak usage", OS.get_static_memory_peak_usage())
 
 	add_header("Environment")
 	add_line("Value of `PATH`", OS.get_environment("PATH"))
+	# Check for case-sensitivity behavior across platforms.
 	add_line("Value of `path`", OS.get_environment("path"))
 
 	add_header("Hardware")
@@ -128,6 +162,7 @@ func _ready() -> void:
 
 	add_header("Localization")
 	add_line("Locale", OS.get_locale())
+	add_line("Language", OS.get_locale_language())
 
 	add_header("Mobile")
 	add_line("Granted permissions", OS.get_granted_permissions())
@@ -137,15 +172,31 @@ func _ready() -> void:
 	add_line("Mono module enabled", "Yes" if csharp_enabled else "No")
 	if csharp_enabled:
 		csharp_test.set_script(load("res://CSharpTest.cs"))
-		add_line("Operating System", csharp_test.OperatingSystem())
-		add_line("Platform Type", csharp_test.PlatformType())
+		add_line("Operating system", csharp_test.OperatingSystem())
+		add_line("Platform type", csharp_test.PlatformType())
 
 	add_header("Software")
 	add_line("OS name", OS.get_name())
-	add_line("Process ID", OS.get_process_id())
+	add_line("OS version", OS.get_version())
+	add_line("Distribution name", OS.get_distribution_name())
 	add_line("System dark mode supported", DisplayServer.is_dark_mode_supported())
 	add_line("System dark mode enabled", DisplayServer.is_dark_mode())
 	add_line("System accent color", "#%s" % DisplayServer.get_accent_color().to_html())
+	add_line("System fonts", "%d fonts available" % OS.get_system_fonts().size())
+	add_line("System font path (\"sans-serif\")", OS.get_system_font_path("sans-serif"))
+	add_line("System font path (\"sans-serif\") for English text", ", ".join(OS.get_system_font_path_for_text("sans-serif", "Hello")))
+	add_line("System font path (\"sans-serif\") for Chinese text", ", ".join(OS.get_system_font_path_for_text("sans-serif", "你好")))
+	add_line("System font path (\"sans-serif\") for Japanese text", ", ".join(OS.get_system_font_path_for_text("sans-serif", "こんにちは")))
+
+	add_header("Security")
+	add_line("Is sandboxed", OS.is_sandboxed())
+	add_line("Entropy (8 random bytes)", OS.get_entropy(8))
+	add_line("System CA certificates", ("Available (%d bytes)" % OS.get_system_ca_certificates().length()) if not OS.get_system_ca_certificates().is_empty() else "Not available")
+
+	add_header("Engine directories")
+	add_line("User data", OS.get_data_dir())
+	add_line("Configuration", OS.get_config_dir())
+	add_line("Cache", OS.get_cache_dir())
 
 	add_header("System directories")
 	add_line("Desktop", OS.get_system_dir(OS.SYSTEM_DIR_DESKTOP))
@@ -160,13 +211,15 @@ func _ready() -> void:
 	add_header("Video")
 	add_line("Adapter name", RenderingServer.get_video_adapter_name())
 	add_line("Adapter vendor", RenderingServer.get_video_adapter_vendor())
-	add_line("Adapter type", [
-		"Other (Unknown)",
-		"Integrated",
-		"Discrete",
-		"Virtual",
-		"CPU",
-	][RenderingServer.get_video_adapter_type()])
+	if ProjectSettings.get_setting_with_override("rendering/renderer/rendering_method") != "gl_compatibility":
+		# Querying the adapter type isn't supported in Compatibility.
+		add_line("Adapter type", [
+			"Other (Unknown)",
+			"Integrated",
+			"Discrete",
+			"Virtual",
+			"CPU",
+		][RenderingServer.get_video_adapter_type()])
 	add_line("Adapter graphics API version", RenderingServer.get_video_adapter_api_version())
 
 	var video_adapter_driver_info := OS.get_video_adapter_driver_info()

--- a/misc/os_test/os_test.tscn
+++ b/misc/os_test/os_test.tscn
@@ -31,6 +31,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 focus_mode = 2
+theme_override_constants/line_separation = 6
 theme_override_styles/focus = SubResource("StyleBoxEmpty_dl4cr")
 bbcode_enabled = true
 

--- a/misc/os_test/project.godot
+++ b/misc/os_test/project.godot
@@ -19,7 +19,7 @@ In a nutshell, this demo shows how you can get information from the
 operating system, or interact with the operating system."
 config/tags=PackedStringArray("demo", "official", "porting")
 run/main_scene="res://os_test.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
 


### PR DESCRIPTION
- Display more return values of Engine/OS methods such as system fonts, memory information and security information.
- Add headless support (the generated report is also printed to stdout).
  - **Note:** Querying MIDI inputs is disabled when in headless mode to work around https://github.com/godotengine/godot/issues/52821.
- Improve theming in the generated report.
- Hide video adapter type if this information can't be queried in the current rendering method.
- Update C# script for Godot 4.x platform names.

Tested on 4.3.stable.

## Preview

### Stitched report

Full report stitched from multiple screenshots, so you can see it in all it sglory.

![Report](https://github.com/user-attachments/assets/2f75ff85-556e-41b0-a2b8-8881c3f212e6)

### Headless support

From VS Code's integrated terminal:

![image](https://github.com/user-attachments/assets/98e493c7-068a-4d0e-98de-c3251f98902e)
