### PR TITLE
Updated main run scene to fix the grey background

### DIFF
--- a/audio/rhythm_game/project.godot
+++ b/audio/rhythm_game/project.godot
@@ -12,8 +12,8 @@ config_version=5
 
 config/name="Rhythm Game"
 config/description="Simple rhythm game utilizing precise playback position."
-run/main_scene="uid://cv53erwosrk7o"
-config/features=PackedStringArray("4.5", "GL Compatibility")
+run/main_scene="uid://dv2yxsk2pn2j"
+config/features=PackedStringArray("4.4", "GL Compatibility")
 run/max_fps=1000
 config/icon="uid://bdd4ws8b7jdqh"
 


### PR DESCRIPTION
issue #1288 reported a grey background in web version of rhythm game https://godotengine.github.io/godot-demo-projects/audio/rhythm_game/ upon downloading and running the game the starting scene seemed to be assigned to a scene godot couldn't recognize but once changed to main.tscn it worked

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
