### PR TITLE
Add SMAA option to the 3D antialiasing and graphics settings demos

### DIFF
--- a/3d/antialiasing/README.md
+++ b/3d/antialiasing/README.md
@@ -1,13 +1,17 @@
 # 3D Anti-Aliasing
 
-This project showcases the various 3D antialiasing techniques supported by Godot.
+This project showcases the various [3D antialiasing](https://docs.godotengine.org/en/latest/tutorials/3d/3d_antialiasing.html)
+techniques supported by Godot.
 
 - **Multisample antialiasing (MSAA):** High quality, high performance cost.
   Does not blur the image.
   - Does not affect shader-induced aliasing (such as specular aliasing) or alpha
 	scissor materials, so these will remain aliased.
-- **Fast approximate antialiasing (FXAA):** Medium quality, low performance cost.
+- **Fast approximate antialiasing (FXAA):** Low quality, low performance cost.
   Slightly blurs the image.
+- **Subpixel morphological antialiasing (SMAA):** Medium quality, moderate performance
+  cost. Slightly blurs the image, but not as much as FXAA. Godot only supports
+  the spatial version of SMAA, also called SMAA 1x.
 - **Temporal antialiasing (TAA):** High-quality, low performance cost. Slightly
   blurs the image (but less so than FXAA).
   - Antialiasing quality is worse on fast-moving objects than other methods,

--- a/3d/antialiasing/anti_aliasing.tscn
+++ b/3d/antialiasing/anti_aliasing.tscn
@@ -813,7 +813,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -68)
 mesh = SubResource("SphereMesh_v4x6x")
 
 [node name="Decal" type="Decal" parent="Testers/MovingDecal"]
-transform = Transform3D(-0.70710397, -1.0132787e-06, -0.7071092, 0.18301255, 0.96592563, -0.1830126, 0.68301517, -0.25881886, -0.68300986, 1, 1, 1)
+transform = Transform3D(-0.70710397, -1.0132787e-06, -0.7071092, 0.18301255, 0.9659256, -0.1830126, 0.68301517, -0.25881886, -0.68300986, 1, 1, 1)
 texture_albedo = ExtResource("3_2nulf")
 texture_normal = ExtResource("4_fdfpv")
 
@@ -886,20 +886,19 @@ offset_right = 394.0
 offset_bottom = 340.0
 theme_override_constants/separation = 10
 
-[node name="MSAAContainer" type="HBoxContainer" parent="Antialiasing"]
+[node name="MultisampleAAContainer" type="HBoxContainer" parent="Antialiasing"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Antialiasing/MSAAContainer"]
+[node name="Label" type="Label" parent="Antialiasing/MultisampleAAContainer"]
 custom_minimum_size = Vector2(120, 2.08165e-12)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
-text = "MSAA
-"
+text = "Multisample AA"
 vertical_alignment = 1
 
-[node name="MSAA" type="OptionButton" parent="Antialiasing/MSAAContainer"]
+[node name="MultisampleAA" type="OptionButton" parent="Antialiasing/MultisampleAAContainer"]
 custom_minimum_size = Vector2(235, 2.08165e-12)
 layout_mode = 2
 selected = 0
@@ -913,43 +912,43 @@ popup/item_2/id = 2
 popup/item_3/text = "8× (Slower)"
 popup/item_3/id = 3
 
-[node name="FXAAContainer" type="HBoxContainer" parent="Antialiasing"]
+[node name="ScreenSpaceAAContainer" type="HBoxContainer" parent="Antialiasing"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Antialiasing/FXAAContainer"]
+[node name="Label" type="Label" parent="Antialiasing/ScreenSpaceAAContainer"]
 custom_minimum_size = Vector2(120, 2.08165e-12)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
-text = "FXAA
-"
+text = "Screen-Space AA"
 vertical_alignment = 1
 
-[node name="FXAA" type="OptionButton" parent="Antialiasing/FXAAContainer"]
+[node name="ScreenSpaceAA" type="OptionButton" parent="Antialiasing/ScreenSpaceAAContainer"]
 custom_minimum_size = Vector2(235, 2.08165e-12)
 layout_mode = 2
 selected = 0
-item_count = 2
+item_count = 3
 popup/item_0/text = "Disabled (Fastest)"
 popup/item_0/id = 0
-popup/item_1/text = "Enabled (Fast)"
+popup/item_1/text = "FXAA (Fast)"
 popup/item_1/id = 1
+popup/item_2/text = "SMAA (Average)"
+popup/item_2/id = 2
 
-[node name="TAAContainer" type="HBoxContainer" parent="Antialiasing"]
+[node name="TemporalAAContainer" type="HBoxContainer" parent="Antialiasing"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Antialiasing/TAAContainer"]
+[node name="Label" type="Label" parent="Antialiasing/TemporalAAContainer"]
 custom_minimum_size = Vector2(120, 2.08165e-12)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
-text = "TAA
-"
+text = "Temporal AA"
 vertical_alignment = 1
 
-[node name="TAA" type="OptionButton" parent="Antialiasing/TAAContainer"]
+[node name="TemporalAA" type="OptionButton" parent="Antialiasing/TemporalAAContainer"]
 custom_minimum_size = Vector2(235, 2.08165e-12)
 layout_mode = 2
 selected = 0
@@ -983,20 +982,20 @@ popup/item_1/id = 1
 popup/item_2/text = "Enabled"
 popup/item_2/id = 2
 
-[node name="LimitFPSContainer" type="HBoxContainer" parent="Antialiasing"]
+[node name="FPSLimitContainer" type="HBoxContainer" parent="Antialiasing"]
 layout_mode = 2
 theme_override_constants/separation = 15
 
-[node name="Label" type="Label" parent="Antialiasing/LimitFPSContainer"]
+[node name="Label" type="Label" parent="Antialiasing/FPSLimitContainer"]
 custom_minimum_size = Vector2(120, 2.08165e-12)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
-text = "Limit FPS"
+text = "FPS Limit"
 vertical_alignment = 1
 
-[node name="LimitFPSScale" type="HSlider" parent="Antialiasing/LimitFPSContainer"]
+[node name="FPSLimitScale" type="HSlider" parent="Antialiasing/FPSLimitContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
@@ -1004,12 +1003,12 @@ size_flags_stretch_ratio = 3.0
 max_value = 300.0
 step = 10.0
 
-[node name="Value" type="Label" parent="Antialiasing/LimitFPSContainer"]
+[node name="Value" type="Label" parent="Antialiasing/FPSLimitContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
-text = "0"
+text = "∞"
 horizontal_alignment = 1
 vertical_alignment = 1
 
@@ -1099,11 +1098,11 @@ metadata/gradient = SubResource("Gradient_ehij4")
 
 [connection signal="pressed" from="Previous" to="." method="_on_previous_pressed"]
 [connection signal="pressed" from="Next" to="." method="_on_next_pressed"]
-[connection signal="item_selected" from="Antialiasing/MSAAContainer/MSAA" to="." method="_on_msaa_item_selected"]
-[connection signal="item_selected" from="Antialiasing/FXAAContainer/FXAA" to="." method="_on_fxaa_item_selected"]
-[connection signal="item_selected" from="Antialiasing/TAAContainer/TAA" to="." method="_on_taa_item_selected"]
+[connection signal="item_selected" from="Antialiasing/MultisampleAAContainer/MultisampleAA" to="." method="_on_msaa_item_selected"]
+[connection signal="item_selected" from="Antialiasing/ScreenSpaceAAContainer/ScreenSpaceAA" to="." method="_on_screen_space_aa_item_selected"]
+[connection signal="item_selected" from="Antialiasing/TemporalAAContainer/TemporalAA" to="." method="_on_taa_item_selected"]
 [connection signal="item_selected" from="Antialiasing/VSyncContainer/VSync" to="." method="_on_v_sync_item_selected"]
-[connection signal="value_changed" from="Antialiasing/LimitFPSContainer/LimitFPSScale" to="." method="_on_limit_fps_scale_value_changed"]
+[connection signal="value_changed" from="Antialiasing/FPSLimitContainer/FPSLimitScale" to="." method="_on_fps_limit_scale_value_changed"]
 [connection signal="value_changed" from="Antialiasing/RenderScaleContainer/RenderScale" to="." method="_on_render_scale_value_changed"]
 [connection signal="toggled" from="Antialiasing/FidelityFXFSR" to="." method="_on_amd_fidelityfx_fsr1_toggled"]
 [connection signal="item_selected" from="Antialiasing/FSRSharpness" to="." method="_on_fsr_sharpness_item_selected"]

--- a/3d/antialiasing/polyhaven/textures/dutch_ship_medium_hull_arm_1k.jpg.import
+++ b/3d/antialiasing/polyhaven/textures/dutch_ship_medium_hull_arm_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://y1d8bbofs2j1"
-path.s3tc="res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_hull_arm_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/antialiasing/polyhaven/textures/dutch_ship_medium_hull_diff_1k.jpg.import
+++ b/3d/antialiasing/polyhaven/textures/dutch_ship_medium_hull_diff_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cpqm052kluinu"
-path.s3tc="res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_hull_diff_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/antialiasing/polyhaven/textures/dutch_ship_medium_hull_nor_gl_1k.jpg.import
+++ b/3d/antialiasing/polyhaven/textures/dutch_ship_medium_hull_nor_gl_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dx4v7lwh3dlk2"
-path.s3tc="res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_hull_nor_gl_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/antialiasing/polyhaven/textures/dutch_ship_medium_rigging_arm_1k.jpg.import
+++ b/3d/antialiasing/polyhaven/textures/dutch_ship_medium_rigging_arm_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cprmlobj741yv"
-path.s3tc="res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_rigging_arm_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/antialiasing/polyhaven/textures/dutch_ship_medium_rigging_diff_1k.jpg.import
+++ b/3d/antialiasing/polyhaven/textures/dutch_ship_medium_rigging_diff_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d0r11ltathrwx"
-path.s3tc="res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_rigging_diff_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/antialiasing/polyhaven/textures/dutch_ship_medium_rigging_nor_gl_1k.jpg.import
+++ b/3d/antialiasing/polyhaven/textures/dutch_ship_medium_rigging_nor_gl_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bws456aqy70dc"
-path.s3tc="res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_rigging_nor_gl_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/antialiasing/polyhaven/textures/dutch_ship_medium_sails_arm_1k.jpg.import
+++ b/3d/antialiasing/polyhaven/textures/dutch_ship_medium_sails_arm_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d2kym821onkb2"
-path.s3tc="res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_sails_arm_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/antialiasing/polyhaven/textures/dutch_ship_medium_sails_diff_1k.jpg.import
+++ b/3d/antialiasing/polyhaven/textures/dutch_ship_medium_sails_diff_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bbknqctn3fk8w"
-path.s3tc="res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_sails_diff_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/antialiasing/polyhaven/textures/dutch_ship_medium_sails_nor_gl_1k.jpg.import
+++ b/3d/antialiasing/polyhaven/textures/dutch_ship_medium_sails_nor_gl_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://8cg5t4hjfcgv"
-path.s3tc="res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_sails_nor_gl_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/README.md
+++ b/3d/graphics_settings/README.md
@@ -8,10 +8,10 @@ Included settings are:
 
 - UI scale.
 - Resolution scale.
-- Display filter (bilinear or AMD FidelityFX Super Resolution 1.0).
+- Display filter (bilinear, AMD FidelityFX Super Resolution 1.0 or 2.2).
 - Fullscreen.
 - V-Sync (traditional and adaptive).
-- Anti-aliasing (MSAA and FXAA).
+- Anti-aliasing (MSAA, FXAA, SMAA, TAA).
 - Camera field of view.
 
 **Effect settings:**

--- a/3d/graphics_settings/control.tscn
+++ b/3d/graphics_settings/control.tscn
@@ -19,7 +19,7 @@ adjustment_enabled = true
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_w3j8l"]
 content_margin_left = 20.0
-content_margin_top = 50.0
+content_margin_top = 40.0
 content_margin_right = 20.0
 content_margin_bottom = 10.0
 bg_color = Color(0.231373, 0.231373, 0.231373, 0.768627)
@@ -240,13 +240,13 @@ popup/item_1/id = 1
 popup/item_2/text = "Enabled"
 popup/item_2/id = 2
 
-[node name="LimitFPSLabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
+[node name="FPSLimitLabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
 text = "Limit FPS:"
 
-[node name="LimitFPSSlider" type="HSlider" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
+[node name="FPSLimitSlider" type="HSlider" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -293,23 +293,25 @@ popup/item_2/id = 2
 popup/item_3/text = "8× (Slower)"
 popup/item_3/id = 3
 
-[node name="FXAALabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
+[node name="ScreenSpaceAALabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
-text = "Anti-Aliasing (FXAA):"
+text = "Screen-Space AA:"
 
-[node name="FXAAOptionButton" type="OptionButton" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
+[node name="ScreenSpaceAAOptionButton" type="OptionButton" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
 selected = 0
-item_count = 2
+item_count = 3
 popup/item_0/text = "Disabled (Fastest)"
 popup/item_0/id = 0
-popup/item_1/text = "Enabled (Fast)"
+popup/item_1/text = "FXAA (Fast)"
 popup/item_1/id = 1
+popup/item_2/text = "SMAA (Average)"
+popup/item_2/id = 2
 
 [node name="FOVLabel" type="Label" parent="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2"]
 layout_mode = 2
@@ -657,10 +659,10 @@ horizontal_alignment = 2
 [connection signal="value_changed" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/FSRSharpnessSlider" to="." method="_on_fsr_sharpness_slider_value_changed"]
 [connection signal="item_selected" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/FullscreenOptionButton" to="." method="_on_fullscreen_option_button_item_selected"]
 [connection signal="item_selected" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/VsyncOptionButton" to="." method="_on_vsync_option_button_item_selected"]
-[connection signal="value_changed" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/LimitFPSSlider" to="." method="_on_limit_fps_slider_value_changed"]
+[connection signal="value_changed" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/FPSLimitSlider" to="." method="_on_fps_limit_slider_value_changed"]
 [connection signal="item_selected" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/TAAOptionButton" to="." method="_on_taa_option_button_item_selected"]
 [connection signal="item_selected" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/MSAAOptionButton" to="." method="_on_msaa_option_button_item_selected"]
-[connection signal="item_selected" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/FXAAOptionButton" to="." method="_on_fxaa_option_button_item_selected"]
+[connection signal="item_selected" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/ScreenSpaceAAOptionButton" to="." method="_on_screen_space_aa_option_button_item_selected"]
 [connection signal="value_changed" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer2/FOVSlider" to="." method="_on_fov_slider_value_changed"]
 [connection signal="item_selected" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer4/ShadowSizeOptionButton" to="." method="_on_shadow_size_option_button_item_selected"]
 [connection signal="item_selected" from="SettingsMenu/ScrollContainer/VBoxContainer/GridContainer4/ShadowFilterOptionButton" to="." method="_on_shadow_filter_option_button_item_selected"]

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_arm_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_arm_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://diw315lrub1vw"
-path.s3tc="res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_hull_arm_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_hull_arm_1k.jpg-1bcb2be1a58190217bafabbba5a96cb5.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_diff_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_diff_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://25kxoi7ssf4p"
-path.s3tc="res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_hull_diff_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_hull_diff_1k.jpg-d22f57383d3437ac6151a5dc155d1b44.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_nor_gl_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_hull_nor_gl_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d0o02dukkiy03"
-path.s3tc="res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_hull_nor_gl_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_hull_nor_gl_1k.jpg-f0fc1f178ac5ff99bdf2aae06e0701f1.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_arm_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_arm_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b5hynjafne8jx"
-path.s3tc="res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_rigging_arm_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_rigging_arm_1k.jpg-6de8e054b6e80b00009332eaf9eafbeb.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_diff_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_diff_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bumebphru2wfw"
-path.s3tc="res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_rigging_diff_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_rigging_diff_1k.jpg-b381c8dba5fcad22696086becdc354b0.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_nor_gl_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_rigging_nor_gl_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://ccyypm1oxyv01"
-path.s3tc="res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_rigging_nor_gl_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_rigging_nor_gl_1k.jpg-26a255f6574d49990ad4162b06c015da.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_arm_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_arm_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://btwwehn0f3vpy"
-path.s3tc="res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_sails_arm_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_sails_arm_1k.jpg-6cdf6ae207b4bb5365f0df8bebf34d57.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_diff_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_diff_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b5k2xxreujcga"
-path.s3tc="res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_sails_diff_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_sails_diff_1k.jpg-501769b3e14d33a1ff05b4b14f45b65b.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_nor_gl_1k.jpg.import
+++ b/3d/graphics_settings/polyhaven/textures/dutch_ship_medium_sails_nor_gl_1k.jpg.import
@@ -3,20 +3,19 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bjhie5s45xhxa"
-path.s3tc="res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.s3tc.ctex"
+path="res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://polyhaven/textures/dutch_ship_medium_sails_nor_gl_1k.jpg"
-dest_files=["res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.s3tc.ctex"]
+dest_files=["res://.godot/imported/dutch_ship_medium_sails_nor_gl_1k.jpg-8bd26cb4511a8400046da66b710b48cf.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0

--- a/3d/graphics_settings/settings.gd
+++ b/3d/graphics_settings/settings.gd
@@ -29,7 +29,7 @@ func _ready() -> void:
 		%UnsupportedLabel.visible = true
 		mark_as_unsupported(%FilterOptionButton)
 		mark_as_unsupported(%TAAOptionButton)
-		mark_as_unsupported(%FXAAOptionButton)
+		mark_as_unsupported(%ScreenSpaceAAOptionButton)
 		mark_as_unsupported(%SDFGIOptionButton)
 		mark_as_unsupported(%SSAOOptionButton)
 		mark_as_unsupported(%SSReflectionsOptionButton)
@@ -134,18 +134,19 @@ func _on_vsync_option_button_item_selected(index: int) -> void:
 	# Adaptive V-Sync automatically disables V-Sync when the framerate target is not met, and enables
 	# V-Sync otherwise. This prevents stuttering and reduces input latency when the framerate target
 	# is not met, at the cost of visible tearing.
-	if index == 0: # Disabled (default)
-		DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
-	elif index == 1: # Adaptive
-		DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_ADAPTIVE)
-	elif index == 2: # Enabled
-		DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_ENABLED)
+	match index:
+		0: # Disabled (default)
+			DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
+		1: # Adaptive
+			DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_ADAPTIVE)
+		2: # Enabled
+			DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_ENABLED)
 
 
-func _on_limit_fps_slider_value_changed(value: float):
+func _on_fps_limit_slider_value_changed(value: float):
 	# The maximum number of frames per second that can be rendered.
 	# A value of 0 means "no limit".
-	Engine.max_fps = value
+	Engine.max_fps = roundi(value)
 
 
 func _on_msaa_option_button_item_selected(index: int) -> void:
@@ -167,10 +168,10 @@ func _on_taa_option_button_item_selected(index: int) -> void:
 	get_viewport().use_taa = index == 1
 
 
-func _on_fxaa_option_button_item_selected(index: int) -> void:
+func _on_screen_space_aa_option_button_item_selected(index: int) -> void:
 	# Fast approximate anti-aliasing. Much faster than MSAA (and works on alpha scissor edges),
 	# but blurs the whole scene rendering slightly.
-	get_viewport().screen_space_aa = int(index == 1) as Viewport.ScreenSpaceAA
+	get_viewport().screen_space_aa = int(index) as Viewport.ScreenSpaceAA
 
 
 func _on_fullscreen_option_button_item_selected(index: int) -> void:
@@ -395,7 +396,7 @@ func _on_saturation_slider_value_changed(value: float) -> void:
 func _on_very_low_preset_pressed() -> void:
 	%TAAOptionButton.selected = 0
 	%MSAAOptionButton.selected = 0
-	%FXAAOptionButton.selected = 0
+	%ScreenSpaceAAOptionButton.selected = 0
 	%ShadowSizeOptionButton.selected = 0
 	%ShadowFilterOptionButton.selected = 0
 	%MeshLODOptionButton.selected = 0
@@ -410,7 +411,7 @@ func _on_very_low_preset_pressed() -> void:
 func _on_low_preset_pressed() -> void:
 	%TAAOptionButton.selected = 0
 	%MSAAOptionButton.selected = 0
-	%FXAAOptionButton.selected = 1
+	%ScreenSpaceAAOptionButton.selected = 1
 	%ShadowSizeOptionButton.selected = 1
 	%ShadowFilterOptionButton.selected = 1
 	%MeshLODOptionButton.selected = 1
@@ -426,7 +427,7 @@ func _on_low_preset_pressed() -> void:
 func _on_medium_preset_pressed() -> void:
 	%TAAOptionButton.selected = 1
 	%MSAAOptionButton.selected = 0
-	%FXAAOptionButton.selected = 0
+	%ScreenSpaceAAOptionButton.selected = 2
 	%ShadowSizeOptionButton.selected = 2
 	%ShadowFilterOptionButton.selected = 2
 	%MeshLODOptionButton.selected = 1
@@ -442,7 +443,7 @@ func _on_medium_preset_pressed() -> void:
 func _on_high_preset_pressed() -> void:
 	%TAAOptionButton.selected = 1
 	%MSAAOptionButton.selected = 0
-	%FXAAOptionButton.selected = 0
+	%ScreenSpaceAAOptionButton.selected = 2
 	%ShadowSizeOptionButton.selected = 3
 	%ShadowFilterOptionButton.selected = 3
 	%MeshLODOptionButton.selected = 2
@@ -458,7 +459,7 @@ func _on_high_preset_pressed() -> void:
 func _on_ultra_preset_pressed() -> void:
 	%TAAOptionButton.selected = 1
 	%MSAAOptionButton.selected = 1
-	%FXAAOptionButton.selected = 0
+	%ScreenSpaceAAOptionButton.selected = 2
 	%ShadowSizeOptionButton.selected = 4
 	%ShadowFilterOptionButton.selected = 4
 	%MeshLODOptionButton.selected = 3
@@ -475,7 +476,7 @@ func update_preset() -> void:
 	# Simulate options being manually selected to run their respective update code.
 	%TAAOptionButton.item_selected.emit(%TAAOptionButton.selected)
 	%MSAAOptionButton.item_selected.emit(%MSAAOptionButton.selected)
-	%FXAAOptionButton.item_selected.emit(%FXAAOptionButton.selected)
+	%ScreenSpaceAAOptionButton.item_selected.emit(%ScreenSpaceAAOptionButton.selected)
 	%ShadowSizeOptionButton.item_selected.emit(%ShadowSizeOptionButton.selected)
 	%ShadowFilterOptionButton.item_selected.emit(%ShadowFilterOptionButton.selected)
 	%MeshLODOptionButton.item_selected.emit(%MeshLODOptionButton.selected)


### PR DESCRIPTION
- Rename various labels for readability.
- Use infinity symbol when FPS limit is set to 0.
- Use lossless compression for ship textures since they are low-resolution, and applied to a large object (making VRAM compression look bad).

___

- This closes https://github.com/godotengine/godot-demo-projects/issues/1277.
- See https://github.com/godotengine/godot/pull/102330.
