### PR TITLE
Multiplayer Bomber Fixed players spawn on client

### DIFF
--- a/networking/multiplayer_bomber/gamestate.gd
+++ b/networking/multiplayer_bomber/gamestate.gd
@@ -122,12 +122,10 @@ func begin_game() -> void:
 	for p: int in players:
 		spawn_points[p] = spawn_point_idx
 		spawn_point_idx += 1
-		
+
 	var spawner: MultiplayerSpawner = world.get_node(^"PlayerSpawner")
 	for p_id: int in spawn_points:
 		var spawn_pos: Vector2 = world.get_node("SpawnPoints/" + str(spawn_points[p_id])).position
-		# The RPC must be called after the player is added to the scene tree.
-		
 		var player = spawner.spawn([spawn_pos, p_id])
 		player.set_player_name.rpc(player_name if p_id == multiplayer.get_unique_id() else players[p_id])
 

--- a/networking/multiplayer_bomber/gamestate.gd
+++ b/networking/multiplayer_bomber/gamestate.gd
@@ -113,7 +113,6 @@ func begin_game() -> void:
 	load_world.rpc()
 
 	var world: Node2D = get_tree().get_root().get_node(^"World")
-	var player_scene: PackedScene = load("res://player.tscn")
 
 	# Create a dictionary with peer ID. and respective spawn points.
 	# TODO: This could be improved by randomizing spawn points for players.
@@ -123,14 +122,13 @@ func begin_game() -> void:
 	for p: int in players:
 		spawn_points[p] = spawn_point_idx
 		spawn_point_idx += 1
-
+		
+	var spawner: MultiplayerSpawner = world.get_node(^"PlayerSpawner")
 	for p_id: int in spawn_points:
 		var spawn_pos: Vector2 = world.get_node("SpawnPoints/" + str(spawn_points[p_id])).position
-		var player := player_scene.instantiate()
-		player.synced_position = spawn_pos
-		player.name = str(p_id)
-		world.get_node(^"Players").add_child(player)
 		# The RPC must be called after the player is added to the scene tree.
+		
+		var player = spawner.spawn([spawn_pos, p_id])
 		player.set_player_name.rpc(player_name if p_id == multiplayer.get_unique_id() else players[p_id])
 
 

--- a/networking/multiplayer_bomber/gamestate.gd
+++ b/networking/multiplayer_bomber/gamestate.gd
@@ -126,7 +126,7 @@ func begin_game() -> void:
 	var spawner: MultiplayerSpawner = world.get_node(^"PlayerSpawner")
 	for p_id: int in spawn_points:
 		var spawn_pos: Vector2 = world.get_node("SpawnPoints/" + str(spawn_points[p_id])).position
-		var player = spawner.spawn([spawn_pos, p_id])
+		var player: CharacterBody2D = spawner.spawn([spawn_pos, p_id])
 		player.set_player_name.rpc(player_name if p_id == multiplayer.get_unique_id() else players[p_id])
 
 

--- a/networking/multiplayer_bomber/player_spawner.gd
+++ b/networking/multiplayer_bomber/player_spawner.gd
@@ -1,17 +1,12 @@
 extends MultiplayerSpawner
 
-
-# Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	set_spawn_function(spawn_player)
-	pass # Replace with function body.
-
 
 
 func spawn_player(data: Array) -> CharacterBody2D:
 	if data.size() != 2 or typeof(data[0]) != TYPE_VECTOR2 or typeof(data[1]) != TYPE_INT:
 		return null
-	
 	var player: CharacterBody2D = preload("res://player.tscn").instantiate()
 	player.synced_position = data[0]
 	player.name = str(data[1])

--- a/networking/multiplayer_bomber/player_spawner.gd
+++ b/networking/multiplayer_bomber/player_spawner.gd
@@ -1,0 +1,18 @@
+extends MultiplayerSpawner
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	set_spawn_function(spawn_player)
+	pass # Replace with function body.
+
+
+
+func spawn_player(data: Array) -> CharacterBody2D:
+	if data.size() != 2 or typeof(data[0]) != TYPE_VECTOR2 or typeof(data[1]) != TYPE_INT:
+		return null
+	
+	var player: CharacterBody2D = preload("res://player.tscn").instantiate()
+	player.synced_position = data[0]
+	player.name = str(data[1])
+	return player

--- a/networking/multiplayer_bomber/player_spawner.gd
+++ b/networking/multiplayer_bomber/player_spawner.gd
@@ -6,6 +6,7 @@ func _ready() -> void:
 
 func spawn_player(data: Array) -> CharacterBody2D:
 	if data.size() != 2 or typeof(data[0]) != TYPE_VECTOR2 or typeof(data[1]) != TYPE_INT:
+		push_error("Invalid MultiplayerSpawner spawn parameter. The parameter must be an array with 2 elements, where index 0 is the Vector2 spawn position and index 1 is the spawn point index.")
 		return null
 	var player: CharacterBody2D = preload("res://player.tscn").instantiate()
 	player.synced_position = data[0]

--- a/networking/multiplayer_bomber/player_spawner.gd.uid
+++ b/networking/multiplayer_bomber/player_spawner.gd.uid
@@ -1,0 +1,1 @@
+uid://dnawfxew5j3m0

--- a/networking/multiplayer_bomber/world.tscn
+++ b/networking/multiplayer_bomber/world.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://cwchcyc0t4cgv" path="res://rock.tscn" id="2"]
 [ext_resource type="Script" uid="uid://i0malmurqy3m" path="res://score.gd" id="3"]
 [ext_resource type="FontFile" uid="uid://cm4wvgsyhdc2w" path="res://montserrat.otf" id="4"]
+[ext_resource type="Script" uid="uid://dnawfxew5j3m0" path="res://player_spawner.gd" id="5_dwbse"]
 [ext_resource type="Script" uid="uid://r8wlac3jv6ck" path="res://bomb_spawner.gd" id="6_ac5ja"]
 
 [node name="World" type="Node2D" unique_id=567359237]
@@ -307,6 +308,7 @@ process_callback = 0
 
 [node name="PlayerSpawner" type="MultiplayerSpawner" parent="." unique_id=165151297]
 spawn_path = NodePath("../Players")
+script = ExtResource("5_dwbse")
 
 [node name="BombSpawner" type="MultiplayerSpawner" parent="." unique_id=1836509659]
 spawn_path = NodePath("..")


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
[Multiplayer Bomber client didn't spawn characters](https://github.com/godotengine/godot-demo-projects/issues/1313).
Added player_spawner.gd to PlayerSpawner at the world and using it instead of instantiate and add_child for players spawner. 

- *Bugsquad edit: This closes https://github.com/godotengine/godot-demo-projects/issues/1313.*