### PR TITLE
Fix physics picking in Gui in 3D Demo

### DIFF
--- a/viewport/gui_in_3d/gui_3d.gd
+++ b/viewport/gui_in_3d/gui_3d.gd
@@ -30,9 +30,13 @@ func _process(_delta: float) -> void:
 
 func _mouse_entered_area() -> void:
 	is_mouse_inside = true
+	# Notify the viewport, that the mouse is now hovering it.
+	node_viewport.notification(NOTIFICATION_VP_MOUSE_ENTER)
 
 
 func _mouse_exited_area() -> void:
+	# Notify the viewport, that the mouse is no longer hovering it.
+	node_viewport.notification(NOTIFICATION_VP_MOUSE_EXIT)
 	is_mouse_inside = false
 
 

--- a/viewport/gui_in_3d/gui_panel_3d.tscn
+++ b/viewport/gui_in_3d/gui_panel_3d.tscn
@@ -121,7 +121,6 @@ grow_horizontal = 0
 grow_vertical = 0
 item_count = 3
 popup/item_0/text = "Item 0"
-popup/item_0/id = 0
 popup/item_1/text = "Item 1"
 popup/item_1/id = 1
 popup/item_2/text = "Item 2"

--- a/viewport/gui_in_3d/project.godot
+++ b/viewport/gui_in_3d/project.godot
@@ -15,7 +15,7 @@ config/description="A demo showing a GUI instanced within a 3D scene using viewp
 as well as forwarding mouse and keyboard input to the GUI."
 config/tags=PackedStringArray("3d", "demo", "gui", "official")
 run/main_scene="res://gui_in_3d.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.webp"
 
 [debug]


### PR DESCRIPTION
Physics picking requires that the SubViewport has a consistent state of the mouse-enter/exit notifications.

Godot V4.3 was changed in comparison to V4.2, so that it now requires this additional step.

While this demo is focused on Control nodes, Physics picking should also work, since the demo project is used sometimes as a baseline for physics interactions ([for example on the forum](https://forum.godotengine.org/t/area2d-not-detecting-input-through-subviewport-push-input/92571)).