### PR TITLE
Add custom_resource plugin demo

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -16,10 +16,13 @@ Check out this demo on the asset library: https://godotengine.org/asset-library/
 
 # How does it work?
 
-This project contains 4 plugins:
+This project contains 5 plugins:
 
 * The custom node plugin shows how to create a custom node type
   using `add_custom_type`. [More info](addons/custom_node).
+
+* The custom resource plugin shows how to create a custom Resource type
+  using `add_custom_type`. [More info](addons/custom_resource).
 
 * The main screen plugin is a minimal example of how to create a plugin
   with a main screen. [More info](addons/main_screen).

--- a/plugins/addons/custom_resource/README.md
+++ b/plugins/addons/custom_resource/README.md
@@ -20,22 +20,3 @@ Using this method you can specify any name, base type, script, and (optionally) 
 There is also another way to add custom Resource types, which is using the `class_name` keyword in a script,
 or [using the `[GlobalClass]` attribute above a class declaration in C#](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_global_classes.html).
 Both approaches work for Resources just as they do for Nodes.
-
-## When to use a custom Resource over a custom Node
-
-Resources are well-suited to plain data that does not need to live in the scene tree:
-character stats, item definitions, dialogue lines, configuration sets, and so on.
-A single Resource file can be loaded once and shared between many scenes,
-which keeps the project organized and reduces duplication.
-Pick a custom Node when the type genuinely needs to participate in the scene tree
-(for example, to draw, process input, or be parented to other nodes).
-
-For a more comprehensive example of working with custom Resources — including custom
-loading, saving, and import logic — see the `material_creator` plugin in this project.
-
-## Trying it out
-
-1. Enable the plugin in **Project > Project Settings > Plugins**.
-2. In the FileSystem dock, right-click and choose **New Resource…**, then pick **Stats**.
-3. Save the resource (for example, as `res://hero_stats.tres`).
-4. Double-click the file to edit `max_health`, `strength`, and `speed` in the inspector.

--- a/plugins/addons/custom_resource/README.md
+++ b/plugins/addons/custom_resource/README.md
@@ -1,0 +1,41 @@
+# Custom Resource Plugin Demo
+
+This plugin demo shows one way to create a custom Resource type in Godot.
+For more information, see the documentation on [making plugins](https://docs.godotengine.org/en/latest/tutorials/plugins/editor/making_plugins.html)
+and [resources](https://docs.godotengine.org/en/latest/tutorials/scripting/resources.html).
+
+A custom Resource type:
+
+* Derives from [Resource](https://docs.godotengine.org/en/latest/classes/class_resource.html) (or a subclass).
+
+* Shows up in the "New Resource" dialog and in the type list when assigning a `Resource`-typed `@export` property.
+
+* Can hold data via `@export` properties that show up in the inspector.
+
+* Can be saved to and loaded from `.tres`/`.res` files.
+
+The way it works in this plugin is using `add_custom_type` and `remove_custom_type` in the plugin script file.
+Using this method you can specify any name, base type, script, and (optionally) icon for your custom Resource.
+
+There is also another way to add custom Resource types, which is using the `class_name` keyword in a script,
+or [using the `[GlobalClass]` attribute above a class declaration in C#](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_global_classes.html).
+Both approaches work for Resources just as they do for Nodes.
+
+## When to use a custom Resource over a custom Node
+
+Resources are well-suited to plain data that does not need to live in the scene tree:
+character stats, item definitions, dialogue lines, configuration sets, and so on.
+A single Resource file can be loaded once and shared between many scenes,
+which keeps the project organized and reduces duplication.
+Pick a custom Node when the type genuinely needs to participate in the scene tree
+(for example, to draw, process input, or be parented to other nodes).
+
+For a more comprehensive example of working with custom Resources — including custom
+loading, saving, and import logic — see the `material_creator` plugin in this project.
+
+## Trying it out
+
+1. Enable the plugin in **Project > Project Settings > Plugins**.
+2. In the FileSystem dock, right-click and choose **New Resource…**, then pick **Stats**.
+3. Save the resource (for example, as `res://hero_stats.tres`).
+4. Double-click the file to edit `max_health`, `strength`, and `speed` in the inspector.

--- a/plugins/addons/custom_resource/plugin.cfg
+++ b/plugins/addons/custom_resource/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Custom Resource Plugin Demo"
+description="Adds a new Stats Resource type using add_custom_type"
+author="adamcodeworks"
+version="1.0"
+script="stats_plugin.gd"

--- a/plugins/addons/custom_resource/stats.gd
+++ b/plugins/addons/custom_resource/stats.gd
@@ -1,0 +1,7 @@
+@tool
+extends Resource
+
+
+@export var max_health: int = 100
+@export var strength: int = 10
+@export var speed: float = 5.0

--- a/plugins/addons/custom_resource/stats.gd.uid
+++ b/plugins/addons/custom_resource/stats.gd.uid
@@ -1,0 +1,1 @@
+uid://t7emyr4cxtfo4

--- a/plugins/addons/custom_resource/stats_plugin.gd
+++ b/plugins/addons/custom_resource/stats_plugin.gd
@@ -1,0 +1,13 @@
+@tool
+extends EditorPlugin
+
+
+func _enter_tree() -> void:
+	# When this plugin node enters tree, add the custom type.
+	# The icon parameter is optional and omitted here for simplicity.
+	add_custom_type("Stats", "Resource", preload("res://addons/custom_resource/stats.gd"), null)
+
+
+func _exit_tree() -> void:
+	# When the plugin node exits the tree, remove the custom type.
+	remove_custom_type("Stats")

--- a/plugins/addons/custom_resource/stats_plugin.gd.uid
+++ b/plugins/addons/custom_resource/stats_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://h65s32y61gpqp

--- a/plugins/project.godot
+++ b/plugins/project.godot
@@ -14,9 +14,10 @@ config/name="Plugin Demos"
 config/description="This contains multiple plugin demos, all placed in a project for convenience.
 Due to bug 36713 you need to open the project to import the assets once, then close, then open.
 
-This project contains 4 plugins:
+This project contains 5 plugins:
 
 * The custom node plugin shows how to create a custom node type using `add_custom_type`.
+* The custom resource plugin shows how to create a custom Resource type using `add_custom_type`.
 * The material import plugin shows how to make a plugin handle importing a custom file type (mtxt).
 * The material creator plugin shows how to add a custom dock with some simple functionality.
 * The main screen plugin is a minimal example of how to create a plugin with a main screen."
@@ -31,7 +32,7 @@ gdscript/warnings/untyped_declaration=1
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/custom_node/plugin.cfg", "res://addons/main_screen/plugin.cfg", "res://addons/material_creator/plugin.cfg", "res://addons/simple_import_plugin/plugin.cfg")
+enabled=PackedStringArray("res://addons/custom_node/plugin.cfg", "res://addons/custom_resource/plugin.cfg", "res://addons/main_screen/plugin.cfg", "res://addons/material_creator/plugin.cfg", "res://addons/simple_import_plugin/plugin.cfg")
 
 [rendering]
 


### PR DESCRIPTION
This adds a new `custom_resource` plugin to the existing plugins demo project, mirroring the `custom_node` plugin but for Resources. It uses `add_custom_type` to register a small `Stats` Resource subclass (with `max_health`, `strength`, and `speed` @export properties) so that the type appears in the "New Resource…" dialog and as an option for `@export var foo: Stats` properties in the inspector.

Why additive rather than replacing `custom_node`: the heart-drawing demo is genuinely a Node use case (it draws via `_draw()` and lives in the scene tree), and the two demos now sit side by side as the canonical pair for `add_custom_type`. Happy to consolidate if you'd prefer a different shape — let me know.

Closes #1061