### PR TITLE
Improve GUI in 3D demo

### DIFF
--- a/viewport/gui_in_3d/gui_panel_3d.tscn
+++ b/viewport/gui_in_3d/gui_panel_3d.tscn
@@ -59,8 +59,9 @@ horizontal_alignment = 1
 layout_mode = 2
 text = "A button!"
 
-[node name="TextEdit" type="LineEdit" parent="SubViewport/GUI/Panel/VBoxContainer"]
+[node name="LineEdit" type="LineEdit" parent="SubViewport/GUI/Panel/VBoxContainer"]
 layout_mode = 2
+placeholder_text = "Enter text here..."
 
 [node name="HSlider" type="HSlider" parent="SubViewport/GUI/Panel/VBoxContainer"]
 layout_mode = 2
@@ -119,6 +120,7 @@ offset_right = -39.0
 offset_bottom = -147.0
 grow_horizontal = 0
 grow_vertical = 0
+selected = 0
 item_count = 3
 popup/item_0/text = "Item 0"
 popup/item_1/text = "Item 1"

--- a/viewport/gui_in_3d/project.godot
+++ b/viewport/gui_in_3d/project.godot
@@ -30,6 +30,10 @@ theme/default_theme_scale=2.0
 
 3d_physics/layer_2="Control"
 
+[physics]
+
+common/physics_ticks_per_second=120
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-demo-projects/pull/1139.

___

- Increase physics ticks per second to 120, so that UI interactions feel smoother and have lower input lag. This happens since input is governed by the physics tick due to the use of physics picking.
- Add a placeholder to the LineEdit and select a default option in the OptionButton.

## Preview

https://github.com/user-attachments/assets/1a68a9ed-c1a7-45b9-a2d4-4be7ff376f20

