### PR TITLE
Disable non-functional XR demos in web exports

### DIFF
--- a/.github/dist/footer.html
+++ b/.github/dist/footer.html
@@ -32,6 +32,7 @@
         <li><code>mono/*</code>: Not available yet (requires Mono-enabled HTML5 build).</li>
         <li><code>networking/*</code>: Doesn't make sense to be hosted on a static host, as the server must be hosted on the same origin due to the browser's same-origin policy.</li>
         <li><code>plugins/*</code>: Only effective within the editor.</li>
+        <li><code>xr/*</code>: Not functional on the web platform, as these demos are not designed for WebXR.</li>
     </ul>
 </body>
 </html>

--- a/.github/dist/header.html
+++ b/.github/dist/header.html
@@ -98,7 +98,7 @@
 		}
 
 		.unsupported-demos li {
-			margin-bottom: 2rem;
+			margin-bottom: 1.5rem;
 		}
 	</style>
 </head>

--- a/.github/workflows/export_web.yml
+++ b/.github/workflows/export_web.yml
@@ -59,7 +59,8 @@ jobs:
             mobile/sensors/ \
             mono/ \
             networking/ \
-            plugins/
+            plugins/ \
+            xr/
 
           for panorama in 3d/material_testers/backgrounds/*.hdr; do
             # Decrease the resolution to get below the 100 MB PCK size limit.


### PR DESCRIPTION
These demos could work if they are redesigned to account for WebXR's limitations when running on the web platform.
