### PR TITLE
Fix "Parse message failed" error in WebRTC Signaling Demo Project

### DIFF
--- a/networking/webrtc_signaling/server/ws_webrtc_server.gd
+++ b/networking/webrtc_signaling/server/ws_webrtc_server.gd
@@ -207,7 +207,7 @@ func _parse_msg(peer: Peer) -> bool:
 	if typeof(parsed) != TYPE_DICTIONARY or not parsed.has("type") or not parsed.has("id") or \
 		typeof(parsed.get("data")) != TYPE_STRING:
 		return false
-	if not str(parsed.type).is_valid_int() or not str(parsed.id).is_valid_int():
+	if not typeof(parsed.type) == Variant.Type.TYPE_FLOAT or not typeof(parsed.id) == Variant.Type.TYPE_FLOAT:
 		return false
 
 	var msg := {

--- a/networking/webrtc_signaling/server/ws_webrtc_server.gd
+++ b/networking/webrtc_signaling/server/ws_webrtc_server.gd
@@ -207,7 +207,7 @@ func _parse_msg(peer: Peer) -> bool:
 	if typeof(parsed) != TYPE_DICTIONARY or not parsed.has("type") or not parsed.has("id") or \
 		typeof(parsed.get("data")) != TYPE_STRING:
 		return false
-	if not typeof(parsed.type) == Variant.Type.TYPE_FLOAT or not typeof(parsed.id) == Variant.Type.TYPE_FLOAT:
+	if parsed.type is not float or parsed.id is not float:
 		return false
 
 	var msg := {


### PR DESCRIPTION
The _parse_msg method type-checks parsed JSON numeric values to require integers, however JSON.parse_string always returns floats, leading to a "Parse message failed" error when running the demo.

Issue link: https://github.com/godotengine/godot/issues/103374