### PR TITLE
Fix missing signal connections in C# demos

### DIFF
--- a/mono/dodge_the_creeps/Main.tscn
+++ b/mono/dodge_the_creeps/Main.tscn
@@ -50,6 +50,8 @@ stream = ExtResource("5_dnvwy")
 [node name="DeathSound" type="AudioStreamPlayer" parent="." unique_id=693847821]
 stream = ExtResource("5_r2snl")
 
+[connection signal="Hit" from="Player" to="." method="GameOver"]
 [connection signal="timeout" from="MobTimer" to="." method="OnMobTimerTimeout"]
 [connection signal="timeout" from="ScoreTimer" to="." method="OnScoreTimerTimeout"]
 [connection signal="timeout" from="StartTimer" to="." method="OnStartTimerTimeout"]
+[connection signal="StartGame" from="HUD" to="." method="NewGame"]

--- a/mono/squash_the_creeps/Main.tscn
+++ b/mono/squash_the_creeps/Main.tscn
@@ -151,4 +151,5 @@ grow_horizontal = 2
 grow_vertical = 2
 text = "Press Enter to retry"
 
+[connection signal="Hit" from="Player" to="." method="OnPlayerHit"]
 [connection signal="timeout" from="MobTimer" to="." method="OnMobTimerTimeout"]


### PR DESCRIPTION
Looks like these signal connections were accidentally removed in https://github.com/godotengine/godot-demo-projects/pull/1258. It likely happened because the projects were saved without compiling the C# code first, and Godot removed the connections to _unknown_ signals.