### PR TITLE
Fix VirtualJoystick class name conflict in 4.7+ in Platformer 3D

### DIFF
--- a/3d/platformer/touch_screen_ui/virtual_joystick/virtual_joystick.gd
+++ b/3d/platformer/touch_screen_ui/virtual_joystick/virtual_joystick.gd
@@ -1,4 +1,4 @@
-class_name VirtualJoystick
+class_name VirtualJoystickAddon
 extends Control
 
 ## A simple virtual joystick for touchscreens, with useful options.


### PR DESCRIPTION
[Godot 4.7 implements a VirtualJoystick node](https://github.com/godotengine/godot/pull/110933), whose class name conflicted with the existing add-on used in the Platformer 3D demo.

This renames the class to avoid a conflict, while keeping the functionality intact on Godot 4.6.

Tested on an Android device.
