### PR TITLE
Fix Sprite3D shader effect bug

### DIFF
--- a/3d/sprites/shaders/paper_emission.gdshader
+++ b/3d/sprites/shaders/paper_emission.gdshader
@@ -28,7 +28,7 @@ void fragment() {
 		ALBEDO = center.rgb;
 		ALPHA = center.a;
 		vec3 normal_tex = texture(normal_map, UV).rgb;
-		normal_tex = -(normal_tex * 2.0 - 1.0);
+		normal_tex = normal_tex * 2.0 - 1.0;
 		NORMAL = normalize(TANGENT * normal_tex.x + BINORMAL * normal_tex.y + NORMAL * normal_tex.z);
 	}
 }

--- a/3d/sprites/shaders/paper_material.gdshader
+++ b/3d/sprites/shaders/paper_material.gdshader
@@ -21,7 +21,7 @@ void fragment() {
 	outline += step(threshold, texture(texture_albedo, uv - vec2(0.0, outline_thickness)).a);
 
 	vec3 normal_tex = texture(normal_map, UV).rgb;
-	normal_tex = -(normal_tex * 2.0 - 1.0);
+	normal_tex = normal_tex * 2.0 - 1.0;
 	NORMAL = normalize(TANGENT * normal_tex.x + BINORMAL * normal_tex.y + NORMAL * normal_tex.z);
 
 	if (center.a < threshold && outline > 0.0) {

--- a/3d/sprites/shaders/paper_rainbow.gdshader
+++ b/3d/sprites/shaders/paper_rainbow.gdshader
@@ -33,7 +33,7 @@ void fragment() {
 		ALBEDO = center.rgb;
 		ALPHA = center.a;
 		vec3 normal_tex = texture(normal_map, UV).rgb;
-		normal_tex = -(normal_tex * 2.0 - 1.0);
+		normal_tex = normal_tex * 2.0 - 1.0;
 		NORMAL = normalize(TANGENT * normal_tex.x + BINORMAL * normal_tex.y + NORMAL * normal_tex.z);
 	}
 }


### PR DESCRIPTION
The normal was not calculated correctly

This is for the bug fix of the merged PR for #1191 

Before: 
![image](https://github.com/user-attachments/assets/3a5b96e4-9d34-4a59-aeba-ce6f54790d53)
After:
![image](https://github.com/user-attachments/assets/3a3e95e0-c9cb-4ede-8a2c-16b688e64794)
