### PR TITLE
Change the way the mobs are cleared from screen

### DIFF
--- a/2d/dodge_the_creeps/main.gd
+++ b/2d/dodge_the_creeps/main.gd
@@ -4,6 +4,7 @@ extends Node
 var score
 
 func game_over():
+	get_tree().call_group(&"mobs", &"queue_free")
 	$ScoreTimer.stop()
 	$MobTimer.stop()
 	$HUD.show_game_over()
@@ -12,7 +13,6 @@ func game_over():
 
 
 func new_game():
-	get_tree().call_group(&"mobs", &"queue_free")
 	score = 0
 	$Player.start($StartPosition.position)
 	$StartTimer.start()


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
This PR was created because of [#10655](https://github.com/godotengine/godot-docs/pull/10655#issuecomment-2646591574)

I think it makes more sense to free the mobs when it's game over so it's more visual to the person who is learning. 

At this point in the tutorial when we die we have a ~2 second window to be able to start the game again. In this time all the mobs on the screen are not visible anymore, so the `queue_free` action is not too obvious. 
It feels better to be able to see what this line of code is doing by removing them immediately when it's game over, this way we can visually see what the code is doing.

Before:
![2143d44000dd690a8406b1ac9b6fa0ce](https://github.com/user-attachments/assets/16eb58fd-c1d0-4171-8c8b-7282507c5f6c)

After:
![69b004679a44531ae3bd28995287506b](https://github.com/user-attachments/assets/8cdb7754-9bca-4157-964f-cd51dcd34e90)



