### PR TITLE
Reinitialize water_plane compute resources on scene re-entry

### DIFF
--- a/compute/texture/water_plane/water_plane.gd
+++ b/compute/texture/water_plane/water_plane.gd
@@ -32,8 +32,10 @@ var add_wave_point: Vector4
 var mouse_pos: Vector2
 var mouse_pressed: bool = false
 
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
+# Use _enter_tree so the compute resources and texture binding are recreated
+# whenever the node re-enters the scene tree (e.g. switching scene tabs in the
+# editor or a runtime scene reload). _ready only fires on the first entry.
+func _enter_tree() -> void:
 	# In case we're running stuff on the rendering thread
 	# we need to do our initialisation on that thread.
 	RenderingServer.call_on_render_thread(_initialize_compute_code.bind(texture_size))

--- a/compute/texture/water_plane/water_plane.gd
+++ b/compute/texture/water_plane/water_plane.gd
@@ -32,27 +32,41 @@ var add_wave_point: Vector4
 var mouse_pos: Vector2
 var mouse_pressed: bool = false
 
+# Set on the render thread once compute resources have been (re)created. The
+# main thread checks this in _process so it doesn't bind freed RIDs in the
+# window between scene re-entry and the render thread finishing init.
+var ready_for_render: bool = false
+
 # Use _enter_tree so the compute resources and texture binding are recreated
 # whenever the node re-enters the scene tree (e.g. switching scene tabs in the
 # editor or a runtime scene reload). _ready only fires on the first entry.
 func _enter_tree() -> void:
+	next_texture = 0
+
+	# Create our own Texture2DRD and bind it to the material rather than
+	# reading the SubResource declared in the scene. The SubResource doesn't
+	# survive a scene unload reliably, so owning the lifetime here keeps the
+	# binding consistent across reloads.
+	texture = Texture2DRD.new()
+
+	var material: ShaderMaterial = $MeshInstance3D.material_override
+	if material:
+		material.set_shader_parameter(&"effect_texture", texture)
+		material.set_shader_parameter(&"effect_texture_size", texture_size)
+
 	# In case we're running stuff on the rendering thread
 	# we need to do our initialisation on that thread.
 	RenderingServer.call_on_render_thread(_initialize_compute_code.bind(texture_size))
 
-	# Get our texture from our material so we set our RID.
-	var material: ShaderMaterial = $MeshInstance3D.material_override
-	if material:
-		material.set_shader_parameter(&"effect_texture_size", texture_size)
-
-		# Get our texture object.
-		texture = material.get_shader_parameter(&"effect_texture")
-
 
 func _exit_tree() -> void:
+	# Block _process from touching compute resources until the next init.
+	ready_for_render = false
+
 	# Make sure we clean up!
 	if texture:
 		texture.texture_rd_rid = RID()
+		texture = null
 
 	RenderingServer.call_on_render_thread(_free_compute_resources)
 
@@ -115,12 +129,16 @@ func _process(delta: float) -> void:
 	else:
 		add_wave_point.z = mouse_size if mouse_pressed else 0.0
 
+	# Wait until the render thread has (re)initialised compute resources before
+	# advancing or dispatching, otherwise we'd bind freed RIDs left from the
+	# previous tree lifecycle.
+	if not ready_for_render:
+		return
+
 	# Increase our next texture index.
 	next_texture = (next_texture + 1) % 3
 
 	# Update our texture to show our next result (we are about to create).
-	# Note that `_initialize_compute_code` may not have run yet so the first
-	# frame this my be an empty RID.
 	if texture:
 		texture.texture_rd_rid = texture_rds[next_texture]
 
@@ -196,6 +214,9 @@ func _initialize_compute_code(init_with_texture_size: Vector2i) -> void:
 		texture_sets[i * 3 + 1] = _create_uniform_set(previous_texture_rd, 1)
 		texture_sets[i * 3 + 2] = _create_uniform_set(next_texture_rd, 2)
 
+	# Resources are live; main-thread _process can start binding and dispatching.
+	ready_for_render = true
+
 
 func _render_process(with_next_texture: int, wave_point: Vector4, tex_size: Vector2i, p_damp: float) -> void:
 	# We don't have structures (yet) so we need to build our push constant
@@ -257,3 +278,10 @@ func _free_compute_resources() -> void:
 
 	if shader:
 		rd.free_rid(shader)
+
+	# Reset so the next init starts from a known-empty state and any stale
+	# read from the main thread doesn't observe freed RIDs.
+	texture_rds = [RID(), RID(), RID()]
+	texture_sets = [RID(), RID(), RID(), RID(), RID(), RID(), RID(), RID(), RID()]
+	shader = RID()
+	pipeline = RID()


### PR DESCRIPTION
Fixes #1152.

## What's wrong

Switching the scene tab away from the water plane and back (or reloading the scene at runtime) left the plane blank and printed errors. Three things were going wrong:

1. **Init only ran once.** The compute resources and the `Texture2DRD` binding were set up in `_ready`, which only fires the first time a node enters the tree. `_exit_tree` was already clearing `texture_rd_rid` and freeing the compute resources, but on re-entry nothing rebuilt them.
2. **The scene's `Texture2DRD` SubResource doesn't survive an unload reliably.** Picking it back up via `material.get_shader_parameter(&"effect_texture")` on re-entry returned a `Texture2DRD` whose underlying RD texture had been torn down.
3. **Main-thread / render-thread race.** `_initialize_compute_code` is queued onto the render thread via `call_on_render_thread`. Between `_enter_tree` returning and the render thread actually running, `_process` kept running on the main thread and bound `texture_rds[next_texture]` — still holding the *previous* lifecycle's now-freed RIDs — onto the texture. With 9 uniform sets backed by those RIDs you get exactly the 9 errors `@Calinou` reported on 4.7.beta2.

## Fix

In `water_plane.gd`:

* Move per-instance setup from `_ready` into `_enter_tree` so it runs every tree entry (matches what `_exit_tree` was already pairing with, and the approach `@BastiaanOlij` suggested in the issue).
* Create a fresh `Texture2DRD` in `_enter_tree` and bind it onto the material with `set_shader_parameter`, instead of reading whatever the scene hands back. The script owns the `Texture2DRD`'s lifetime now, so reloads can't leave it stranded.
* Add a `ready_for_render` flag set on the render thread at the end of `_initialize_compute_code` and cleared on the main thread in `_exit_tree`. `_process` bails out before binding/dispatching while it's false, so we no longer bind freed RIDs during the init window.
* Reset `texture_rds` / `texture_sets` / `shader` / `pipeline` at the end of `_free_compute_resources` so a stale read from the main thread can never observe freed RIDs.

No changes to the GLSL, `.tscn`, or any other file.

## Verification

I wrote a small standalone scene mirroring the lifecycle pattern (init in `_ready` vs. init in `_enter_tree`) and exercised it through `add_child` / `remove_child`:

```
=== buggy variant (init in _ready) ===
after first add: initialized=1
after re-add:    initialized=1   <-- bug

=== fixed variant (init in _enter_tree) ===
after first add: initialized=1
after re-add:    initialized=2   <-- fixed
```

I haven't loaded the patched scene in the editor to confirm the 9 errors are gone and the ripples come back visually after a tab switch on macOS — please re-test before merging.
