### PR TITLE
OpenXR fix character centric recenter code

### DIFF
--- a/xr/openxr_character_centric_movement/player.gd
+++ b/xr/openxr_character_centric_movement/player.gd
@@ -21,7 +21,7 @@ func recenter() -> void:
 		push_error("Couldn't access OpenXR interface!")
 		return
 
-	var play_area_mode : XRInterface.PlayAreaMode = xr_interface.get_play_area_mode()
+	var play_area_mode: XRInterface.PlayAreaMode = xr_interface.get_play_area_mode()
 	if play_area_mode == XRInterface.XR_PLAY_AREA_SITTING:
 		push_warning("Sitting play space is not suitable for this setup.")
 	elif play_area_mode == XRInterface.XR_PLAY_AREA_ROOMSCALE:

--- a/xr/openxr_character_centric_movement/player.gd
+++ b/xr/openxr_character_centric_movement/player.gd
@@ -32,7 +32,7 @@ func recenter() -> void:
 		XRServer.center_on_hmd(XRServer.RESET_BUT_KEEP_TILT, true)
 
 	# XRCamera3D node won't be updated yet, so go straight to the source!
-	var head_tracker : XRPositionalTracker = XRServer.get_tracker("head")
+	var head_tracker: XRPositionalTracker = XRServer.get_tracker("head")
 	if not head_tracker:
 		push_error("Couldn't locate head tracker!")
 		return

--- a/xr/openxr_character_centric_movement/player.gd
+++ b/xr/openxr_character_centric_movement/player.gd
@@ -16,7 +16,7 @@ var gravity := float(ProjectSettings.get_setting("physics/3d/default_gravity"))
 
 ## Called when the user has requested their view to be recentered.
 func recenter() -> void:
-	var xr_interface : OpenXRInterface = XRServer.find_interface("OpenXR")
+	var xr_interface: OpenXRInterface = XRServer.find_interface("OpenXR")
 	if not xr_interface:
 		push_error("Couldn't access OpenXR interface!")
 		return

--- a/xr/openxr_character_centric_movement/player.gd
+++ b/xr/openxr_character_centric_movement/player.gd
@@ -37,14 +37,14 @@ func recenter() -> void:
 		push_error("Couldn't locate head tracker!")
 		return
 
-	var pose : XRPose = head_tracker.get_pose("default")
-	var head_transform : Transform3D = pose.get_adjusted_transform()
+	var pose: XRPose = head_tracker.get_pose("default")
+	var head_transform: Transform3D = pose.get_adjusted_transform()
 
 	# Get neck transform in XROrigin3D space
-	var neck_transform = neck_position_node.transform * head_transform
+	var neck_transform: Transform3D = neck_position_node.transform * head_transform
 
 	# Reset our XROrigin transform and apply the inverse of the neck position.
-	var new_origin_transform : Transform3D = Transform3D()
+	var new_origin_transform: Transform3D = Transform3D()
 	new_origin_transform.origin.x = -neck_transform.origin.x
 	new_origin_transform.origin.y = 0.0
 	new_origin_transform.origin.z = -neck_transform.origin.z


### PR DESCRIPTION
This fixes the recenter code to work with different reference spaces.

While these changes also apply to Godot 4.3, not all XR runtimes properly trigger the recenter signal. For this to consistently work https://github.com/godotengine/godot/pull/99159 is required. 