### PR TITLE
Fix memory leak in "Compute Texture"

### DIFF
--- a/compute/texture/water_plane/water_plane.gd
+++ b/compute/texture/water_plane/water_plane.gd
@@ -219,7 +219,7 @@ func _render_process(with_next_texture: int, wave_point: Vector4, tex_size: Vect
 	@warning_ignore("integer_division")
 	var y_groups := (tex_size.y - 1) / 8 + 1
 
-	# Figure out which uniforms to assign.
+	# Figure out which texture to assign to which set.
 	var current_set := texture_sets[with_next_texture * 3]
 	var previous_set := texture_sets[with_next_texture * 3 + 1]
 	var next_set := texture_sets[with_next_texture * 3 + 2]


### PR DESCRIPTION
Fix a memory leak resulting from improper uniform set handling introduced in #1247.

Follow the recommendation in https://github.com/godotengine/godot-demo-projects/issues/1269#issuecomment-3478434095.


<img width="1035" height="436" alt="Compute Texture memory profiling" src="https://github.com/user-attachments/assets/b724ea44-6843-4259-8993-e4c24258a7f3" />


Also address warning:
```
The local function parameter "input_event" is shadowing an already-declared signal in the base class "CollisionObject3D".
```

---

Tested in:
- [x] v4.5.1.stable
- [x] v4.4.1.stable

---

Closes:
- #1269