### PR TITLE
Minor spelling fixes in strings, comments and non-code files.

### DIFF
--- a/2d/bullet_shower/bullets.gd
+++ b/2d/bullet_shower/bullets.gd
@@ -1,5 +1,5 @@
 extends Node2D
-# This demo is an example of controling a high number of 2D objects with logic
+# This demo is an example of controlling a high number of 2D objects with logic
 # and collision without using nodes in the scene. This technique is a lot more
 # efficient than using instancing and nodes, but requires more programming and
 # is less visual. Bullets are managed together in the `bullets.gd` script.

--- a/2d/bullet_shower/player.gd
+++ b/2d/bullet_shower/player.gd
@@ -1,5 +1,5 @@
 extends Node2D
-# This demo is an example of controling a high number of 2D objects with logic
+# This demo is an example of controlling a high number of 2D objects with logic
 # and collision without using nodes in the scene. This technique is a lot more
 # efficient than using instancing and nodes, but requires more programming and
 # is less visual. Bullets are managed together in the `bullets.gd` script.

--- a/2d/physics_platformer/stage.tscn
+++ b/2d/physics_platformer/stage.tscn
@@ -348,7 +348,7 @@ size_flags_vertical = 0
 text = "This is a simple demo on how to make a platformer game with Godot.
 This version uses physics and the 2D physics engine for motion and collision.
 The demo also shows the benefits of using the scene system, where coins,
-enemies and the player are edited separatedly and instanced in the stage.
+enemies and the player are edited separately and instanced in the stage.
 
 To edit the base tiles for the  tileset, open the tileset_edit.tscn file and follow
 instructions."

--- a/3d/graphics_settings/settings.gd
+++ b/3d/graphics_settings/settings.gd
@@ -110,7 +110,7 @@ func _on_vsync_option_button_item_selected(index: int) -> void:
 	# Vertical synchronization locks framerate and makes screen tearing not visible at the cost of
 	# higher input latency and stuttering when the framerate target is not met.
 	# Adaptive V-Sync automatically disables V-Sync when the framerate target is not met, and enables
-	# V-Sync otherwise. This prevents suttering and reduces input latency when the framerate target
+	# V-Sync otherwise. This prevents stuttering and reduces input latency when the framerate target
 	# is not met, at the cost of visible tearing.
 	if index == 0: # Disabled (default)
 		DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
@@ -152,7 +152,7 @@ func _on_fxaa_option_button_item_selected(index: int) -> void:
 
 
 func _on_fullscreen_option_button_item_selected(index: int) -> void:
-	# To change between winow, fullscreen and other window modes,
+	# To change between window, fullscreen and other window modes,
 	# set the root mode to one of the options of Window.MODE_*.
 	# Other modes are maximized and minimized.
 	if index == 0: # Disabled (default)
@@ -172,7 +172,7 @@ func _on_shadow_size_option_button_item_selected(index):
 	if index == 0: # Minimum
 		RenderingServer.directional_shadow_atlas_set_size(512, true)
 		# Adjust shadow bias according to shadow resolution.
-		# Higher resultions can use a lower bias without suffering from shadow acne.
+		# Higher resolutions can use a lower bias without suffering from shadow acne.
 		directional_light.shadow_bias = 0.06
 
 		# Disable positional (omni/spot) light shadows entirely to further improve performance.

--- a/3d/ik/addons/sade/ik_fabrik.gd
+++ b/3d/ik/addons/sade/ik_fabrik.gd
@@ -5,7 +5,7 @@ extends Node3D
 
 # The delta/tolerance for the bone chain (how do the bones need to be before it is considered satisfactory)
 const CHAIN_TOLERANCE = 0.01
-# The amount of interations the bone chain will go through in an attempt to get to the target position
+# The amount of iterations the bone chain will go through in an attempt to get to the target position
 const CHAIN_MAX_ITER = 10
 
 @export var skeleton_path: NodePath:
@@ -87,7 +87,7 @@ var chain_origin = Vector3()
 # The combined length of every bone in the bone chain
 var total_length = INF
 # The amount of iterations we've been through, and whether or not we want to limit our solver to CHAIN_MAX_ITER
-# amounts of interations.
+# amounts of iterations.
 @export var chain_iterations: int = 0
 @export var limit_chain_iterations: bool = true
 # Should we reset chain_iterations on movement during our update method?
@@ -151,7 +151,7 @@ func _ready():
 	update_mode = update_mode
 
 
-# Various upate methods
+# Various update methods
 func _process(_delta):
 	if reset_iterations_on_update:
 		chain_iterations = 0
@@ -206,7 +206,7 @@ func update_skeleton():
 		for bone_name in bones_in_chain:
 			bone_IDs[bone_name] = skeleton.find_bone(bone_name)
 
-			# Set the bone node to the currect bone position
+			# Set the bone node to the current bone position
 			bone_nodes[i].global_transform = get_bone_transform(i)
 			# If this is not the last bone in the bone chain, make it look at the next bone in the bone chain
 			if i < bone_IDs.size()-1:
@@ -423,7 +423,7 @@ func _make_editor_sphere_at_node(node, color):
 	indicator_mesh.radial_segments = 8
 	indicator_mesh.rings = 4
 
-	# The mesh needs a material (unless we want to use the defualt one).
+	# The mesh needs a material (unless we want to use the default one).
 	# Let's create a material and use the EditorGizmoTexture to texture it.
 	var indicator_material = StandardMaterial3D.new()
 	indicator_material.flags_unshaded = true

--- a/3d/ik/addons/sade/ik_fabrik.gd
+++ b/3d/ik/addons/sade/ik_fabrik.gd
@@ -5,7 +5,7 @@ extends Node3D
 
 # The delta/tolerance for the bone chain (how do the bones need to be before it is considered satisfactory)
 const CHAIN_TOLERANCE = 0.01
-# The amount of iterations the bone chain will go through in an attempt to get to the target position
+# The number of iterations the bone chain will go through in an attempt to get to the target position
 const CHAIN_MAX_ITER = 10
 
 @export var skeleton_path: NodePath:
@@ -87,7 +87,7 @@ var chain_origin = Vector3()
 # The combined length of every bone in the bone chain
 var total_length = INF
 # The amount of iterations we've been through, and whether or not we want to limit our solver to CHAIN_MAX_ITER
-# amounts of iterations.
+# iterations.
 @export var chain_iterations: int = 0
 @export var limit_chain_iterations: bool = true
 # Should we reset chain_iterations on movement during our update method?

--- a/3d/ik/fps/example_player.gd
+++ b/3d/ik/fps/example_player.gd
@@ -5,7 +5,7 @@ const norm_grav = -38.8
 const MAX_SPEED = 22
 const JUMP_SPEED = 26
 const ACCEL = 8.5
-# Sprinting variables. Similar to the varibles above, just allowing for quicker movement
+# Sprinting variables. Similar to the variables above, just allowing for quicker movement
 const MAX_SPRINT_SPEED = 34
 const SPRINT_ACCEL = 18
 # How fast we slow down, and the steepest angle we can climb.
@@ -139,7 +139,7 @@ func process_input(delta):
 	# ----------------------------------
 
 	# ----------------------------------
-	# Leaninng
+	# Leaning
 	if Input.is_key_pressed(KEY_Q):
 		lean_value += 1.2 * delta
 	elif Input.is_key_pressed(KEY_E):

--- a/3d/labels_and_texts/README.md
+++ b/3d/labels_and_texts/README.md
@@ -15,7 +15,7 @@ PrimitiveMesh resource you use within a MeshsInstance3D node. Therefore, you
 won't see TextMesh in the Create New Node dialog.
 
 Icons can also be displayed in Label3D and TextMesh using icon fonts, which can
-be generated from SVG files using serivces like
+be generated from SVG files using services like
 [Fontello](https://fontello.com/). Note that while Label3D supports colored
 rasterized fonts (such as emoji), only monochrome fonts can be generated from
 Fontello. TextMesh and Label3D with MSDF fonts are limited to monochrome fonts

--- a/3d/sprites/README.md
+++ b/3d/sprites/README.md
@@ -22,7 +22,7 @@ complex animations or when you need to manage multiple frames efficiently.
 
 This demo includes examples of basic rotation animation and showcases how
 shaders can be applied to Sprite3D and AnimatedSprite3D for stylized results.
-The shaders demostration also shows how to create paper-like effects, which can
+The shaders demonstration also shows how to create paper-like effects, which can
 be useful for creating a unique visual style in most of the game.
 
 Language: GDScript

--- a/compute/texture/water_plane/water_compute.glsl
+++ b/compute/texture/water_plane/water_compute.glsl
@@ -24,7 +24,7 @@ void main() {
 
 	ivec2 uv = ivec2(gl_GlobalInvocationID.xy);
 
-	// Just in case the texture size is not divisable by 8.
+	// Just in case the texture size is not divisible by 8.
 	if ((uv.x > size.x) || (uv.y > size.y)) {
 		return;
 	}

--- a/gui/gd_paint/paint_control.gd
+++ b/gui/gd_paint/paint_control.gd
@@ -29,7 +29,7 @@ var mouse_click_start_pos := Vector2.INF
 
 # A boolean to tell whether we've set undo_elements_list_num, which holds the size of draw_elements_list
 # before a new stroke is added (unless the current brush mode is 'rectangle shape' or 'circle shape', in
-# which case we do things a litte differently. See the undo_stroke function for more details).
+# which case we do things a little differently. See the undo_stroke function for more details).
 var undo_set := false
 var undo_element_list_num := -1
 
@@ -73,7 +73,7 @@ func _process(_delta: float) -> void:
 					add_brush(mouse_pos, brush_mode)
 
 	else:
-		# We've finished our stroke, so we can set a new undo (if a new storke is made).
+		# We've finished our stroke, so we can set a new undo (if a new stroke is made).
 		undo_set = false
 
 		# If the mouse is inside the canvas.
@@ -97,7 +97,7 @@ func check_if_mouse_is_inside_canvas() -> bool:
 	# Make sure we have a mouse click starting position.
 	if mouse_click_start_pos != null:
 		# Make sure the mouse click starting position is inside the canvas.
-		# This is so if we start out click outside the canvas (say chosing a color from the color picker)
+		# This is so if we start out click outside the canvas (say choosing a color from the color picker)
 		# and then move our mouse back into the canvas, it won't start painting.
 		if Rect2(drawing_area.position, drawing_area.size).has_point(mouse_click_start_pos):
 			# Make sure the current mouse position is inside the canvas.
@@ -141,14 +141,14 @@ func add_brush(mouse_pos: Vector2, type: BrushMode) -> void:
 	var new_brush := {}
 
 	# Populate the dictionary with values based on the global brush variables.
-	# We will override these as needed if the brush is a rectange or circle.
+	# We will override these as needed if the brush is a rectangle or circle.
 	new_brush.brush_type = type
 	new_brush.brush_pos = mouse_pos
 	new_brush.brush_shape = brush_shape
 	new_brush.brush_size = brush_size
 	new_brush.brush_color = brush_color
 
-	# If the new bursh is a rectangle shape, we need to calculate the top left corner of the rectangle and the
+	# If the new brush is a rectangle shape, we need to calculate the top left corner of the rectangle and the
 	# bottom right corner of the rectangle.
 	if type == BrushMode.RECTANGLE_SHAPE:
 		var TL_pos := Vector2()
@@ -176,10 +176,10 @@ func add_brush(mouse_pos: Vector2, type: BrushMode) -> void:
 
 	# If the brush isa circle shape, then we need to calculate the radius of the circle.
 	if type == BrushMode.CIRCLE_SHAPE:
-		# Get the center point inbetween the mouse position and the position of the mouse when we clicked.
+		# Get the center point in between the mouse position and the position of the mouse when we clicked.
 		var center_pos := Vector2((mouse_pos.x + mouse_click_start_pos.x) / 2, (mouse_pos.y + mouse_click_start_pos.y) / 2)
 		# Assign the brush position to the center point, and calculate the radius of the circle using the distance from
-		# the center to the top/bottom positon of the mouse.
+		# the center to the top/bottom position of the mouse.
 		new_brush.brush_pos = center_pos
 		new_brush.brush_shape_circle_radius = center_pos.distance_to(Vector2(center_pos.x, mouse_pos.y))
 
@@ -193,7 +193,7 @@ func _draw() -> void:
 		match brush.brush_type:
 			BrushMode.PENCIL:
 				# If the brush shape is a rectangle, then we need to make a Rect2 so we can use draw_rect.
-				# Draw_rect draws a rectagle at the top left corner, using the scale for the size.
+				# Draw_rect draws a rectangle at the top left corner, using the scale for the size.
 				# So we offset the position by half of the brush size so the rectangle's center is at mouse position.
 				if brush.brush_shape == BrushShape.RECTANGLE:
 					var rect := Rect2(brush.brush_pos - Vector2(brush.brush_size / 2, brush.brush_size / 2), Vector2(brush.brush_size, brush.brush_size))
@@ -214,7 +214,7 @@ func _draw() -> void:
 				elif brush.brush_shape == BrushShape.CIRCLE:
 					draw_circle(brush.brush_pos, brush.brush_size / 2, bg_color)
 			BrushMode.RECTANGLE_SHAPE:
-				# We make a Rect2 with the postion at the top left. To get the size we take the bottom right position
+				# We make a Rect2 with the position at the top left. To get the size we take the bottom right position
 				# and subtract the top left corner's position.
 				var rect := Rect2(brush.brush_pos, brush.brush_shape_rect_pos_BR - brush.brush_pos)
 				draw_rect(rect, brush.brush_color)

--- a/gui/gd_paint/tools_panel.gd
+++ b/gui/gd_paint/tools_panel.gd
@@ -68,7 +68,7 @@ func button_pressed(button_name: String) -> void:
 		paint_control.brush_shape = paint_control.BrushShape.CIRCLE
 		shape_name = "Circle"
 
-	# If an operation button is pressed
+	# If an operation button is pressed.
 	elif button_name == "clear_picture":
 		paint_control.brush_data_list.clear()
 		paint_control.queue_redraw()

--- a/gui/gd_paint/tools_panel.gd
+++ b/gui/gd_paint/tools_panel.gd
@@ -68,7 +68,7 @@ func button_pressed(button_name: String) -> void:
 		paint_control.brush_shape = paint_control.BrushShape.CIRCLE
 		shape_name = "Circle"
 
-	# If a opperation button is pressed
+	# If an operation button is pressed
 	elif button_name == "clear_picture":
 		paint_control.brush_data_list.clear()
 		paint_control.queue_redraw()
@@ -90,7 +90,7 @@ func brush_color_changed(color: Color) -> void:
 
 
 func background_color_changed(color: Color) -> void:
-	# Change the background color to whatever colorthe background color picker is.
+	# Change the background color to whatever color the background color picker is.
 	get_parent().get_node(^"DrawingAreaBG").modulate = color
 	paint_control.bg_color = color
 	# Because of how the eraser works we also need to redraw the paint control.
@@ -104,5 +104,5 @@ func brush_size_changed(value: float) -> void:
 
 
 func save_file_selected(path: String) -> void:
-	# Call save_picture in paint_control, passing in the path we recieved from SaveFileDialog.
+	# Call save_picture in paint_control, passing in the path we received from SaveFileDialog.
 	paint_control.save_picture(path)

--- a/gui/translation/README.md
+++ b/gui/translation/README.md
@@ -16,7 +16,7 @@ automatically on locale change. This process is known as *remapping*.
 Both CSV and gettext (PO/POT) approaches are showcased. Use the button in the
 bottom-right corner to switch between the two approaches.
 
-The resouce remapping process with PO is the same with CSV. The in-game text translation
+The resource remapping process with PO is the same with CSV. The in-game text translation
 process is also the same – use keys to fetch the appropriate translation.
 
 The main difference between PO files and CSV files is the way both of them store

--- a/gui/translation/translation_demo_po.tscn
+++ b/gui/translation/translation_demo_po.tscn
@@ -70,7 +70,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 0
 text = "This second demo showcases localization using gettext (PO/POT) files.
 
-The resouce remapping process is the same with CSV. The in-game text translation
+The resource remapping process is the same with CSV. The in-game text translation
 process is also the same – use keys to fetch the appropriate translation.
 
 The main difference between PO files and CSV files is the way both of them store

--- a/gui/translation/translations/po/translation_demo.pot
+++ b/gui/translation/translations/po/translation_demo.pot
@@ -37,7 +37,7 @@ msgstr ""
 #: translation_demo_po.tscn
 msgid "This second demo shows translation using PO files. "
 ""
-"The resouce remapping process is the same with CSV. The in-game text translation "
+"The resource remapping process is the same with CSV. The in-game text translation "
 "process is also the same - use keys to fetch the appropriate translation."
 ""
 "The main difference between PO files and CSV files is the way both of them store "

--- a/gui/translation/translations/po/translation_demo_es.po
+++ b/gui/translation/translations/po/translation_demo_es.po
@@ -43,7 +43,7 @@ msgstr ""
 
 #: translation_demo_po.tscn
 msgid ""
-"This second demo shows translation using PO files. The resouce remapping "
+"This second demo shows translation using PO files. The resource remapping "
 "process is the same with CSV. The in-game text translation process is also "
 "the same - use keys to fetch the appropriate translation.The main difference "
 "between PO files and CSV files is the way both of them store the translated "

--- a/gui/translation/translations/po/translation_demo_ja.po
+++ b/gui/translation/translations/po/translation_demo_ja.po
@@ -42,7 +42,7 @@ msgstr ""
 
 #: translation_demo_po.tscn
 msgid ""
-"This second demo shows translation using PO files. The resouce remapping "
+"This second demo shows translation using PO files. The resource remapping "
 "process is the same with CSV. The in-game text translation process is also "
 "the same - use keys to fetch the appropriate translation.The main difference "
 "between PO files and CSV files is the way both of them store the translated "

--- a/misc/graphics_tablet_input/graphics_tablet_input.gd
+++ b/misc/graphics_tablet_input/graphics_tablet_input.gd
@@ -14,7 +14,7 @@ var event_tilt: Vector2
 var line_color := Color.BLACK
 var line_width: float = 3.0
 
-# If `true`, modulate line width accordding to pen pressure.
+# If `true`, modulate line width according to pen pressure.
 # This is done using a width curve that is continuously recreated to match the line's actual profile
 # as the line is being drawn by the user.
 var pressure_sensitive: bool = true

--- a/misc/joypads/joypads.gd
+++ b/misc/joypads/joypads.gd
@@ -71,7 +71,7 @@ func _process(_delta: float) -> void:
 				# Transparent white modulate, non-alpha color channels are not changed here.
 				joypad_axes.get_node(str(axis)).self_modulate.a = scaled_alpha_value
 
-		# Highlight axis labels that are within the "active" value range. Simular to the button highlighting for loop below.
+		# Highlight axis labels that are within the "active" value range. Similar to the button highlighting for loop below.
 		axes.get_node("Axis" + str(axis) + "/Label").add_theme_color_override("font_color", FONT_COLOR_DEFAULT)
 		if abs(axis_value) >= DEADZONE:
 			axes.get_node("Axis" + str(axis) + "/Label").add_theme_color_override("font_color", FONT_COLOR_ACTIVE)

--- a/misc/window_management/README.md
+++ b/misc/window_management/README.md
@@ -13,7 +13,7 @@ A demo showing the various window management features available through
 
 Language: GDScript
 
-Renderer: Compatbility
+Renderer: Compatibility
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/2791
 

--- a/networking/webrtc_signaling/README.md
+++ b/networking/webrtc_signaling/README.md
@@ -1,6 +1,6 @@
 # A WebSocket signaling server/client for WebRTC.
 
-This demo is devided in 4 parts:
+This demo is divided in 4 parts:
 
 - The `server` folder contains the signaling server implementation written in GDScript (so it can be run by a game server running Godot)
 - The `server_node` folder contains the signaling server implementation written in Node.js (if you don't plan to run a game server but only match-making).

--- a/networking/webrtc_signaling/project.godot
+++ b/networking/webrtc_signaling/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="WebRTC Signaling Example"
 config/description="A WebSocket signaling server/client for WebRTC.
-This demo is devided in 4 parts.
+This demo is divided in 4 parts.
 The protocol is text based, and composed by a command and possibly
 multiple payload arguments, each separated by a new line."
 config/tags=PackedStringArray("demo", "network", "official")

--- a/networking/websocket_chat/client.gd
+++ b/networking/websocket_chat/client.gd
@@ -13,7 +13,7 @@ func info(msg: String) -> void:
 #region Client signals
 func _on_web_socket_client_connection_closed() -> void:
 	var ws := _client.get_socket()
-	info("Client just disconnected with code: %s, reson: %s" % [ws.get_close_code(), ws.get_close_reason()])
+	info("Client just disconnected with code: %s, reason: %s" % [ws.get_close_code(), ws.get_close_reason()])
 
 
 func _on_web_socket_client_connected_to_server() -> void:

--- a/plugins/addons/material_creator/material_resource.gd
+++ b/plugins/addons/material_creator/material_resource.gd
@@ -10,7 +10,7 @@ var metallic_strength := 0.0
 var roughness_strength := 0.0
 
 
-# Convert our data into an dictonary so we can convert it
+# Convert our data into an dictionary so we can convert it
 # into the JSON format.
 func make_json() -> String:
 	var json_dict := {}
@@ -26,7 +26,7 @@ func make_json() -> String:
 	return JSON.stringify(json_dict)
 
 
-# Convert the passed in string to a JSON dictonary, and then
+# Convert the passed in string to a JSON dictionary, and then
 # fill in our data.
 func from_json(json_dict_as_string: String) -> void:
 	var json_dict: Dictionary = JSON.parse_string(json_dict_as_string)

--- a/viewport/2d_in_3d/pong.gd
+++ b/viewport/2d_in_3d/pong.gd
@@ -25,7 +25,7 @@ func _process(delta: float) -> void:
 	var left_rect := Rect2(left_paddle.get_position() - pad_size * 0.5, pad_size)
 	var right_rect := Rect2(right_paddle.get_position() - pad_size * 0.5, pad_size)
 
-	# Integrate new ball postion.
+	# Integrate new ball position.
 	ball_pos += direction * ball_speed * delta
 
 	# Flip when touching roof or floor.

--- a/viewport/dynamic_split_screen/README.md
+++ b/viewport/dynamic_split_screen/README.md
@@ -12,12 +12,12 @@ Check out this demo on the asset library: https://godotengine.org/asset-library/
 ## Details
 
 A dynamic split screen system displays a single screen when
-the two players are close but a splitted view when they move apart.
+the two players are close but a split view when they move apart.
 
 The splitting line can take any angle depending on the players'
 position, so it won't be either vertical or horizontal.
 
-This system was popularized by the Lego videogames.
+This system was popularized by the Lego video games.
 
 ## How it works
 
@@ -26,7 +26,7 @@ texture, as well as some other parameters, are passed to a
 shader attached to a TextureRect filling the whole screen.
 
 The `SplitScreen` shader, with the help of the `CameraController`
-script, chooses wich texture to display on each pixel to
+script, chooses which texture to display on each pixel to
 achieve the effect.
 
 The cameras are placed on the segment joining the two players,

--- a/viewport/dynamic_split_screen/camera_controller.gd
+++ b/viewport/dynamic_split_screen/camera_controller.gd
@@ -1,6 +1,6 @@
 extends Node3D
 # Handle the motion of both player cameras as well as communication with the
-# SplitScreen shader to achieve the dynamic split screen effet
+# SplitScreen shader to achieve the dynamic split screen effect
 #
 # Cameras are place on the segment joining the two players, either in the middle
 # if players are close enough or at a fixed distance if they are not.
@@ -8,7 +8,7 @@ extends Node3D
 # the first one is used for the entire screen thus allowing the players to play
 # on a unsplit screen.
 # In the second case, the screen is split in two with a line perpendicular to the
-# segement joining the two players.
+# segment joining the two players.
 #
 # The points of customization are:
 #   max_separation: the distance between players at which the view starts to split

--- a/xr/openxr_character_centric_movement/README.md
+++ b/xr/openxr_character_centric_movement/README.md
@@ -12,7 +12,7 @@ Check out this demo on the asset library: https://godotengine.org/asset-library/
 ## How does it work?
 
 With modern VR equipment the user is able to move around a large playspace.
-This is often refered to as roomscale VR.
+This is often referred to as roomscale VR.
 The position of the headset and controllers are tracked in reference to a fixed point within this playspace.
 This is often a point on the ground at the center of the playspace mapped out by the user when setting up their guardian.
 

--- a/xr/openxr_hand_tracking_demo/README.md
+++ b/xr/openxr_hand_tracking_demo/README.md
@@ -51,7 +51,7 @@ For advanced gesture recognition you would still use this data however it is now
 the physical means in which this data is obtained.
 
 At the same time, in this school of thought the action map system is seen as the primary means to gain input
-and is no longer restriced to input from controllers. The XR runtime is now responsible for recognising base
+and is no longer restricted to input from controllers. The XR runtime is now responsible for recognising base
 gestures such as pinching and pointing resulting in inputs that can be bound in the action map.
 
 OpenXR is moving towards this approach and this demo has been build in accordance with this however not all runtimes have been updated yet.
@@ -67,7 +67,7 @@ For other runtimes like Picos, HTC, Varjos, Magic Leaps, etc. may or may not yet
 
 ### Conclusion
 
-Due to the wildgrowth in capabilities in XR runtimes,
+Due to the wild growth in capabilities in XR runtimes,
 and there being no solid way to detect the full limitations of the platform you are currently on,
 Godot XR Tools does not have support for the hand tracking API and purely relies on its own inferred hand positioning approach.
 
@@ -105,7 +105,7 @@ This split is applied because:
 
 ## (Half) body Tracking API
 
-Just an honerable mention of this, this is not part of this demo but Godot now also has support
+Just an honorable mention of this, this is not part of this demo but Godot now also has support
 for half and full body tracking that includes hand tracking. This functionality however is only
 available on a limited number of XR runtimes.
 

--- a/xr/openxr_origin_centric_movement/README.md
+++ b/xr/openxr_origin_centric_movement/README.md
@@ -12,7 +12,7 @@ Check out this demo on the asset library: https://godotengine.org/asset-library/
 ## How does it work?
 
 With modern VR equipment the user is able to move around a large playspace.
-This is often refered to as roomscale VR.
+This is often referred to as roomscale VR.
 The position of the headset and controllers are tracked in reference to a fixed point within this playspace.
 This is often a point on the ground at the center of the playspace mapped out by the user when setting up their guardian.
 


### PR DESCRIPTION
This is a set of hand picked and entered (no LLM's here) spelling fixes in only strings, comments and non-code files.

No functional changes should exist here: I avoided changing any variables or other code based spellings.

These should be non-controversial: I didn't get into yak shaving about hyphenated words or industry terms. Just the "normal words", and I tried to avoid changing anything that was just an acceptable alternate based on national origin (i.e. US vs British).

Credit to `cspell`: I used `cspell` to find these to start with, but the changes were hand picked based on being good targets and then hand-fixed to make sure they made sense in context and had no affect on code operation.

As justification: Finding a lot of spelling mistakes in comments and descriptions causes some issues for some people such as:
1. Because of how some people read, it can trip them up and slow them down.
2. It can make what is otherwise high quality code feel "amateurish" even though it is not.

This is by no means exhaustive, but hopefully meaningful.

_This is all because I ran into one spelling error and wanted to fix it, but I felt it would waste everyone's time to make a PR for one fix. hopefully this is worth the time._