### PR TITLE
Change physics joint tests to freeze bodies as kinematic

### DIFF
--- a/2d/physics_tests/tests/functional/test_joints.gd
+++ b/2d/physics_tests/tests/functional/test_joints.gd
@@ -113,6 +113,7 @@ func _create_joint() -> void:
 			parent_body.gravity_scale = 0.0
 			child_body.gravity_scale = 0.0
 		else:
+			parent_body.freeze_mode = RigidBody2D.FREEZE_MODE_KINEMATIC
 			parent_body.freeze = true
 		if _change_positions:
 			root.add_child(parent_body)

--- a/3d/physics_tests/tests/functional/test_joints.gd
+++ b/3d/physics_tests/tests/functional/test_joints.gd
@@ -113,6 +113,7 @@ func _create_joint() -> void:
 			parent_body.gravity_scale = 0.0
 			child_body.gravity_scale = 0.0
 		else:
+			parent_body.freeze_mode = RigidBody3D.FREEZE_MODE_KINEMATIC
 			parent_body.freeze = true
 		if _change_positions:
 			root.add_child(parent_body)


### PR DESCRIPTION
The joint tests found in `3d/physics_tests/test/functional/test_joints.gd` are currently behaving a bit strange when you use Jolt Physics as the 3D physics engine, while having all the test options set to their default value:

https://github.com/user-attachments/assets/e48855c1-60dc-4b45-b69f-4502b2439ab7

The reason for this seems to be related to the fact that the upper body (`parent_body`) in this test is by default set to use `freeze = true`, which by default uses `freeze_mode = RigidBody3D.FREEZE_MODE_STATIC`. This effectively turns the body into a `StaticBody3D`, which as the name suggests isn't really meant to be moved, and thus have no linear or angular velocities associated with it, which will cause problems when connected to joints, as solving for the underlying joint constraints (in either physics engine) involves the bodies' velocities.

The fact that the lower body just sits there seems to be related to the lower body going to sleep, which we can confirm by disabling sleeping:

https://github.com/user-attachments/assets/e262d457-da44-4073-8e17-d151a1c4b0f0

Static bodies in Jolt are always considered to be sleeping, so it makes sense to me why moving the upper body wouldn't wake up the lower body, despite being connected by a constraint. I don't quite understand why this isn't the case for Godot Physics as well though.

Note however that something looks/feels a bit off ("sluggish") with how the lower body behaves even when just disabling sleeping, which as mentioned above is related to there being no velocities associated with the static body.

If we instead change `freeze_mode` to `RigidBody3D.FREEZE_MODE_KINEMATIC`, we get this, which works even when leaving sleeping enabled:

https://github.com/user-attachments/assets/35c0e465-78d8-42f5-a625-7777526c1381

This can be reproduced with Godot Physics as well to some degree, although the discrepancy between the two body modes is less pronounced there, which I think is due to the fact that Jolt by default only uses 2 position iterations in its solver, whereas I think Godot Physics solves for *both* velocity and position in its 16 default solver iterations.

Upping the solver iterations to something like 16 for Jolt makes things behave a bit better, even when using `FREEZE_MODE_STATIC`, but this would be a hack in this case.

This PR instead fixes all of this by simply switching `freeze_mode` to `FREEZE_MODE_KINEMATIC` in these tests, as it should be.