### PR TITLE
Interpolate brush samples in gd_paint to fill stroke gaps

### DIFF
--- a/gui/gd_paint/paint_control.gd
+++ b/gui/gd_paint/paint_control.gd
@@ -56,7 +56,8 @@ func _process(_delta: float) -> void:
 		# If we do not have a position for when the mouse was first clicked, then this must
 		# be the first time is_mouse_button_pressed has been called since the mouse button was
 		# released, so we need to store the position.
-		if mouse_click_start_pos.is_equal_approx(Vector2.INF):
+		var stroke_just_started := mouse_click_start_pos.is_equal_approx(Vector2.INF)
+		if stroke_just_started:
 			mouse_click_start_pos = mouse_pos
 
 		# If the mouse is inside the canvas and the mouse is 1px away from the position of the mouse last _process call.
@@ -69,8 +70,16 @@ func _process(_delta: float) -> void:
 					if undo_set == false:
 						undo_set = true
 						undo_element_list_num = brush_data_list.size()
-					# Add the brush object to draw_elements_array.
-					add_brush(mouse_pos, brush_mode)
+					# On the first sample of a new stroke we just place a single brush at the mouse
+					# position. On subsequent samples we interpolate from the previous mouse
+					# position so that fast mouse motion does not leave gaps between brushes.
+					# When last_mouse_pos was outside the canvas (e.g. the cursor briefly left
+					# the drawing area mid-stroke) we also fall back to a single brush so we
+					# don't draw a line through the area outside the canvas.
+					if stroke_just_started or not drawing_area_rect.has_point(last_mouse_pos):
+						add_brush(mouse_pos, brush_mode)
+					else:
+						add_brush_line(last_mouse_pos, mouse_pos, brush_mode)
 
 	else:
 		# We've finished our stroke, so we can set a new undo (if a new stroke is made).
@@ -186,6 +195,19 @@ func add_brush(mouse_pos: Vector2, type: BrushMode) -> void:
 	# Add the brush and update/draw all of the brushes.
 	brush_data_list.append(new_brush)
 	queue_redraw()
+
+
+# Adds a series of brush samples along the line from `from` to `to` so that fast
+# mouse motion does not leave visible gaps between brushes. We step roughly once
+# per pixel along the line; this is the same idea as Bresenham's line algorithm,
+# expressed parametrically because brush positions are stored as floats.
+func add_brush_line(from: Vector2, to: Vector2, type: BrushMode) -> void:
+	var steps := int(ceil(from.distance_to(to)))
+	if steps <= 1:
+		add_brush(to, type)
+		return
+	for i in range(1, steps + 1):
+		add_brush(from.lerp(to, float(i) / float(steps)), type)
 
 
 func _draw() -> void:

--- a/gui/gd_paint/paint_control.gd
+++ b/gui/gd_paint/paint_control.gd
@@ -197,15 +197,18 @@ func add_brush(mouse_pos: Vector2, type: BrushMode) -> void:
 	queue_redraw()
 
 
-# Adds a series of brush samples along the line from `from` to `to` so that fast
-# mouse motion does not leave visible gaps between brushes. We step roughly once
-# per pixel along the line; this is the same idea as Bresenham's line algorithm,
-# expressed parametrically because brush positions are stored as floats.
+# Adds a series of brush samples along the line from `from` to `to` so that
+# fast mouse motion does not leave visible gaps between brushes. We step at
+# roughly a quarter of the brush size (clamped to at least 1px) so adjacent
+# brushes still overlap generously while keeping the brush count - and hence
+# the redraw cost, since `_draw` walks the full list every frame - bounded.
 func add_brush_line(from: Vector2, to: Vector2, type: BrushMode) -> void:
-	var steps := int(ceil(from.distance_to(to)))
-	if steps <= 1:
+	var step := maxf(1.0, float(brush_size) / 4.0)
+	var distance := from.distance_to(to)
+	if distance <= step:
 		add_brush(to, type)
 		return
+	var steps := int(ceil(distance / step))
 	for i in range(1, steps + 1):
 		add_brush(from.lerp(to, float(i) / float(steps)), type)
 


### PR DESCRIPTION
Fixes #846.

## Problem

The GDPaint demo adds one brush sample per `_process` call (one per frame). When the mouse moves faster than one brush per frame the stroke shows visible gaps between brushes — most obvious with the default 32-pixel brush and a quick swipe of the mouse.

## Fix

When a stroke continues from one frame to the next, interpolate brush samples along the line from the previous mouse position to the current one, stepping roughly one pixel at a time. This is the same idea as Bresenham's line algorithm (as suggested by @Calinou in the issue), expressed parametrically because brush positions are stored as floats. A new helper `add_brush_line()` centralizes the loop.

Two corner cases keep the existing behavior intact:

1. The first sample of a stroke still places a single brush at the mouse position — there is no previous in-stroke sample to interpolate from.
2. If the previous sample's position is outside the canvas (the user briefly left and re-entered the drawing area mid-stroke), we also place a single brush instead of drawing a line through the off-canvas area. The `PaintControl` node does not clip its drawing, so without this guard a re-entry could draw brushes on top of the tools panel.

Undo continues to work unchanged: `undo_element_list_num` is captured before any sample is added in a stroke, and `undo_stroke()` already pops every sample added since then, regardless of how many were appended per frame.

## Testing

I haven't run this in the editor yet, so a quick visual check before merging would be appreciated. Algorithmically: gapless strokes for any mouse speed, undo semantics preserved, no drawing outside the canvas.
