### PR TITLE
Fix bright streaks in tunnel in Platformer 3D demo

### DIFF
--- a/3d/platformer/stage/stage.tscn
+++ b/3d/platformer/stage/stage.tscn
@@ -52,7 +52,7 @@ box_projection = true
 [node name="Reflection2" type="ReflectionProbe" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 15, 0, 0)
 intensity = 0.5
-size = Vector3(16, 5, 6)
+size = Vector3(16, 6, 6)
 origin_offset = Vector3(0, -0.22168, 0)
 box_projection = true
 
@@ -65,11 +65,10 @@ origin_offset = Vector3(0, -0.22168, 0)
 box_projection = true
 
 [node name="Reflection7" type="ReflectionProbe" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 17.0391, 6.19519, 1.14534)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 17.039, 6, 1.145)
 intensity = 0.5
 max_distance = 18.7
-size = Vector3(8, 6, 14)
-origin_offset = Vector3(0, -0.22168, 0)
+size = Vector3(11, 6, 16)
 box_projection = true
 
 [node name="Reflection4" type="ReflectionProbe" parent="."]


### PR DESCRIPTION
This adjusts reflection probes following the blend distance changes in 4.4.

## Preview

<img width="567" height="315" alt="Screenshot 2025-10-02 at 15 45 39" src="https://github.com/user-attachments/assets/032b7eb3-5a01-4a04-af74-b0625a99b2e6" />