### PR TITLE
Update web exports to Godot 4.5.1

### DIFF
--- a/.github/workflows/export_web.yml
+++ b/.github/workflows/export_web.yml
@@ -5,7 +5,7 @@ on:
       - master
 
 env:
-  GODOT_VERSION: 4.3
+  GODOT_VERSION: 4.5.1
 
 jobs:
   export-html5:
@@ -13,7 +13,7 @@ jobs:
     name: Export projects to Web and deploy to GitHub Pages
     runs-on: ubuntu-24.04
     container:
-      image: barichello/godot-ci:4.3
+      image: barichello/godot-ci:4.5.1
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
* This partially addresses https://github.com/godotengine/godot-demo-projects/issues/1288.
