### PR TITLE
Improve GUI in 3D demo project

### DIFF
--- a/viewport/gui_in_3d/gui.tscn
+++ b/viewport/gui_in_3d/gui.tscn
@@ -1,0 +1,107 @@
+[gd_scene load_steps=2 format=3 uid="uid://b6w45me7tdr80"]
+
+[ext_resource type="Texture2D" uid="uid://dcqujt48gf5l5" path="res://icon.webp" id="1_80edf"]
+
+[node name="GUI" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 560.0
+offset_bottom = 360.0
+mouse_filter = 1
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 9
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = 20.0
+offset_right = 319.0
+offset_bottom = -20.0
+grow_vertical = 2
+theme_override_constants/separation = 13
+
+[node name="Label" type="Label" parent="Panel/VBoxContainer"]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+text = "SubViewport is rendered on Quad"
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="Button" type="Button" parent="Panel/VBoxContainer"]
+layout_mode = 2
+text = "A button!"
+
+[node name="LineEdit" type="LineEdit" parent="Panel/VBoxContainer"]
+layout_mode = 2
+placeholder_text = "Enter text here..."
+
+[node name="HSlider" type="HSlider" parent="Panel/VBoxContainer"]
+layout_mode = 2
+step = 0.0
+ticks_on_borders = true
+
+[node name="ColorRect" type="ColorRect" parent="Panel"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -182.0
+offset_top = 16.0
+offset_right = -54.0
+offset_bottom = 144.0
+grow_horizontal = 0
+color = Color(1, 0, 0, 1)
+
+[node name="TextureRect" type="TextureRect" parent="Panel"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -166.0
+offset_top = 32.0
+offset_right = -70.0
+offset_bottom = 128.0
+grow_horizontal = 0
+texture = ExtResource("1_80edf")
+expand_mode = 1
+
+[node name="VSlider" type="VSlider" parent="Panel"]
+layout_mode = 1
+anchors_preset = 11
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -37.0
+offset_top = 16.0
+offset_right = -5.0
+offset_bottom = -16.0
+grow_horizontal = 0
+grow_vertical = 2
+step = 0.0
+
+[node name="OptionButton" type="OptionButton" parent="Panel"]
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -227.0
+offset_top = -208.0
+offset_right = -39.0
+offset_bottom = -147.0
+grow_horizontal = 0
+grow_vertical = 0
+selected = 0
+item_count = 3
+popup/item_0/text = "Item 0"
+popup/item_0/id = 0
+popup/item_1/text = "Item 1"
+popup/item_1/id = 1
+popup/item_2/text = "Item 2"
+popup/item_2/id = 2

--- a/viewport/gui_in_3d/gui_in_3d.tscn
+++ b/viewport/gui_in_3d/gui_in_3d.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=10 format=3 uid="uid://clhke86mq8b7m"]
+[gd_scene load_steps=11 format=3 uid="uid://clhke86mq8b7m"]
 
 [ext_resource type="PackedScene" uid="uid://ul1fp38n6h7k" path="res://gui_panel_3d.tscn" id="1"]
+[ext_resource type="PackedScene" uid="uid://b6w45me7tdr80" path="res://gui.tscn" id="2_yk1yt"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_1lgdv"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -54,6 +55,9 @@ shadow_enabled = true
 environment = SubResource("Environment_niyks")
 
 [node name="GUIPanel3D" parent="." instance=ExtResource("1")]
+gui_scene = ExtResource("2_yk1yt")
+screen_size_3d = Vector2(3, 2)
+screen_size_2d = Vector2(560, 360)
 
 [node name="Camera3D" type="Camera3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 0.999999, 0, 0, 3)

--- a/viewport/gui_in_3d/gui_panel_3d.tscn
+++ b/viewport/gui_in_3d/gui_panel_3d.tscn
@@ -1,10 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://ul1fp38n6h7k"]
+[gd_scene load_steps=6 format=3 uid="uid://ul1fp38n6h7k"]
 
 [ext_resource type="Script" uid="uid://cgjafujbxj4i" path="res://gui_3d.gd" id="1"]
-[ext_resource type="Texture2D" uid="uid://dcqujt48gf5l5" path="res://icon.webp" id="2"]
 
 [sub_resource type="QuadMesh" id="1"]
-size = Vector2(3, 2)
 
 [sub_resource type="ViewportTexture" id="2"]
 viewport_path = NodePath("SubViewport")
@@ -16,7 +14,7 @@ shading_mode = 0
 albedo_texture = SubResource("2")
 
 [sub_resource type="BoxShape3D" id="4"]
-size = Vector3(3, 2, 0.1)
+size = Vector3(1, 1, 0.001)
 
 [node name="GUIPanel3D" type="Node3D"]
 process_mode = 3
@@ -27,110 +25,6 @@ editor_description = "SubViewport contents can be displayed using a ViewportText
 gui_embed_subwindows = true
 size = Vector2i(560, 360)
 render_target_update_mode = 4
-
-[node name="GUI" type="Control" parent="SubViewport"]
-layout_mode = 3
-anchors_preset = 0
-offset_right = 560.0
-offset_bottom = 360.0
-mouse_filter = 1
-
-[node name="Panel" type="Panel" parent="SubViewport/GUI"]
-layout_mode = 0
-anchor_right = 1.0
-anchor_bottom = 1.0
-
-[node name="VBoxContainer" type="VBoxContainer" parent="SubViewport/GUI/Panel"]
-layout_mode = 1
-anchors_preset = 9
-anchor_bottom = 1.0
-offset_left = 20.0
-offset_top = 20.0
-offset_right = 319.0
-offset_bottom = -20.0
-grow_vertical = 2
-theme_override_constants/separation = 13
-
-[node name="Label" type="Label" parent="SubViewport/GUI/Panel/VBoxContainer"]
-custom_minimum_size = Vector2(200, 0)
-layout_mode = 2
-text = "SubViewport is rendered on Quad"
-horizontal_alignment = 1
-autowrap_mode = 2
-
-[node name="Button" type="Button" parent="SubViewport/GUI/Panel/VBoxContainer"]
-layout_mode = 2
-text = "A button!"
-
-[node name="LineEdit" type="LineEdit" parent="SubViewport/GUI/Panel/VBoxContainer"]
-layout_mode = 2
-placeholder_text = "Enter text here..."
-
-[node name="HSlider" type="HSlider" parent="SubViewport/GUI/Panel/VBoxContainer"]
-layout_mode = 2
-step = 0.0
-ticks_on_borders = true
-
-[node name="ColorRect" type="ColorRect" parent="SubViewport/GUI/Panel"]
-layout_mode = 1
-anchors_preset = 1
-anchor_left = 1.0
-anchor_right = 1.0
-offset_left = -182.0
-offset_top = 16.0
-offset_right = -54.0
-offset_bottom = 144.0
-grow_horizontal = 0
-color = Color(1, 0, 0, 1)
-
-[node name="TextureRect" type="TextureRect" parent="SubViewport/GUI/Panel"]
-layout_mode = 1
-anchors_preset = 1
-anchor_left = 1.0
-anchor_right = 1.0
-offset_left = -166.0
-offset_top = 32.0
-offset_right = -70.0
-offset_bottom = 128.0
-grow_horizontal = 0
-texture = ExtResource("2")
-expand_mode = 1
-
-[node name="VSlider" type="VSlider" parent="SubViewport/GUI/Panel"]
-layout_mode = 1
-anchors_preset = 11
-anchor_left = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -37.0
-offset_top = 16.0
-offset_right = -5.0
-offset_bottom = -16.0
-grow_horizontal = 0
-grow_vertical = 2
-step = 0.0
-
-[node name="OptionButton" type="OptionButton" parent="SubViewport/GUI/Panel"]
-layout_mode = 1
-anchors_preset = 3
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -227.0
-offset_top = -208.0
-offset_right = -39.0
-offset_bottom = -147.0
-grow_horizontal = 0
-grow_vertical = 0
-selected = 0
-item_count = 3
-popup/item_0/text = "Item 0"
-popup/item_0/id = 0
-popup/item_1/text = "Item 1"
-popup/item_1/id = 1
-popup/item_2/text = "Item 2"
-popup/item_2/id = 2
 
 [node name="Quad" type="MeshInstance3D" parent="."]
 editor_description = "To setup this MeshInstance3D:


### PR DESCRIPTION
- fixed GUI input issue in billboard mode (by use custom billboard calculation also for mesh node)
- added settings for gui_3d script gui_panel_3d.tscn allows configure gui in 3d without modifying this scene (and easily reuse it)

I'm not sure if this approach (with configuration via setters in `gui_3d.gd`) isn't too complicated for a demo ... but:
1. managing the billboard at the script level (and not the material level) allows solving the input synchronization problem by applying rotation to the entire node (and not just collisions) ... this shouldn't cause a significant overhead because these calculations were performed and applied by this script anyway ...
2. separates the configuration from the logic of the 3D GUI object, allowing you to easily reuse this solution in your project
