### PR TITLE
Show AudioEffectCapture by use of a shader showing the captured waveform in stereo

### DIFF
--- a/audio/mic_record/MicRecord.gd
+++ b/audio/mic_record/MicRecord.gd
@@ -1,24 +1,49 @@
 extends Control
 
-var effect: AudioEffect
+var recordeffect: AudioEffectRecord
+var captureeffect: AudioEffectCapture
 var recording: AudioStreamWAV
 
 var stereo := true
 var mix_rate := 44100  # This is the default mix rate on recordings.
 var format := AudioStreamWAV.FORMAT_16_BITS  # This is the default format on recordings.
 
+var audiosamplesize : int = 882
+var audiosampleframetextureimage : Image
+var audiosampleframetexture : ImageTexture
+var totalsamples = 0
+var sampleduration = 0.0
 
 func _ready() -> void:
 	var idx := AudioServer.get_bus_index("Record")
-	effect = AudioServer.get_bus_effect(idx, 0)
+	recordeffect = AudioServer.get_bus_effect(idx, 0)
+	captureeffect = AudioServer.get_bus_effect(idx, 1)
 
+	var audiosampleframedata_blank = PackedVector2Array()
+	audiosampleframedata_blank.resize(audiosamplesize)
+	for j in range(audiosamplesize):
+		audiosampleframedata_blank.set(j, Vector2(-0.5,0.9) if (j%10)<5 else Vector2(0.6,0.1))
+	audiosampleframetextureimage = Image.create_from_data(audiosamplesize, 1, false, Image.FORMAT_RGF, audiosampleframedata_blank.to_byte_array())
+	audiosampleframetexture = ImageTexture.create_from_image(audiosampleframetextureimage)
+	$MicTexture.material.set_shader_parameter("audiosample", audiosampleframetexture)
+
+func _process(delta):
+	sampleduration += delta
+	var audiosamples : PackedVector2Array = captureeffect.get_buffer(audiosamplesize)
+	if audiosamples != null:
+		audiosampleframetextureimage.set_data(audiosamplesize, 1, false, Image.FORMAT_RGF, audiosamples.to_byte_array())
+		audiosampleframetexture.update(audiosampleframetextureimage)
+		totalsamples += len(audiosamples)
+		$SampleCount.text = "%.0f samples/sec" % (totalsamples/sampleduration)
 
 func _on_record_button_pressed() -> void:
-	if effect.is_recording_active():
-		recording = effect.get_recording()
+	totalsamples = 0
+	sampleduration = 0.0
+	if recordeffect.is_recording_active():
+		recording = recordeffect.get_recording()
 		$PlayButton.disabled = false
 		$SaveButton.disabled = false
-		effect.set_recording_active(false)
+		recordeffect.set_recording_active(false)
 		recording.set_mix_rate(mix_rate)
 		recording.set_format(format)
 		recording.set_stereo(stereo)
@@ -27,7 +52,7 @@ func _on_record_button_pressed() -> void:
 	else:
 		$PlayButton.disabled = true
 		$SaveButton.disabled = true
-		effect.set_recording_active(true)
+		recordeffect.set_recording_active(true)
 		$RecordButton.text = "Stop"
 		$Status.text = "Status: Recording..."
 
@@ -96,4 +121,3 @@ func _on_stereo_check_button_toggled(button_pressed: bool) -> void:
 
 func _on_open_user_folder_button_pressed() -> void:
 	OS.shell_open(ProjectSettings.globalize_path("user://"))
-

--- a/audio/mic_record/MicRecord.gd.uid
+++ b/audio/mic_record/MicRecord.gd.uid
@@ -1,0 +1,1 @@
+uid://dbbfvbf6ronrp

--- a/audio/mic_record/MicRecord.gdshader
+++ b/audio/mic_record/MicRecord.gdshader
@@ -1,0 +1,19 @@
+shader_type canvas_item;
+render_mode blend_mix;
+
+uniform sampler2D audiosample : repeat_enable;
+const float cfac = 4.0;
+const float mfac = 2.0;
+const float mdisp = 0.166667;
+const float mthick = 0.05;
+
+void fragment() {
+  vec4 a = texture(audiosample, UV);
+  float dr = abs(UV.y*2.0 - 1.0 - (a.r + mdisp)*mfac);
+  float dg = abs(UV.y*2.0 - 1.0 - (a.g - mdisp)*mfac);
+  COLOR = vec4(0.1+max(a.r,0.0)*cfac, 0.1, 0.1+max(-a.r,0.0)*cfac, 1.0);
+  if (dg < mthick)
+    COLOR = vec4(1.0,1.0,0.9,1.0);
+  else if (dr < mthick)
+    COLOR = vec4(0.8,0.8,0.9,1.0);
+}

--- a/audio/mic_record/MicRecord.tscn
+++ b/audio/mic_record/MicRecord.tscn
@@ -1,9 +1,13 @@
-[gd_scene load_steps=4 format=3 uid="uid://dvjlkpjvjxn0h"]
+[gd_scene load_steps=6 format=3 uid="uid://dvjlkpjvjxn0h"]
 
 [ext_resource type="Script" path="res://MicRecord.gd" id="1"]
 [ext_resource type="AudioStream" uid="uid://c2re52petqrvx" path="res://Intro.ogg" id="2"]
+[ext_resource type="Shader" path="res://MicRecord.gdshader" id="3_vkk4n"]
 
 [sub_resource type="AudioStreamMicrophone" id="1"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_m4htd"]
+shader = ExtResource("3_vkk4n")
 
 [node name="MicRecord" type="Control"]
 layout_mode = 3
@@ -18,6 +22,7 @@ offset_right = 296.0
 offset_bottom = 226.0
 grow_horizontal = 2
 grow_vertical = 2
+rotation = 0.00166517
 script = ExtResource("1")
 
 [node name="AudioStreamRecord" type="AudioStreamPlayer" parent="."]
@@ -43,18 +48,18 @@ horizontal_alignment = 1
 
 [node name="RecordButton" type="Button" parent="."]
 layout_mode = 0
-offset_left = 29.0
-offset_top = 77.0
-offset_right = 159.0
-offset_bottom = 117.0
+offset_left = 31.0566
+offset_top = 33.9483
+offset_right = 161.057
+offset_bottom = 73.9483
 text = "Record"
 
 [node name="PlayButton" type="Button" parent="."]
 layout_mode = 0
-offset_left = 209.0
-offset_top = 77.0
-offset_right = 339.0
-offset_bottom = 117.0
+offset_left = 209.06
+offset_top = 35.6519
+offset_right = 339.06
+offset_bottom = 75.6519
 disabled = true
 text = "Play"
 
@@ -68,22 +73,21 @@ text = "Play Music"
 
 [node name="FormatLabel" type="Label" parent="."]
 layout_mode = 0
-offset_left = 33.0
-offset_top = 153.0
-offset_right = 102.0
-offset_bottom = 179.0
+offset_left = 41.3546
+offset_top = 212.931
+offset_right = 110.355
+offset_bottom = 238.931
 text = "Format:"
 
 [node name="FormatOptionButton" type="OptionButton" parent="."]
 layout_mode = 0
-offset_left = 131.0
-offset_top = 150.0
-offset_right = 315.0
-offset_bottom = 181.0
-item_count = 3
+offset_left = 153.348
+offset_top = 208.745
+offset_right = 382.348
+offset_bottom = 239.745
 selected = 1
+item_count = 3
 popup/item_0/text = "8-bit Uncompressed"
-popup/item_0/id = 0
 popup/item_1/text = "16-bit Uncompressed"
 popup/item_1/id = 1
 popup/item_2/text = "IMA ADPCM Compression"
@@ -91,22 +95,21 @@ popup/item_2/id = 2
 
 [node name="MixRateLabel" type="Label" parent="."]
 layout_mode = 0
-offset_left = 33.0
-offset_top = 192.0
-offset_right = 102.0
-offset_bottom = 218.0
+offset_left = 42.4112
+offset_top = 246.93
+offset_right = 111.411
+offset_bottom = 272.93
 text = "Mix rate:"
 
 [node name="MixRateOptionButton" type="OptionButton" parent="."]
 layout_mode = 0
-offset_left = 131.0
-offset_top = 189.0
-offset_right = 220.0
-offset_bottom = 220.0
-item_count = 6
+offset_left = 142.408
+offset_top = 244.763
+offset_right = 244.408
+offset_bottom = 275.763
 selected = 4
+item_count = 6
 popup/item_0/text = "11025 Hz"
-popup/item_0/id = 0
 popup/item_1/text = "16000 Hz"
 popup/item_1/id = 1
 popup/item_2/text = "22050 Hz"
@@ -119,45 +122,64 @@ popup/item_5/text = "48000 Hz"
 popup/item_5/id = 5
 
 [node name="StereoLabel" type="Label" parent="."]
+visible = false
 layout_mode = 0
-offset_left = 33.0
-offset_top = 233.0
-offset_right = 102.0
-offset_bottom = 259.0
+offset_left = 39.4662
+offset_top = 279.935
+offset_right = 108.466
+offset_bottom = 305.935
 text = "Stereo:"
 
 [node name="StereoCheckButton" type="CheckButton" parent="."]
+visible = false
 layout_mode = 0
-offset_left = 126.0
-offset_top = 233.0
-offset_right = 170.0
-offset_bottom = 264.0
+offset_left = 132.464
+offset_top = 278.78
+offset_right = 176.464
+offset_bottom = 309.78
 button_pressed = true
 
 [node name="SaveButton" type="Button" parent="."]
 layout_mode = 0
-offset_left = 29.0
-offset_top = 284.0
-offset_right = 159.0
-offset_bottom = 324.0
+offset_left = 29.5478
+offset_top = 328.951
+offset_right = 159.548
+offset_bottom = 368.951
 disabled = true
 text = "Save WAV To:"
 
 [node name="Filename" type="LineEdit" parent="SaveButton"]
 layout_mode = 0
-offset_left = 180.0
-offset_right = 507.0
-offset_bottom = 40.0
+offset_left = 184.0
+offset_top = -0.306404
+offset_right = 511.0
+offset_bottom = 39.6936
 text = "user://record.wav"
 caret_blink = true
 
 [node name="OpenUserFolderButton" type="Button" parent="."]
 layout_mode = 1
-offset_left = 209.0
-offset_top = 334.0
-offset_right = 372.0
-offset_bottom = 374.0
+offset_left = 208.634
+offset_top = 380.653
+offset_right = 371.634
+offset_bottom = 420.653
 text = "Open User Folder"
+
+[node name="MicTexture" type="ColorRect" parent="."]
+material = SubResource("ShaderMaterial_m4htd")
+layout_mode = 0
+offset_left = 30.0
+offset_top = 90.0
+offset_right = 558.0
+offset_bottom = 179.0
+
+[node name="SampleCount" type="Label" parent="."]
+layout_mode = 0
+offset_left = 440.064
+offset_top = 38.2673
+offset_right = 522.064
+offset_bottom = 61.2673
+text = "N-samples"
 
 [connection signal="pressed" from="RecordButton" to="." method="_on_record_button_pressed"]
 [connection signal="pressed" from="PlayButton" to="." method="_on_play_button_pressed"]

--- a/audio/mic_record/default_bus_layout.tres
+++ b/audio/mic_record/default_bus_layout.tres
@@ -1,7 +1,10 @@
-[gd_resource type="AudioBusLayout" load_steps=2 format=3 uid="uid://tuxl6tvrr2dv"]
+[gd_resource type="AudioBusLayout" load_steps=3 format=3 uid="uid://tuxl6tvrr2dv"]
 
 [sub_resource type="AudioEffectRecord" id="AudioEffectRecord_fo272"]
 resource_name = "Record"
+
+[sub_resource type="AudioEffectCapture" id="AudioEffectCapture_xywfp"]
+resource_name = "Capture"
 
 [resource]
 bus/1/name = &"Record"
@@ -12,3 +15,5 @@ bus/1/volume_db = 0.0
 bus/1/send = &"Master"
 bus/1/effect/0/effect = SubResource("AudioEffectRecord_fo272")
 bus/1/effect/0/enabled = true
+bus/1/effect/1/effect = SubResource("AudioEffectCapture_xywfp")
+bus/1/effect/1/enabled = true

--- a/audio/mic_record/project.godot
+++ b/audio/mic_record/project.godot
@@ -15,7 +15,7 @@ config/description="This is an example showing how one can record audio from
 the microphone and later play it back or save it to a file."
 config/tags=PackedStringArray("audio", "demo", "official")
 run/main_scene="res://MicRecord.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
 


### PR DESCRIPTION
Microphone data is normally read using AudioEffectCapture rather than AudioEffectRecord, so we should adapt this demo project to use it.  And a good way to show that something is happening is to plot the waveform using a shader.  

This shows it in stereo because a lot of computers have two microphones.  

It's also useful to measure the sample rate of the microphone according to the data stream it is generating.

![Screenshot from 2025-03-02 18-23-26](https://github.com/user-attachments/assets/b3162b01-0bd6-4277-9446-1f238eadbcdb)
