### PR TITLE
Disable GH `export_web` workflow in forks

### DIFF
--- a/.github/workflows/export_web.yml
+++ b/.github/workflows/export_web.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   export-html5:
+    if: github.repository == 'godotengine/godot-demo-projects'
     name: Export projects to Web and deploy to GitHub Pages
     runs-on: ubuntu-24.04
     container:


### PR DESCRIPTION
https://github.com/godotengine/godot-demo-projects/pull/1127#issuecomment-2885245893

In my fork it is skipped, or should we leave `static checks` active in forks?


![Bildschirmfoto 2025-05-16 um 01 42 12](https://github.com/user-attachments/assets/e2cd4c5a-326d-4706-a214-9f957b508efb)
