### PR TITLE
physics_tests: Upped the Jolt Physics limit settings so that the performance tests run without errors

### DIFF
--- a/3d/physics_tests/project.godot
+++ b/3d/physics_tests/project.godot
@@ -92,3 +92,9 @@ character_jump={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 ]
 }
+
+[physics]
+
+jolt_physics_3d/limits/max_bodies=20480
+jolt_physics_3d/limits/max_body_pairs=131072
+jolt_physics_3d/limits/max_contact_constraints=40960


### PR DESCRIPTION
This change makes sure that if you switch physics to use the Jolt Physics module, that the correct settings are applied.