### PR TITLE
Fixed an issue with WebRTC signaling example server parsing

### DIFF
--- a/networking/webrtc_signaling/server/ws_webrtc_server.gd
+++ b/networking/webrtc_signaling/server/ws_webrtc_server.gd
@@ -207,7 +207,9 @@ func _parse_msg(peer: Peer) -> bool:
 	if typeof(parsed) != TYPE_DICTIONARY or not parsed.has("type") or not parsed.has("id") or \
 		typeof(parsed.get("data")) != TYPE_STRING:
 		return false
-	if not str(parsed.type).is_valid_int() or not str(parsed.id).is_valid_int():
+	if not typeof(parsed.type) == TYPE_FLOAT and int(parsed.type) == parsed.type:
+		return false
+	if not typeof(parsed.id == TYPE_FLOAT) and int(parsed.id) == parsed.id:
 		return false
 
 	var msg := {

--- a/networking/webrtc_signaling/server/ws_webrtc_server.gd
+++ b/networking/webrtc_signaling/server/ws_webrtc_server.gd
@@ -209,7 +209,7 @@ func _parse_msg(peer: Peer) -> bool:
 		return false
 	if not typeof(parsed.type) == TYPE_FLOAT and int(parsed.type) == parsed.type:
 		return false
-	if not typeof(parsed.id == TYPE_FLOAT) and int(parsed.id) == parsed.id:
+	if not typeof(parsed.id) == TYPE_FLOAT and int(parsed.id) == parsed.id:
 		return false
 
 	var msg := {


### PR DESCRIPTION
Went to try out the WebRTC Signaling example - hit Listen, and then connect, and got an error.
I then tried the included node server, which worked perfectly.

After adding some debugging prints, I found an issue within _parse_msg - JSON numbers are always parsed as a float, and so this code:

```gdscript
if not str(parsed.type).is_valid_int() or not str(parsed.id).is_valid_int():
    return false
```
fails, as these are both floats (and not valid ints).

Checks have been adjusted for both equality (x=int(x)) and type equality (typeof(x) = TYPE_FLOAT), for both the message ID and type.

This means the demo will run correctly, as previously the server could be started from the UI, but not joined, at least via a desktop environment with webrtc Gdextension.


