### PR TITLE
Fix indentation in note_manager.gd causing Rhythm Game to fail at run.

### DIFF
--- a/audio/rhythm_game/game_state/note_manager.gd
+++ b/audio/rhythm_game/game_state/note_manager.gd
@@ -26,7 +26,7 @@ func _ready() -> void:
 	_play_stats.changed.connect(
 			func() -> void:
 				play_stats_updated.emit(_play_stats)
-		)
+				)
 
 	var chart_data := ChartData.get_chart_data(chart)
 


### PR DESCRIPTION
Godot 4.6.1

In the current Rhythm Game Demo, the script note_manager.gd contained an indentation error that prevented the demo project from running. This fork fixes that indentation problem and allows the NoteManager class to be referenced in other files.