### PR TITLE
Update vehicle.gd in 3d/truck_town

### DIFF
--- a/3d/truck_town/vehicles/vehicle.gd
+++ b/3d/truck_town/vehicles/vehicle.gd
@@ -75,9 +75,9 @@ func _physics_process(delta: float) -> void:
 		# Increase engine force at low speeds to make the initial reversing faster.
 		var speed := linear_velocity.length()
 		if speed < 5.0 and not is_zero_approx(speed):
-			engine_force = -clampf(engine_force_value * BRAKE_STRENGTH * 5.0 / speed, 0.0, 100.0)
+			engine_force = -clampf(engine_force_value * 5.0 / speed, 0.0, 100.0)
 		else:
-			engine_force = -engine_force_value * BRAKE_STRENGTH
+			engine_force = -engine_force_value
 
 		# Apply analog brake factor for more subtle braking if not fully holding down the trigger.
 		engine_force *= Input.get_action_strength(&"reverse")


### PR DESCRIPTION
Fixed the double acceleration bug when reversing. Breaking needs to happen through reducing speed to 0 instead of applying reverse acceleration.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
