### PR TITLE
Fix incorrect `class_name` declaration in 2D physics tests demo

### DIFF
--- a/2d/physics_tests/tests/functional/test_character.gd
+++ b/2d/physics_tests/tests/functional/test_character.gd
@@ -1,5 +1,5 @@
-class_name Test
-extends TestCharacter
+class_name TestCharacter
+extends Test
 
 enum BodyType {
 	CHARACTER_BODY,

--- a/compute/post_shader/post_process_grayscale.gd
+++ b/compute/post_shader/post_process_grayscale.gd
@@ -1,6 +1,6 @@
 @tool
-extends CompositorEffect
 class_name PostProcessGrayScale
+extends CompositorEffect
 
 var rd: RenderingDevice
 var shader: RID

--- a/compute/post_shader/post_process_shader.gd
+++ b/compute/post_shader/post_process_shader.gd
@@ -1,6 +1,6 @@
 @tool
-extends CompositorEffect
 class_name PostProcessShader
+extends CompositorEffect
 
 const template_shader := """#version 450
 

--- a/xr/openxr_hand_tracking_demo/pickup/pickup_able_body.gd
+++ b/xr/openxr_hand_tracking_demo/pickup/pickup_able_body.gd
@@ -1,6 +1,5 @@
-extends RigidBody3D
 class_name PickupAbleBody3D
-
+extends RigidBody3D
 
 var highlight_material : Material = preload("res://shaders/highlight_material.tres")
 var picked_up_by : Area3D
@@ -8,6 +7,7 @@ var closest_areas : Array
 
 var original_parent : Node3D
 var tween : Tween
+
 
 # Called when this object becomes the closest body in an area
 func add_is_closest(area : Area3D) -> void:

--- a/xr/openxr_hand_tracking_demo/pickup/pickup_handler.gd
+++ b/xr/openxr_hand_tracking_demo/pickup/pickup_handler.gd
@@ -1,6 +1,6 @@
 @tool
-extends Area3D
 class_name PickupHandler3D
+extends Area3D
 
 # This area3D class detects all physics bodys based on
 # PickupAbleBody3D within range and handles the logic
@@ -23,6 +23,7 @@ class_name PickupHandler3D
 var closest_body : PickupAbleBody3D
 var picked_up_body: PickupAbleBody3D
 var was_pickup_pressed : bool = false
+
 
 # Update our detection range.
 func _update_detect_range() -> void:


### PR DESCRIPTION
This also reorders declarations in other projects to follow the [GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html).
