### PR TITLE
Fix StateMachine crash when start_state is left empty

### DIFF
--- a/2d/finite_state_machine/state_machine/state_machine.gd
+++ b/2d/finite_state_machine/state_machine/state_machine.gd
@@ -22,18 +22,24 @@ var _active: bool = false:
 
 
 func _enter_tree() -> void:
+	var initial_state: Node
 	if start_state.is_empty():
-		start_state = get_child(0).get_path()
+		# Children have not entered the tree yet during their parent's
+		# _enter_tree(), so calling get_path() on get_child(0) would return
+		# an empty NodePath. Resolve to the Node reference directly.
+		initial_state = get_child(0)
+	else:
+		initial_state = get_node(start_state)
 	for child in get_children():
 		var err: bool = child.finished.connect(_change_state)
 		if err:
 			printerr(err)
-	initialize(start_state)
+	initialize(initial_state)
 
 
-func initialize(initial_state: NodePath) -> void:
+func initialize(initial_state: Node) -> void:
 	_active = true
-	states_stack.push_front(get_node(initial_state))
+	states_stack.push_front(initial_state)
 	current_state = states_stack[0]
 	current_state.enter()
 


### PR DESCRIPTION
Fixes #1303.

The base `StateMachine` script in the Hierarchical Finite State Machine demo was meant to fall back to its first child when no `start_state` is set:

```gdscript
@export var start_state: NodePath
…
func _enter_tree() -> void:
    if start_state.is_empty():
        start_state = get_child(0).get_path()
    …
    initialize(start_state)
```

But Godot fires `_enter_tree()` on a node *before* propagating the callback to its children, which means the children's `is_inside_tree()` is still false at this point. `get_path()` on a node not yet in the tree returns an empty `NodePath` (with an error message), so `initialize()` then runs `get_node(NodePath(""))` and the demo crashes with a null current state.

The shipped `Demo.tscn` happens to set `start_state = NodePath("Idle")` on the player's `StateMachine`, so the demo itself never hits this branch — but the `state_machine.gd` script is also explicitly framed as a copy-paste starting point for users' own state machines (the comment on `start_state` says "If you don't [set one], the game will default to the first state in the state machine's children"), so the broken fallback has been a footgun for users following that pattern.

This patches `_enter_tree()` to resolve the initial state to a `Node` directly when `start_state` is empty, sidestepping `get_path()`. `initialize()` is changed to accept a `Node` rather than a `NodePath`, removing the now-redundant `get_node()` call. There are no external callers of `initialize()` (only `_enter_tree()` calls it; `PlayerStateMachine` extends the base but doesn't override or invoke `initialize()`), so the signature change is safe.

Behavior of the existing demo is unchanged — `Demo.tscn` still passes `NodePath("Idle")` through the `else` branch and resolves the same node it always did. The only observable difference is that the empty-`start_state` fallback now actually works.
