### PR TITLE
Link C# version in Squash the Creeps demo README

### DIFF
--- a/2d/dodge_the_creeps/README.md
+++ b/2d/dodge_the_creeps/README.md
@@ -12,7 +12,9 @@ Language: GDScript
 
 Renderer: Compatibility
 
-Note: There is a C# version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/mono/dodge_the_creeps).
+> [!NOTE]
+>
+> There is a C# version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/mono/dodge_the_creeps).
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/2712
 

--- a/2d/pong/README.md
+++ b/2d/pong/README.md
@@ -8,7 +8,9 @@ Language: GDScript
 
 Renderer: Compatibility
 
-Note: There is a C# version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/mono/pong).
+> [!NOTE]
+>
+> There is a C# version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/mono/pong).
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/2728
 

--- a/3d/squash_the_creeps/README.md
+++ b/3d/squash_the_creeps/README.md
@@ -29,6 +29,10 @@ Language: GDScript
 
 Renderer: Forward+
 
+> [!NOTE]
+>
+> There is a C# version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/mono/squash_the_creeps).
+
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/2751
 
 ## Screenshots

--- a/misc/2.5d/README.md
+++ b/misc/2.5d/README.md
@@ -8,7 +8,9 @@ Language: GDScript
 
 Renderer: Compatibility
 
-Note: There is a C# version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/mono/2.5d).
+> [!NOTE]
+>
+> There is a C# version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/mono/2.5d).
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/2783
 

--- a/mono/2.5d/README.md
+++ b/mono/2.5d/README.md
@@ -8,7 +8,9 @@ Language: [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_shar
 
 Renderer: Compatibility
 
-Note: There is a GDScript version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/misc/2.5d).
+> [!NOTE]
+>
+> There is a GDScript version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/misc/2.5d).
 
 ## How does it work?
 

--- a/mono/dodge_the_creeps/README.md
+++ b/mono/dodge_the_creeps/README.md
@@ -12,7 +12,9 @@ Language: [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_shar
 
 Renderer: Compatibility
 
-Note: There is a GDScript version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/2d/dodge_the_creeps).
+> [!NOTE]
+>
+> There is a GDScript version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/2d/dodge_the_creeps).
 
 ## Screenshots
 

--- a/mono/pong/README.md
+++ b/mono/pong/README.md
@@ -8,7 +8,9 @@ Language: [C#](https://docs.godotengine.org/en/latest/tutorials/scripting/c_shar
 
 Renderer: Compatibility
 
-Note: There is a GDScript version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/2d/pong).
+> [!NOTE]
+>
+> There is a GDScript version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/2d/pong).
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/2796
 

--- a/mono/squash_the_creeps/README.md
+++ b/mono/squash_the_creeps/README.md
@@ -29,6 +29,10 @@ Language: C#
 
 Renderer: Forward+
 
+> [!NOTE]
+>
+> There is a GDScript version available [here](https://github.com/godotengine/godot-demo-projects/tree/master/3d/squash_the_creeps).
+
 ## Screenshots
 
 ![Screenshot](screenshots/squash_the_creeps.webp)


### PR DESCRIPTION
- Demos counterpart of https://github.com/godotengine/godot-docs/pull/11443.

___

- Also add a link the other way around (from the C# version to the GDScript version) to match Dodge the Creeps.
- Use GitHub admonition syntax.

___

- See https://github.com/godotengine/godot-docs/issues/4427#issuecomment-3492945989.
