### PR TITLE
Fix notifying viewport about mouse status in Gui-in-3D-demo

### DIFF
--- a/viewport/gui_in_3d/gui_3d.gd
+++ b/viewport/gui_in_3d/gui_3d.gd
@@ -31,12 +31,12 @@ func _process(_delta: float) -> void:
 func _mouse_entered_area() -> void:
 	is_mouse_inside = true
 	# Notify the viewport that the mouse is now hovering it.
-	node_viewport.notification(NOTIFICATION_VP_MOUSE_ENTER)
+	node_viewport.notify_mouse_entered()
 
 
 func _mouse_exited_area() -> void:
 	# Notify the viewport that the mouse is no longer hovering it.
-	node_viewport.notification(NOTIFICATION_VP_MOUSE_EXIT)
+	node_viewport.notify_mouse_exited()
 	is_mouse_inside = false
 
 

--- a/viewport/gui_in_3d/gui_3d.gd.uid
+++ b/viewport/gui_in_3d/gui_3d.gd.uid
@@ -1,0 +1,1 @@
+uid://cv6jhitk2iiy1

--- a/viewport/gui_in_3d/gui_in_3d.tscn
+++ b/viewport/gui_in_3d/gui_in_3d.tscn
@@ -33,7 +33,7 @@ tracks/0/keys = {
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_uw4n0"]
 _data = {
-"Move_camera": SubResource("1")
+&"Move_camera": SubResource("1")
 }
 
 [sub_resource type="PlaneMesh" id="2"]
@@ -69,7 +69,7 @@ omni_range = 10.0
 
 [node name="Camera_Move" type="AnimationPlayer" parent="."]
 libraries = {
-"": SubResource("AnimationLibrary_uw4n0")
+&"": SubResource("AnimationLibrary_uw4n0")
 }
 autoplay = "Move_camera"
 

--- a/viewport/gui_in_3d/gui_panel_3d.tscn
+++ b/viewport/gui_in_3d/gui_panel_3d.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=7 format=3 uid="uid://dvl383ispakmn"]
 
-[ext_resource type="Script" path="res://gui_3d.gd" id="1"]
+[ext_resource type="Script" uid="uid://cv6jhitk2iiy1" path="res://gui_3d.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://brwp8bimc75uu" path="res://icon.webp" id="2"]
 
 [sub_resource type="QuadMesh" id="1"]
@@ -123,6 +123,7 @@ grow_vertical = 0
 selected = 0
 item_count = 3
 popup/item_0/text = "Item 0"
+popup/item_0/id = 0
 popup/item_1/text = "Item 1"
 popup/item_1/id = 1
 popup/item_2/text = "Item 2"
@@ -138,3 +139,4 @@ input_capture_on_drag = true
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Quad/Area3D"]
 shape = SubResource("4")
+debug_color = Color(0, 0.6, 0.7, 0.42)

--- a/viewport/gui_in_3d/project.godot
+++ b/viewport/gui_in_3d/project.godot
@@ -15,7 +15,7 @@ config/description="A demo showing a GUI instanced within a 3D scene using viewp
 as well as forwarding mouse and keyboard input to the GUI."
 config/tags=PackedStringArray("3d", "demo", "gui", "official")
 run/main_scene="res://gui_in_3d.tscn"
-config/features=PackedStringArray("4.3")
+config/features=PackedStringArray("4.4")
 config/icon="res://icon.webp"
 
 [debug]


### PR DESCRIPTION
Update files to Version 4.4

Implement adjustments of https://github.com/godotengine/godot/pull/99890  in order to fix problems with mouse exit detection in situation similar to the MRP of https://github.com/godotengine/godot/issues/98003.

Keeping the PR as a draft until 4.4 is released.