### PR TITLE
Added line to play animation at the end.

### DIFF
--- a/2d/dodge_the_creeps/mob.gd
+++ b/2d/dodge_the_creeps/mob.gd
@@ -1,9 +1,9 @@
 extends RigidBody2D
 
 func _ready():
-	$AnimatedSprite2D.play()
 	var mob_types = Array($AnimatedSprite2D.sprite_frames.get_animation_names())
 	$AnimatedSprite2D.animation = mob_types.pick_random()
+	$AnimatedSprite2D.play()
 
 
 func _on_VisibilityNotifier2D_screen_exited():


### PR DESCRIPTION
The '$AnimatedSprite2D.play()' is called at the beginning in the '_ready' function, when it should actually be called at the end, after selecting the animation.