### PR TITLE
remove broken int type check in webrtc

### DIFF
--- a/networking/webrtc_signaling/client/ws_webrtc_client.gd
+++ b/networking/webrtc_signaling/client/ws_webrtc_client.gd
@@ -64,11 +64,9 @@ func _parse_msg() -> bool:
 		return false
 
 	var msg := parsed as Dictionary
-	if not str(msg.type).is_valid_int() or not str(msg.id).is_valid_int():
-		return false
 
-	var type := str(msg.type).to_int()
-	var src_id := str(msg.id).to_int()
+	var type := int(msg.type)
+	var src_id := int(msg.id)
 
 	if type == Message.ID:
 		connected.emit(src_id, msg.data == "true")


### PR DESCRIPTION
JSON.parse_string() parses all numbers as floats, even if there are no decimals. `str(JSON.parse_string('{"type": 3}').asdf)` would result in `"3.0"`, which is not a valid int. Because of this the demo is not working