### PR TITLE
Fix FPS-dependent movement in Navigation AStar demo

### DIFF
--- a/2d/navigation_astar/character.gd
+++ b/2d/navigation_astar/character.gd
@@ -25,7 +25,7 @@ func _ready() -> void:
 	_change_state(State.IDLE)
 
 
-func _process(_delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	if _state != State.FOLLOW:
 		return
 
@@ -44,6 +44,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		if event.is_action_pressed(&"teleport_to", false, true):
 			_change_state(State.IDLE)
 			global_position = _tile_map.round_local_position(_click_position)
+			reset_physics_interpolation()
 		elif event.is_action_pressed(&"move_to"):
 			_change_state(State.FOLLOW)
 
@@ -52,7 +53,7 @@ func _move_to(local_position: Vector2) -> bool:
 	var desired_velocity: Vector2 = (local_position - position).normalized() * speed
 	var steering: Vector2 = desired_velocity - _velocity
 	_velocity += steering / MASS
-	position += _velocity * get_process_delta_time()
+	position += _velocity * get_physics_process_delta_time()
 	rotation = _velocity.angle()
 	return position.distance_to(local_position) < ARRIVE_DISTANCE
 

--- a/2d/navigation_astar/game.tscn
+++ b/2d/navigation_astar/game.tscn
@@ -59,3 +59,4 @@ texture = ExtResource("6_b3lcn")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 offset = Vector2(576, 324)
+process_callback = 0

--- a/2d/navigation_astar/project.godot
+++ b/2d/navigation_astar/project.godot
@@ -40,6 +40,11 @@ move_to={
 ]
 }
 
+[physics]
+
+common/physics_ticks_per_second=120
+common/physics_interpolation=true
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
Previously, the way in which the spaceship steered depended on the rendered framerate. Very low framerates (< 20) could cause the ship to steer in circles with sharp turns.

This moves ship movement to the physics step to avoid this, and enables physics interpolation for smooth motion.

I noticed this while testing https://github.com/godotengine/godot-demo-projects/pull/1208.
