### PR TITLE
Fix invalid icon reference in C# Android IAP demo

### DIFF
--- a/mono/android_iap/project.godot
+++ b/mono/android_iap/project.godot
@@ -17,7 +17,7 @@ Note: Running the demo requires exporting and uploading the game to Google Play.
 config/tags=PackedStringArray("demo", "mobile", "official", "porting")
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.3", "C#", "Mobile")
-config/icon="res://icon.svg"
+config/icon="res://icon.webp"
 
 [display]
 


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-demo-projects/issues/1158.

The demo is still not ported to 4.x, but at least it should no longer display an error when you scan all demos in the project manager.