### PR TITLE
Fix physics joint warning in Truck Town when using tow truck

### DIFF
--- a/3d/truck_town/vehicles/tow_truck.tscn
+++ b/3d/truck_town/vehicles/tow_truck.tscn
@@ -296,19 +296,16 @@ node_b = NodePath("../ChainB2")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.644947, -1.85661)
 node_a = NodePath("../ChainB2")
 node_b = NodePath("../ChainB3")
-params/bias = 0.5
 
 [node name="PinJoint4" type="PinJoint3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.350687, -2.04279)
 node_a = NodePath("../ChainB3")
 node_b = NodePath("../ChainB4")
-params/bias = 0.5
 
 [node name="PinJoint5" type="PinJoint3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.217609, -2.33375)
 node_a = NodePath("../ChainB4")
 node_b = NodePath("../ChainB5")
-params/bias = 0.5
 
 [node name="Body2" type="VehicleBody3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00169557, 0.222867, -3.97518)


### PR DESCRIPTION
Following the switch to Jolt Physics, 3 warnings were printed every time you selected the tow truck in Truck Town, as custom joint bias is not supported.

This reverts 3 of the joints to use the default bias, which appears to have no negative impact on behavior on either Jolt Physics or GodotPhysics3D.
