### PR TITLE
Update and fix Glow for 2D demo for Godot 4.6

### DIFF
--- a/2d/glow/README.md
+++ b/2d/glow/README.md
@@ -2,11 +2,14 @@
 
 This showcases how to use glow in a 2D game via the WorldEnvironment node.
 
-Slide the cave image left and right to observe the glow effect at work.
+Slide the cave image left and right to observe the glow effect at work. Press <kbd>G</kbd>
+to toggle the glow map (lens dirt) effect.
+
+The Label is on a separate CanvasLayer, so that it is not affected by glow.
 
 Language: GDScript
 
-Renderer: Forward+
+Renderer: Mobile
 
 Check out this demo on the asset library: https://godotengine.org/asset-library/asset/2715
 

--- a/2d/glow/beach_cave.tscn
+++ b/2d/glow/beach_cave.tscn
@@ -7,13 +7,12 @@
 [sub_resource type="Environment" id="1"]
 background_mode = 3
 ambient_light_sky_contribution = 0.0
+tonemap_mode = 4
+tonemap_agx_contrast = 1.0
 glow_enabled = true
-glow_levels/3 = 0.0
-glow_levels/4 = 1.0
-glow_levels/7 = 1.0
-glow_strength = 0.88
-glow_bloom = 0.08
-glow_blend_mode = 0
+glow_levels/5 = 0.1
+glow_levels/6 = 0.1
+glow_levels/7 = 0.02
 
 [node name="BeachCave" type="Node2D" unique_id=379183590]
 script = ExtResource("1")
@@ -38,13 +37,15 @@ environment = SubResource("1")
 [node name="Camera2D" type="Camera2D" parent="." unique_id=962517249]
 offset = Vector2(540, 360)
 
-[node name="Label" type="Label" parent="." unique_id=211507946]
-visible = false
+[node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=1571277078]
+
+[node name="Label" type="Label" parent="CanvasLayer" unique_id=211507946]
 offset_left = 18.0
 offset_top = 18.0
 offset_right = 294.0
 offset_bottom = 70.0
 size_flags_horizontal = 2
 size_flags_vertical = 0
+theme_override_constants/outline_size = 6
 text = "Drag left and right with the mouse
 G: Toggle glow map (lens dirt effect)"

--- a/2d/glow/project.godot
+++ b/2d/glow/project.godot
@@ -41,4 +41,7 @@ toggle_glow_map={
 
 [rendering]
 
+renderer/rendering_method="mobile"
+viewport/hdr_2d=true
+anti_aliasing/quality/use_debanding=true
 environment/defaults/default_clear_color=Color(0.0666667, 0.0588235, 0.0431373, 1)


### PR DESCRIPTION
- Switch to Mobile renderer for consistent visuals across platforms.
- Enable HDR 2D and debanding for better visuals.
- Tweak glow parameters to make the effect more visible.
- Use AgX tonemapping.
- Use a CanvasLayer to show the help label, so that it is not affected by glow. Give it a outline to be readable on any background.
