### PR TITLE
Fix uniform sets in "Compute Texture"

### DIFF
--- a/compute/texture/water_plane/water_plane.gd
+++ b/compute/texture/water_plane/water_plane.gd
@@ -210,10 +210,15 @@ func _render_process(with_next_texture: int, wave_point: Vector4, tex_size: Vect
 	@warning_ignore("integer_division")
 	var y_groups := (tex_size.y - 1) / 8 + 1
 
+	# Figure out which texture to assign to which set.
+	var current_texture_rd := texture_rds[(with_next_texture - 1) % 3]
+	var previous_texture_rd := texture_rds[(with_next_texture - 2) % 3]
+	var next_texture_rd := texture_rds[with_next_texture]
+
 	# Create our uniform sets so we can use these textures in our shader.
-	var current_set := _create_uniform_set(texture_rds[(with_next_texture - 1) % 3], 0)
-	var previous_set := _create_uniform_set(texture_rds[(with_next_texture - 2) % 3], 1)
-	var next_set := _create_uniform_set(texture_rds[with_next_texture], 2)
+	var current_set := _create_uniform_set(current_texture_rd, 0)
+	var previous_set := _create_uniform_set(previous_texture_rd, 1)
+	var next_set := _create_uniform_set(next_texture_rd, 2)
 
 	# Run our compute shader.
 	var compute_list := rd.compute_list_begin()


### PR DESCRIPTION
Fix uniform sets that were hardcoded as `0`, which seems to work with `v4.4` but has broken this demo in `v4.5`.

Still works with `v4.4.1` ✅ 

Also removed the unnecessary texture usage bits.

---

```
  ERROR: Uniforms supplied for set (2):
  ERROR: Set: 0 Binding: 0 Type: Image Writable: N Length: 1
  ERROR: are not the same format as required by the pipeline shader. Pipeline shader requires the following bindings:
  ERROR: Set: 0 Binding: 0 Type: Image Writable: N Length: 1
  ERROR: Set: 1 Binding: 0 Type: Image Writable: N Length: 1
  ERROR: Set: 2 Binding: 0 Type: Image Writable: Y Length: 1
```
