### PR TITLE
Update NavigationChunk demos

### DIFF
--- a/2d/navigation_mesh_chunks/navmesh_chhunks_demo_2d.gd
+++ b/2d/navigation_mesh_chunks/navmesh_chhunks_demo_2d.gd
@@ -45,7 +45,7 @@ func _ready() -> void:
 static func create_region_chunks(chunks_root_node: Node, p_source_geometry: NavigationMeshSourceGeometryData2D, p_chunk_size: float, p_agent_radius: float) -> void:
 	# We need to know how many chunks are required for the input geometry.
 	# So first get an axis aligned bounding box that covers all vertices.
-	var input_geometry_bounds: Rect2 = calculate_source_geometry_bounds(p_source_geometry)
+	var input_geometry_bounds: Rect2 = p_source_geometry.get_bounds()
 
 	# Rasterize bounding box into chunk grid to know range of required chunks.
 	var start_chunk: Vector2 = floor(
@@ -94,43 +94,6 @@ static func create_region_chunks(chunks_root_node: Node, p_source_geometry: Navi
 			chunk_id_to_region[chunk_id] = chunk_region
 
 
-static func calculate_source_geometry_bounds(p_source_geometry: NavigationMeshSourceGeometryData2D) -> Rect2:
-	if p_source_geometry.has_method("get_bounds"):
-		# Godot 4.3 Patch added get_bounds() function that does the same but faster.
-		return p_source_geometry.call("get_bounds")
-
-	var bounds: Rect2 = Rect2()
-	var first_vertex: bool = true
-
-	for traversable_outline: PackedVector2Array in p_source_geometry.get_traversable_outlines():
-		for traversable_point: Vector2 in traversable_outline:
-			if first_vertex:
-				first_vertex = false
-				bounds.position = traversable_point
-			else:
-				bounds = bounds.expand(traversable_point)
-
-	for obstruction_outline: PackedVector2Array in p_source_geometry.get_obstruction_outlines():
-		for obstruction_point: Vector2 in obstruction_outline:
-			if first_vertex:
-				first_vertex = false
-				bounds.position = obstruction_point
-			else:
-				bounds = bounds.expand(obstruction_point)
-
-	for projected_obstruction: Dictionary in p_source_geometry.get_projected_obstructions():
-		var projected_obstruction_vertices: PackedFloat32Array = projected_obstruction["vertices"]
-		for i in projected_obstruction_vertices.size() / 2:
-			var vertex: Vector2 = Vector2(projected_obstruction_vertices[i * 2], projected_obstruction_vertices[i * 2 + 1])
-			if first_vertex:
-				first_vertex = false
-				bounds.position = vertex
-			else:
-				bounds = bounds.expand(vertex)
-
-	return bounds
-
-
 func _process(_delta: float) -> void:
 	var mouse_cursor_position: Vector2 = get_global_mouse_position()
 
@@ -151,6 +114,8 @@ func _process(_delta: float) -> void:
 
 	%PathDebugCorridorFunnel.target_position = closest_point_on_navmesh
 	%PathDebugEdgeCentered.target_position = closest_point_on_navmesh
+	%PathDebugNoPostProcessing.target_position = closest_point_on_navmesh
 
 	%PathDebugCorridorFunnel.get_next_path_position()
 	%PathDebugEdgeCentered.get_next_path_position()
+	%PathDebugNoPostProcessing.get_next_path_position()

--- a/2d/navigation_mesh_chunks/navmesh_chhunks_demo_2d.tscn
+++ b/2d/navigation_mesh_chunks/navmesh_chhunks_demo_2d.tscn
@@ -43,6 +43,15 @@ debug_path_custom_color = Color(1, 1, 0, 1)
 debug_path_custom_point_size = 10.0
 debug_path_custom_line_width = 4.0
 
+[node name="PathDebugNoPostProcessing" type="NavigationAgent2D" parent="DebugPaths"]
+unique_name_in_owner = true
+path_postprocessing = 2
+debug_enabled = true
+debug_use_custom = true
+debug_path_custom_color = Color(1, 0, 0, 1)
+debug_path_custom_point_size = 10.0
+debug_path_custom_line_width = 4.0
+
 [node name="ChunksContainer" type="Node2D" parent="."]
 unique_name_in_owner = true
 
@@ -95,5 +104,21 @@ color = Color(1, 1, 0, 1)
 [node name="Label" type="Label" parent="CanvasLayer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
 layout_mode = 2
 text = "Path edge-centered"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="CanvasLayer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="ColorRect" type="ColorRect" parent="CanvasLayer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+custom_minimum_size = Vector2(128, 8)
+layout_mode = 2
+size_flags_vertical = 4
+color = Color(1, 0, 0, 1)
+
+[node name="Label" type="Label" parent="CanvasLayer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+layout_mode = 2
+text = "Path no post-processing"
 horizontal_alignment = 1
 vertical_alignment = 1

--- a/3d/navigation_mesh_chunks/navmesh_chhunks_demo_3d.gd
+++ b/3d/navigation_mesh_chunks/navmesh_chhunks_demo_3d.gd
@@ -36,7 +36,7 @@ func _ready() -> void:
 static func create_region_chunks(chunks_root_node: Node, p_source_geometry: NavigationMeshSourceGeometryData3D, p_chunk_size: float, p_agent_radius: float) -> void:
 	# We need to know how many chunks are required for the input geometry.
 	# So first get an axis aligned bounding box that covers all vertices.
-	var input_geometry_bounds: AABB = calculate_source_geometry_bounds(p_source_geometry)
+	var input_geometry_bounds: AABB = p_source_geometry.get_bounds()
 
 	# Rasterize bounding box into chunk grid to know range of required chunks.
 	var start_chunk: Vector3 = floor(
@@ -96,37 +96,6 @@ static func create_region_chunks(chunks_root_node: Node, p_source_geometry: Navi
 			chunk_id_to_region[chunk_id] = chunk_region
 
 
-static func calculate_source_geometry_bounds(p_source_geometry: NavigationMeshSourceGeometryData3D) -> AABB:
-	if p_source_geometry.has_method("get_bounds"):
-		# Godot 4.3 Patch added get_bounds() function that does the same but faster.
-		return p_source_geometry.call("get_bounds")
-
-	var bounds: AABB = AABB()
-	var first_vertex: bool = true
-
-	var vertices: PackedFloat32Array = p_source_geometry.get_vertices()
-	var vertices_count: int = vertices.size() / 3
-	for i in vertices_count:
-		var vertex: Vector3 = Vector3(vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2])
-		if first_vertex:
-			first_vertex = false
-			bounds.position = vertex
-		else:
-			bounds = bounds.expand(vertex)
-
-	for projected_obstruction: Dictionary in p_source_geometry.get_projected_obstructions():
-		var projected_obstruction_vertices: PackedFloat32Array = projected_obstruction["vertices"]
-		for i in projected_obstruction_vertices.size() / 3:
-			var vertex: Vector3 = Vector3(projected_obstruction.vertices[i * 3], projected_obstruction.vertices[i * 3 + 1], projected_obstruction.vertices[i * 3 + 2]);
-			if first_vertex:
-				first_vertex = false
-				bounds.position = vertex
-			else:
-				bounds = bounds.expand(vertex)
-
-	return bounds
-
-
 func _process(_delta: float) -> void:
 	var mouse_cursor_position: Vector2 = get_viewport().get_mouse_position()
 
@@ -152,6 +121,8 @@ func _process(_delta: float) -> void:
 
 	%PathDebugCorridorFunnel.target_position = closest_point_on_navmesh
 	%PathDebugEdgeCentered.target_position = closest_point_on_navmesh
+	%PathDebugNoPostProcessing.target_position = closest_point_on_navmesh
 
 	%PathDebugCorridorFunnel.get_next_path_position()
 	%PathDebugEdgeCentered.get_next_path_position()
+	%PathDebugNoPostProcessing.get_next_path_position()

--- a/3d/navigation_mesh_chunks/navmesh_chhunks_demo_3d.tscn
+++ b/3d/navigation_mesh_chunks/navmesh_chhunks_demo_3d.tscn
@@ -93,6 +93,14 @@ debug_use_custom = true
 debug_path_custom_color = Color(1, 1, 0, 1)
 debug_path_custom_point_size = 10.0
 
+[node name="PathDebugNoPostProcessing" type="NavigationAgent3D" parent="DebugPaths"]
+unique_name_in_owner = true
+path_postprocessing = 2
+debug_enabled = true
+debug_use_custom = true
+debug_path_custom_color = Color(1, 0, 0, 1)
+debug_path_custom_point_size = 10.0
+
 [node name="DebugMousePos" type="Node3D" parent="DebugPaths"]
 unique_name_in_owner = true
 
@@ -148,5 +156,21 @@ color = Color(1, 1, 0, 1)
 [node name="Label" type="Label" parent="CanvasLayer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
 layout_mode = 2
 text = "Path edge-centered"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="CanvasLayer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="ColorRect" type="ColorRect" parent="CanvasLayer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+custom_minimum_size = Vector2(128, 8)
+layout_mode = 2
+size_flags_vertical = 4
+color = Color(1, 0, 0, 1)
+
+[node name="Label" type="Label" parent="CanvasLayer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+layout_mode = 2
+text = "Path no post-processing"
 horizontal_alignment = 1
 vertical_alignment = 1


### PR DESCRIPTION
Updates NavigationChunk demos for Godot 4.4 that has the newer `get_bounds()` function and new NavigationAgent no post-processing option.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
