### PR TITLE
Fix typo in WebSocketServer class name

### DIFF
--- a/networking/websocket_chat/websocket/WebSocketServer.gd
+++ b/networking/websocket_chat/websocket/WebSocketServer.gd
@@ -1,4 +1,4 @@
-class_name NWebSocketServer
+class_name WebSocketServer
 extends Node
 
 signal message_received(peer_id: int, message: String)


### PR DESCRIPTION
Seem to have been mistakenly added in 9a0c857131b8561257d3c289a0b76a611c10dbcc