### PR TITLE
Use GodotPhysics3D in Voxel demo to work around performance issue

### DIFF
--- a/3d/voxel/project.godot
+++ b/3d/voxel/project.godot
@@ -148,8 +148,8 @@ pick_block={
 [physics]
 
 common/physics_ticks_per_second=120
+3d/physics_engine="GodotPhysics3D"
 3d/default_gravity=20.0
-3d/physics_engine="Jolt Physics"
 common/physics_interpolation=true
 
 [rendering]


### PR DESCRIPTION
This avoids stuttering during world generation due to mutating compound shapes being slow in Jolt Physics.

This is especially noticeable in the Flat Grass world due to the higher number of voxels being generated.

- See https://github.com/godotengine/godot/pull/111115.
