### PR TITLE
Enable Autosmooth on stair corner example in CSG demo

### DIFF
--- a/3d/csg/csg.tscn
+++ b/3d/csg/csg.tscn
@@ -162,6 +162,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -28)
 
 [node name="CSGPolygon3D" type="CSGPolygon3D" parent="Testers/StaircaseSpin" unique_id=1363827634]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 1, 1)
+autosmooth = true
 polygon = PackedVector2Array(0, -1, 0, 0, 0.5, 0, 0.5, -0.25, 1, -0.25, 1, -0.5, 1.5, -0.5, 1.5, -0.75, 2, -0.75, 2, -1)
 mode = 1
 spin_degrees = 90.0

--- a/3d/csg/project.godot
+++ b/3d/csg/project.godot
@@ -15,7 +15,7 @@ config/description="This project showcases the various constructive solid geomet
 CSG can be used to prototype level designs within the 3D editor."
 config/tags=PackedStringArray("3d", "demo", "official")
 run/main_scene="res://csg.tscn"
-config/features=PackedStringArray("4.6")
+config/features=PackedStringArray("4.7")
 run/low_processor_mode=true
 config/icon="res://icon.webp"
 


### PR DESCRIPTION
This smooths out the curved surface on the corner staircase example.

Compared to using CSGPolygon3D's Smooth Faces, this does not cause the flat parts of the staircase to be smoothed out (which looked incorrect).

## Preview

Before | After
-|-
<img width="901" height="635" alt="Screenshot_20260518_203107" src="https://github.com/user-attachments/assets/b73277dc-9aec-4e09-ae23-e7306953aeb9" /> | <img width="901" height="635" alt="Screenshot_20260518_203058" src="https://github.com/user-attachments/assets/f7a4a5c7-d526-4047-9b32-63c330a58d4a" />