### PR TITLE
Improve flat terrain generation in the Voxel demo

### DIFF
--- a/3d/voxel/world/terrain_generator.gd
+++ b/3d/voxel/world/terrain_generator.gd
@@ -27,7 +27,10 @@ static func flat(chunk_position: Vector3i) -> Dictionary:
 
 	for x in Chunk.CHUNK_SIZE:
 		for z in Chunk.CHUNK_SIZE:
-			data[Vector3i(x, 0, z)] = 3
+			data[Vector3i(x, 2, z)] = 3  # Grass.
+			data[Vector3i(x, 1, z)] = 2  # Dirt.
+			data[Vector3i(x, 0, z)] = 2  # Dirt.
+			data[Vector3i(x, -1, z)] = 9  # Bedrock (can't be destroyed due to its Y coordinate).
 
 	return data
 


### PR DESCRIPTION
This adds 2 layers of dirt below the grass layer and a layer of indestructible bedrock below it so you can't fall off the world.

## Preview

![image](https://github.com/user-attachments/assets/a3553cbe-aa70-4a36-b731-ae17ac994a0a)
