### PR TITLE
Update some GDScript files

### DIFF
--- a/2d/dynamic_tilemap_layers/level/tile_map.gd
+++ b/2d/dynamic_tilemap_layers/level/tile_map.gd
@@ -42,7 +42,7 @@ func _tile_data_runtime_update(_layer: int, _coords: Vector2i, tile_data: TileDa
 
 
 func _on_secret_detector_body_entered(body: Node2D) -> void:
-	if not body is CharacterBody2D:
+	if body is not CharacterBody2D:
 		# Detect the player only.
 		return
 
@@ -51,7 +51,7 @@ func _on_secret_detector_body_entered(body: Node2D) -> void:
 
 
 func _on_secret_detector_body_exited(body: Node2D) -> void:
-	if not body is CharacterBody2D:
+	if body is not CharacterBody2D:
 		return
 
 	player_in_secret = false

--- a/2d/dynamic_tilemap_layers/project.godot
+++ b/2d/dynamic_tilemap_layers/project.godot
@@ -16,7 +16,7 @@ CharacterBody2D. The character moves around, is affected by moving
 platforms, can jump through one-way collision platforms, etc."
 config/tags=PackedStringArray("2d", "demo", "official", "tilemap")
 run/main_scene="res://world.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.png"
 
 [debug]
@@ -37,25 +37,25 @@ jump={
 "events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 move_left={
 "deadzone": 0.2,
 "events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 move_right={
 "deadzone": 0.2,
 "events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/2d/dynamic_tilemap_layers/world.tscn
+++ b/2d/dynamic_tilemap_layers/world.tscn
@@ -9,8 +9,6 @@
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_vnjib"]
 texture = ExtResource("2")
 0:0/0 = 0
-0:0/0/physics_layer_0/linear_velocity = Vector2(0, 0)
-0:0/0/physics_layer_0/angular_velocity = 0.0
 0:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
 
 [sub_resource type="TileSet" id="TileSet_xqlka"]

--- a/2d/finite_state_machine/player/states/motion/on_ground/on_ground.gd
+++ b/2d/finite_state_machine/player/states/motion/on_ground/on_ground.gd
@@ -1,6 +1,5 @@
 extends "../motion.gd"
 
-# warning-ignore-all:unused_class_variable
 var speed := 0.0
 var velocity := Vector2()
 

--- a/2d/finite_state_machine/state_machine/state.gd
+++ b/2d/finite_state_machine/state_machine/state.gd
@@ -3,7 +3,7 @@ extends Node
 # but forces us to pass the right arguments to the methods below
 # and makes sure every State object had all of these methods.
 
-# warning-ignore:unused_signal
+@warning_ignore("unused_signal")
 signal finished(next_state_name: String)
 
 # Initialize the state. E.g. change the animation.

--- a/2d/isometric/player/goblin.gd
+++ b/2d/isometric/player/goblin.gd
@@ -35,7 +35,6 @@ func _physics_process(_delta):
 	motion.y = Input.get_action_strength("move_down") - Input.get_action_strength("move_up")
 	motion.y /= 2
 	motion = motion.normalized() * MOTION_SPEED
-	#warning-ignore:return_value_discarded
 	set_velocity(motion)
 	move_and_slide()
 	var dir = velocity
@@ -48,7 +47,6 @@ func _physics_process(_delta):
 
 
 func update_animation(anim_set):
-
 	var angle = rad_to_deg(last_direction.angle()) + 22.5
 	var slice_dir = floor(angle / 45)
 

--- a/2d/physics_tests/tests/functional/test_one_way_collision.gd
+++ b/2d/physics_tests/tests/functional/test_one_way_collision.gd
@@ -154,7 +154,7 @@ func _update_platform_size(value: float, reset: bool = true) -> void:
 			var platform_collision := _platform_template.get_child(0)
 			platform_collision.shape.size.x = value
 			if _platform_body:
-				# Bug: need to re-add when changing shape.
+				# BUG: Need to re-add when changing shape.
 				var child_index := _platform_body.get_index()
 				remove_child(_platform_body)
 				add_child(_platform_body)

--- a/2d/role_playing_game/combat/combat.gd
+++ b/2d/role_playing_game/combat/combat.gd
@@ -23,7 +23,8 @@ func clear_combat() -> void:
 
 
 func finish_combat(winner: Combatant, loser: Combatant) -> void:
-	# FIXME: Error calling from signal 'combat_finished' to callable: 'Node(game.gd)::_on_combat_finished': Cannot convert argument 1 from Object to Object.
+	# FIXME: Error calling from signal 'combat_finished' to callable:
+	# 'Node(game.gd)::_on_combat_finished': Cannot convert argument 1 from Object to Object.
 	combat_finished.emit(winner, loser)
 
 

--- a/2d/role_playing_game/combat/turn_queue.gd
+++ b/2d/role_playing_game/combat/turn_queue.gd
@@ -38,7 +38,7 @@ func remove(combatant: Combatant) -> void:
 func set_queue(new_queue: Array[Node]) -> void:
 	queue.clear()
 	for node in new_queue:
-		if not node is Combatant:
+		if node is not Combatant:
 			continue
 		queue.append(node)
 		node.active = false

--- a/2d/role_playing_game/project.godot
+++ b/2d/role_playing_game/project.godot
@@ -16,7 +16,7 @@ and GDScript. It also includes a simple JRPG-style dialogue and
 battle system on top of it."
 config/tags=PackedStringArray("2d", "demo", "gui", "official", "tilemap")
 run/main_scene="res://game.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.svg"
 
 [debug]
@@ -38,32 +38,32 @@ import/blender/enabled=false
 
 move_up={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":122,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":122,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":-1.0,"script":null)
 ]
 }
 move_down={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":1.0,"script":null)
 ]
 }
 move_left={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":113,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":-1.0,"script":null)
 ]
 }
 move_right={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":1.0,"script":null)
 ]

--- a/2d/role_playing_game/theme/fonts/montserrat_extra_bold.otf.import
+++ b/2d/role_playing_game/theme/fonts/montserrat_extra_bold.otf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/montserrat_extra_bold.otf-d2f398ef6213b24fc13
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/3d/squash_the_creeps/Main.gd
+++ b/3d/squash_the_creeps/Main.gd
@@ -9,7 +9,6 @@ func _ready():
 
 func _unhandled_input(event):
 	if event.is_action_pressed("ui_accept") and $UserInterface/Retry.visible:
-		# warning-ignore:return_value_discarded
 		get_tree().reload_current_scene()
 
 

--- a/audio/midi_piano/piano.gd
+++ b/audio/midi_piano/piano.gd
@@ -33,7 +33,7 @@ func _ready() -> void:
 
 
 func _input(input_event: InputEvent) -> void:
-	if not input_event is InputEventMIDI:
+	if input_event is not InputEventMIDI:
 		return
 
 	var midi_event: InputEventMIDI = input_event

--- a/audio/midi_piano/project.godot
+++ b/audio/midi_piano/project.godot
@@ -13,7 +13,7 @@ config_version=5
 config/name="MIDI Piano Demo"
 config/tags=PackedStringArray("audio", "demo", "official")
 run/main_scene="res://piano.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.webp"
 
 [debug]

--- a/gui/gd_paint/paint_control.gd
+++ b/gui/gd_paint/paint_control.gd
@@ -126,8 +126,7 @@ func undo_stroke() -> void:
 		# Figure out how many elements/brushes we've added in the last stroke.
 		var elements_to_remove := brush_data_list.size() - undo_element_list_num
 		# Remove all of the elements we've added this in the last stroke.
-		#warning-ignore:unused_variable
-		for elment_num in elements_to_remove:
+		for _elment_num in elements_to_remove:
 			brush_data_list.pop_back()
 
 		# Now that we've undone a stoke, we cannot undo again until another stoke is added.

--- a/misc/2.5d/addons/node25d/.broken-gdscripts/Basis25D.gd
+++ b/misc/2.5d/addons/node25d/.broken-gdscripts/Basis25D.gd
@@ -3,7 +3,7 @@
 # https://github.com/godotengine/godot-proposals/issues/279
 
 # Basis25D structure for performing 2.5D transform math.
-# Note: All code assumes that Y is UP in 3D, and DOWN in 2D.
+# NOTE: All code assumes that Y is UP in 3D, and DOWN in 2D.
 # Meaning, a top-down view has a Y axis component of (0, 0), with a Z axis component of (0, 1).
 # For a front side view, Y is (0, -1) and Z is (0, 0).
 # Remember that Godot's 2D mode has the Y axis pointing DOWN on the screen.

--- a/misc/2.5d/addons/node25d/y_sort_25d.gd
+++ b/misc/2.5d/addons/node25d/y_sort_25d.gd
@@ -5,7 +5,7 @@
 @tool
 @icon("res://addons/node25d/icons/y_sort_25d_icon.png")
 class_name YSort25D
-extends Node  # NOTE: NOT Node2D, Node25D, or Node2D
+extends Node  # NOTE: NOT Node2D or Node25D.
 
 
 # Whether or not to automatically call sort() in _process().

--- a/misc/2.5d/assets/player/player_sprite.gd
+++ b/misc/2.5d/assets/player/player_sprite.gd
@@ -88,7 +88,8 @@ func _sprite_basis() -> void:
 
 # This method returns a bool but if true it also outputs to the direction variable.
 func _check_movement() -> bool:
-	# Gather player input and store movement to these int variables. Note: These indeed have to be integers.
+	# Gather player input and store movement to these int variables.
+	# NOTE: These indeed have to be integers.
 	var x := 0
 	var z := 0
 

--- a/misc/joypads/project.godot
+++ b/misc/joypads/project.godot
@@ -14,7 +14,7 @@ config/name="Joypads"
 config/description="A tool for testing joypad input."
 config/tags=PackedStringArray("demo", "gui", "input", "official")
 run/main_scene="res://joypads.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
 

--- a/misc/joypads/remap/remap_wizard.gd
+++ b/misc/joypads/remap/remap_wizard.gd
@@ -24,7 +24,7 @@ func _input(event: InputEvent) -> void:
 		return
 
 	# Ignore events not related to gamepads.
-	if not (event is InputEventJoypadButton or event is InputEventJoypadMotion):
+	if event is not InputEventJoypadButton and event is not InputEventJoypadMotion:
 		return
 
 	# Ignore devices other than the one being remapped. Handles accidental input and analog drift.

--- a/networking/multiplayer_bomber/bomb.gd
+++ b/networking/multiplayer_bomber/bomb.gd
@@ -16,7 +16,7 @@ func explode() -> void:
 			var query := PhysicsRayQueryParameters2D.create(position, p.position)
 			query.hit_from_inside = true
 			var result: Dictionary  = world_state.intersect_ray(query)
-			if not result.collider is TileMap:
+			if result.collider is not TileMap:
 				# Exploded can only be called by the authority, but will also be called locally.
 				p.exploded.rpc(from_player)
 

--- a/networking/multiplayer_bomber/montserrat.otf.import
+++ b/networking/multiplayer_bomber/montserrat.otf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/montserrat.otf-0d875bde8933edfaf65407b0d9da84
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/networking/multiplayer_bomber/project.godot
+++ b/networking/multiplayer_bomber/project.godot
@@ -16,7 +16,7 @@ One of the players should press \"Host\", while the other
 should type in his address and press \"Play\"."
 config/tags=PackedStringArray("2d", "demo", "network", "official")
 run/main_scene="res://lobby.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.webp"
 
 [autoload]
@@ -36,39 +36,39 @@ window/stretch/aspect="expand"
 
 move_down={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 move_left={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":113,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":-1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 move_right={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 move_up={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":-1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 set_bomb={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 , Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":1,"pressure":0.0,"pressed":false,"script":null)

--- a/xr/openxr_composition_layers/main.gd
+++ b/xr/openxr_composition_layers/main.gd
@@ -42,7 +42,7 @@ func _on_left_hand_button_pressed(action_name):
 		_do_tween_energy()
 
 		# And make us feel it.
-		# Note: frequence == 0.0 => XR runtime chooses optimal frequency for a given controller.
+		# NOTE: `frequence == 0.0` => XR runtime chooses optimal frequency for a given controller.
 		active_hand.trigger_haptic_pulse("haptic", 0.0, 1.0, 0.5, 0.0)
 
 
@@ -60,5 +60,5 @@ func _on_right_hand_button_pressed(action_name):
 		_do_tween_energy()
 
 		# And make us feel it.
-		# Note: frequence == 0.0 => XR runtime chooses optimal frequency for a given controller.
+		# NOTE: `frequence == 0.0` => XR runtime chooses optimal frequency for a given controller.
 		active_hand.trigger_haptic_pulse("haptic", 0.0, 1.0, 0.5, 0.0)


### PR DESCRIPTION
* Replace `not X is Y` with `X is not Y`.
  * This is supported since 4.3, so `project.godot` and `*.import` files for such projects have also been updated.
* Replace `# warning-ignore:X` with `@warning_ignore("X")` and remove unnecessary warning ignores.
* Convert comment keywords such as `NOTE` and `BUG` to uppercase (they are highlighted in the editor).