### PR TITLE
Improve 2d/physics_tests for debugging and review

### DIFF
--- a/2d/physics_tests/main.tscn
+++ b/2d/physics_tests/main.tscn
@@ -6,18 +6,17 @@
 [ext_resource type="Script" uid="uid://cfs8ay2xabc1j" path="res://tests_menu.gd" id="4"]
 [ext_resource type="Script" uid="uid://bddc5b3tojfxc" path="res://utils/label_test.gd" id="5"]
 [ext_resource type="Script" uid="uid://df276frwk3fje" path="res://utils/label_pause.gd" id="6"]
-[ext_resource type="Script" uid="uid://cg23ktlqpvfgx" path="res://utils/ticks_per_second.gd" id="8_dg77c"]
-[ext_resource type="Script" uid="uid://d12wj88dgcvd4" path="res://utils/time_scale.gd" id="9_ycdy4"]
+[ext_resource type="Script" uid="uid://bn4y1s3dxwyus" path="res://utils/label_frames.gd" id="7_w48qg"]
 [ext_resource type="Script" uid="uid://t6xab6he1cp6" path="res://utils/container_log.gd" id="10"]
-[ext_resource type="Script" uid="uid://cyx64fbvm7bw0" path="res://utils/max_steps_per_frame.gd" id="10_w48qg"]
 [ext_resource type="Script" uid="uid://bg74ptn4ol2g8" path="res://utils/scroll_log.gd" id="11"]
-[ext_resource type="Script" uid="uid://c805rm8ds7mo3" path="res://utils/physics_interpolation.gd" id="11_ycdy4"]
 [ext_resource type="Script" uid="uid://bce1220nuv7w0" path="res://tests.gd" id="12"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0, 0, 0, 0.176471)
 
 [node name="Main" type="Control" unique_id=2128203463]
+process_mode = 3
+modulate = Color(1, 1, 1, 0.7058824)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -28,11 +27,12 @@ mouse_filter = 2
 script = ExtResource("12")
 
 [node name="TestsMenu" type="MenuButton" parent="." unique_id=1051533574]
+unique_name_in_owner = true
 layout_mode = 0
 offset_left = 10.0
 offset_top = 10.0
 offset_right = 125.0
-offset_bottom = 30.0
+offset_bottom = 41.0
 text = "Tests"
 flat = false
 script = ExtResource("4")
@@ -41,72 +41,63 @@ script = ExtResource("4")
 layout_mode = 0
 offset_left = 157.0
 offset_top = 13.0
-offset_right = 646.0
-offset_bottom = 27.0
+offset_right = 925.0
+offset_bottom = 36.0
 theme_override_constants/outline_size = 4
-text = "P: Toggle Pause  |  R: Restart  |  C: Toggle Collision  |  F: Toggle Fullscreen  |  ESC: Quit"
+text = "P: Toggle Pause  |  L: Step Once | R: Restart  |  C: Toggle Collision  |  F: Toggle Fullscreen  |  ESC: Quit"
 
-[node name="LabelFPS" type="Label" parent="." unique_id=1221424336]
+[node name="StatsContainer" type="MarginContainer" parent="." unique_id=1189787900]
 layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -36.0
-offset_right = 55.0
-offset_bottom = -13.0
-grow_vertical = 0
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 4
-text = "FPS: 0"
-script = ExtResource("1")
-
-[node name="LabelEngine" type="Label" parent="." unique_id=285515091]
-layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -64.0
+offset_top = -141.0
 offset_right = 128.0
-offset_bottom = -41.0
 grow_vertical = 0
-theme_override_colors/font_color = Color(1, 1, 1, 0.752941)
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="Stats" type="VBoxContainer" parent="StatsContainer" unique_id=441593164]
+layout_mode = 2
+
+[node name="LabelTest" type="Label" parent="StatsContainer/Stats" unique_id=789147083]
+unique_name_in_owner = true
+layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
-text = "Physics engine:"
-script = ExtResource("3")
+text = "Test:"
+script = ExtResource("5")
 
-[node name="LabelVersion" type="Label" parent="." unique_id=1425389712]
-layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -92.0
-offset_right = 125.0
-offset_bottom = -69.0
-grow_vertical = 0
+[node name="LabelVersion" type="Label" parent="StatsContainer/Stats" unique_id=1425389712]
+layout_mode = 2
 theme_override_colors/font_color = Color(1, 1, 1, 0.752941)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "Godot version:"
 script = ExtResource("2")
 
-[node name="LabelTest" type="Label" parent="." unique_id=789147083]
-layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -120.0
-offset_right = 50.0
-offset_bottom = -97.0
-grow_vertical = 0
+[node name="LabelEngine" type="Label" parent="StatsContainer/Stats" unique_id=285515091]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 0.752941)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
-text = "Test:"
-script = ExtResource("5")
+text = "Physics engine:"
+script = ExtResource("3")
+
+[node name="LabelFPS" type="Label" parent="StatsContainer/Stats" unique_id=1221424336]
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "FPS: 0"
+script = ExtResource("1")
+
+[node name="LabelFrames" type="Label" parent="StatsContainer/Stats" unique_id=1888219416]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "Frame:"
+script = ExtResource("7_w48qg")
 
 [node name="LabelPause" type="Label" parent="." unique_id=238168997]
 modulate = Color(1, 1, 0, 1)
@@ -132,17 +123,17 @@ anchor_right = 1.0
 offset_left = -392.0
 offset_top = 56.0
 offset_right = -16.0
-offset_bottom = 168.0
+offset_bottom = 261.0
 grow_horizontal = 0
 theme_override_constants/separation = 6
 
 [node name="TicksPerSecond" type="HBoxContainer" parent="Options" unique_id=538503540]
 layout_mode = 2
+layout_direction = 2
 tooltip_text = "Higher values make physics more precise at the cost of higher CPU utilization.
 Low values may result in objects phasing through each other (tunneling).
 Physics ticks per second are automatically multiplied by Time Scale in this project."
 theme_override_constants/separation = 10
-script = ExtResource("8_dg77c")
 
 [node name="Label" type="Label" parent="Options/TicksPerSecond" unique_id=1576971871]
 custom_minimum_size = Vector2(164, 0)
@@ -151,7 +142,8 @@ theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "Ticks per Second"
 
-[node name="HSlider" type="HSlider" parent="Options/TicksPerSecond" unique_id=247607595]
+[node name="TicksPerSecond" type="HSlider" parent="Options/TicksPerSecond" unique_id=247607595]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 size_flags_vertical = 4
@@ -160,7 +152,8 @@ max_value = 240.0
 step = 10.0
 value = 60.0
 
-[node name="Value" type="Label" parent="Options/TicksPerSecond" unique_id=549785606]
+[node name="TicksPerSecondValue" type="Label" parent="Options/TicksPerSecond" unique_id=549785606]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
@@ -172,7 +165,6 @@ tooltip_text = "Game speed multiplier. Physics ticks per second are
 automatically multiplied by Time Scale in this project
 to ensure accurate simulation regardless of time scale."
 theme_override_constants/separation = 10
-script = ExtResource("9_ycdy4")
 
 [node name="Label" type="Label" parent="Options/TimeScale" unique_id=151694134]
 custom_minimum_size = Vector2(164, 0)
@@ -181,15 +173,17 @@ theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "Time Scale"
 
-[node name="HSlider" type="HSlider" parent="Options/TimeScale" unique_id=8530608]
+[node name="TimeScale" type="HSlider" parent="Options/TimeScale" unique_id=8530608]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 size_flags_vertical = 4
 max_value = 5.0
 step = 0.5
-value = 0.5
+value = 1.0
 
-[node name="Value" type="Label" parent="Options/TimeScale" unique_id=1344187457]
+[node name="TimeScaleValue" type="Label" parent="Options/TimeScale" unique_id=1344187457]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
@@ -201,7 +195,6 @@ tooltip_text = "Physics will slow down if more physics steps
 than this value need to be simulated in a
 single rendered frame."
 theme_override_constants/separation = 10
-script = ExtResource("10_w48qg")
 
 [node name="Label" type="Label" parent="Options/MaxStepsPerFrame" unique_id=856708187]
 custom_minimum_size = Vector2(164, 0)
@@ -210,7 +203,8 @@ theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "Max Steps per Frame"
 
-[node name="HSlider" type="HSlider" parent="Options/MaxStepsPerFrame" unique_id=1839821832]
+[node name="MaxStepsPerFrame" type="HSlider" parent="Options/MaxStepsPerFrame" unique_id=1839821832]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 size_flags_vertical = 4
@@ -218,13 +212,99 @@ min_value = 1.0
 max_value = 20.0
 value = 8.0
 
-[node name="Value" type="Label" parent="Options/MaxStepsPerFrame" unique_id=233340329]
+[node name="MaxStepsPerFrameValue" type="Label" parent="Options/MaxStepsPerFrame" unique_id=233340329]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "8"
 
-[node name="PhysicsInterpolation" type="CheckButton" parent="Options" unique_id=594845751]
+[node name="SolverIterations" type="HBoxContainer" parent="Options" unique_id=1380786056]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Label" type="Label" parent="Options/SolverIterations" unique_id=1066078852]
+custom_minimum_size = Vector2(164, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "Solver Iterations"
+
+[node name="SolverIterations" type="HSlider" parent="Options/SolverIterations" unique_id=279084094]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(160, 0)
+layout_mode = 2
+size_flags_vertical = 4
+min_value = 1.0
+max_value = 200.0
+value = 16.0
+
+[node name="SolverIterationsValue" type="Label" parent="Options/SolverIterations" unique_id=591474766]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "16"
+
+[node name="ContactBias" type="HBoxContainer" parent="Options" unique_id=1405354295]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Label" type="Label" parent="Options/ContactBias" unique_id=81432287]
+custom_minimum_size = Vector2(164, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "Contact Bias"
+
+[node name="ContactBias" type="HSlider" parent="Options/ContactBias" unique_id=726514010]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(160, 0)
+layout_mode = 2
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.05
+value = 0.8
+
+[node name="ContactBiasValue" type="Label" parent="Options/ContactBias" unique_id=278195393]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "0.80"
+
+[node name="ConstraintBias" type="HBoxContainer" parent="Options" unique_id=657942059]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Label" type="Label" parent="Options/ConstraintBias" unique_id=379484429]
+custom_minimum_size = Vector2(164, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "Constraint Bias"
+
+[node name="ConstraintBias" type="HSlider" parent="Options/ConstraintBias" unique_id=663335015]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(160, 0)
+layout_mode = 2
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.01
+value = 0.2
+
+[node name="ConstraintBiasValue" type="Label" parent="Options/ConstraintBias" unique_id=1259003201]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "0.20"
+
+[node name="PhysicsInterpolation2" type="HBoxContainer" parent="Options" unique_id=1044808489]
+layout_mode = 2
+
+[node name="PhysicsInterpolation" type="CheckButton" parent="Options/PhysicsInterpolation2" unique_id=594845751]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(217, 0)
 layout_mode = 2
 size_flags_horizontal = 0
@@ -233,7 +313,6 @@ This is a purely visual effect and has no impact on the physics simulation."
 theme_override_constants/outline_size = 4
 button_pressed = true
 text = "Physics Interpolation"
-script = ExtResource("11_ycdy4")
 
 [node name="PanelLog" type="Panel" parent="." unique_id=859449411]
 layout_mode = 1
@@ -303,9 +382,12 @@ layout_mode = 2
 text = "Log start"
 max_lines_visible = 5
 
-[connection signal="value_changed" from="Options/TicksPerSecond/HSlider" to="Options/TicksPerSecond" method="_on_h_slider_value_changed"]
-[connection signal="value_changed" from="Options/TimeScale/HSlider" to="Options/TimeScale" method="_on_h_slider_value_changed"]
-[connection signal="value_changed" from="Options/MaxStepsPerFrame/HSlider" to="Options/MaxStepsPerFrame" method="_on_h_slider_value_changed"]
-[connection signal="toggled" from="Options/PhysicsInterpolation" to="Options/PhysicsInterpolation" method="_on_check_button_toggled"]
+[connection signal="value_changed" from="Options/TicksPerSecond/TicksPerSecond" to="." method="_on_ticks_per_second_value_changed"]
+[connection signal="value_changed" from="Options/TimeScale/TimeScale" to="." method="_on_time_scale_value_changed"]
+[connection signal="value_changed" from="Options/MaxStepsPerFrame/MaxStepsPerFrame" to="." method="_on_max_steps_per_frame_value_changed"]
+[connection signal="value_changed" from="Options/SolverIterations/SolverIterations" to="." method="_on_solver_iterations_value_changed"]
+[connection signal="value_changed" from="Options/ContactBias/ContactBias" to="." method="_on_contact_bias_value_changed"]
+[connection signal="value_changed" from="Options/ConstraintBias/ConstraintBias" to="." method="_on_constraint_bias_value_changed"]
+[connection signal="toggled" from="Options/PhysicsInterpolation2/PhysicsInterpolation" to="." method="_on_physics_interpolation_toggled"]
 [connection signal="pressed" from="PanelLog/ButtonClear" to="PanelLog/ScrollLog/VBoxLog" method="clear"]
 [connection signal="toggled" from="PanelLog/CheckBoxScroll" to="PanelLog/ScrollLog" method="_on_check_box_scroll_toggled"]

--- a/2d/physics_tests/main.tscn
+++ b/2d/physics_tests/main.tscn
@@ -44,7 +44,7 @@ offset_top = 13.0
 offset_right = 925.0
 offset_bottom = 36.0
 theme_override_constants/outline_size = 4
-text = "P: Toggle Pause  |  L: Step Once | R: Restart  |  C: Toggle Collision  |  F: Toggle Fullscreen  |  ESC: Quit"
+text = "P: Toggle Pause  |  L: Step Once  |  R: Restart  |  C: Toggle Collision  |  F: Toggle Fullscreen  |  ESC: Quit"
 
 [node name="StatsContainer" type="MarginContainer" parent="." unique_id=1189787900]
 layout_mode = 1

--- a/2d/physics_tests/project.godot
+++ b/2d/physics_tests/project.godot
@@ -93,6 +93,11 @@ character_jump={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 ]
 }
+step_once={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":76,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [memory]
 

--- a/2d/physics_tests/tests.gd
+++ b/2d/physics_tests/tests.gd
@@ -83,31 +83,31 @@ func _ready() -> void:
 		else:
 			arguments[arg.trim_prefix("--")] = ""
 
-	if arguments.has("ticks_per_second"):
-		Engine.physics_ticks_per_second = int(arguments["ticks_per_second"])
+	if arguments.has("ticks-per-second"):
+		Engine.physics_ticks_per_second = int(arguments["ticks-per-second"])
 		%TicksPerSecond.value = Engine.physics_ticks_per_second
 
-	if arguments.has("time_scale"):
-		Engine.time_scale = float(arguments["time_scale"])
+	if arguments.has("time-scale"):
+		Engine.time_scale = float(arguments["time-scale"])
 		%TimeScale.value = Engine.time_scale
 
-	if arguments.has("max_steps_per_frame"):
-		Engine.max_physics_steps_per_frame = int(arguments["max_steps_per_frame"])
+	if arguments.has("max-steps-per-frame"):
+		Engine.max_physics_steps_per_frame = int(arguments["max-steps-per-frame"])
 		%MaxStepsPerFrame.value = Engine.max_physics_steps_per_frame
 
-	if arguments.has("solver_iterations"):
-		%SolverIterations.value = int(arguments["solver_iterations"])
-		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS, int(arguments["solver_iterations"]))
+	if arguments.has("solver-iterations"):
+		%SolverIterations.value = int(arguments["solver-iterations"])
+		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS, int(arguments["solver-iterations"]))
 
-	if arguments.has("contact_bias"):
-		%ContactBias.value = float(arguments["contact_bias"])
-		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONTACT_DEFAULT_BIAS, float(arguments["contact_bias"]))
+	if arguments.has("contact-bias"):
+		%ContactBias.value = float(arguments["contact-bias"])
+		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONTACT_DEFAULT_BIAS, float(arguments["contact-bias"]))
 
-	if arguments.has("constraint_bias"):
-		%ConstraintBias.value = float(arguments["constraint_bias"])
-		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS, float(arguments["constraint_bias"]))
+	if arguments.has("constraint-bias"):
+		%ConstraintBias.value = float(arguments["constraint-bias"])
+		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS, float(arguments["constraint-bias"]))
 
-	if arguments.has("physics_interpolation"):
+	if arguments.has("physics-interpolation"):
 		var arg: String = arguments["physics_interpolation"].to_lower()
 		get_tree().physics_interpolation = arg == "true" or arg == "on"
 		%PhysicsInterpolation.button_pressed = get_tree().physics_interpolation
@@ -115,8 +115,8 @@ func _ready() -> void:
 	if arguments.has("fullscreen"):
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
 
-	if arguments.has("test_scene"):
-		test_menu.start_test_from_scene.call_deferred(arguments["test_scene"])
+	if arguments.has("test-scene"):
+		test_menu.start_test_from_scene.call_deferred(arguments["test-scene"])
 
 
 func _on_ticks_per_second_value_changed(value: float) -> void:

--- a/2d/physics_tests/tests.gd
+++ b/2d/physics_tests/tests.gd
@@ -139,7 +139,7 @@ func _on_max_steps_per_frame_value_changed(value: float) -> void:
 
 func _on_solver_iterations_value_changed(value: float) -> void:
 	%SolverIterationsValue.text = str(roundi(value))
-	PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS,roundi(value))
+	PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS, roundi(value))
 
 
 func _on_contact_bias_value_changed(value: float) -> void:

--- a/2d/physics_tests/tests.gd
+++ b/2d/physics_tests/tests.gd
@@ -112,9 +112,6 @@ func _ready() -> void:
 		get_tree().physics_interpolation = arg == "true" or arg == "on"
 		%PhysicsInterpolation.button_pressed = get_tree().physics_interpolation
 
-	if arguments.has("fullscreen"):
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
-
 	if arguments.has("test-scene"):
 		test_menu.start_test_from_scene.call_deferred(arguments["test-scene"])
 

--- a/2d/physics_tests/tests.gd
+++ b/2d/physics_tests/tests.gd
@@ -1,6 +1,6 @@
 extends Node
 
-var _tests : Array[Dictionary] = [
+var _tests: Array[Dictionary] = [
 	{
 		"id": "Functional Tests/Shapes",
 		"path": "res://tests/functional/test_shapes.tscn",
@@ -108,7 +108,7 @@ func _ready() -> void:
 		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS, float(arguments["constraint-bias"]))
 
 	if arguments.has("physics-interpolation"):
-		var arg: String = arguments["physics_interpolation"].to_lower()
+		var arg: String = arguments["physics-interpolation"].to_lower()
 		get_tree().physics_interpolation = arg == "true" or arg == "on"
 		%PhysicsInterpolation.button_pressed = get_tree().physics_interpolation
 

--- a/2d/physics_tests/tests.gd
+++ b/2d/physics_tests/tests.gd
@@ -1,6 +1,6 @@
 extends Node
 
-var _tests: Array[Dictionary] = [
+var _tests : Array[Dictionary] = [
 	{
 		"id": "Functional Tests/Shapes",
 		"path": "res://tests/functional/test_shapes.tscn",
@@ -53,10 +53,114 @@ var _tests: Array[Dictionary] = [
 		"id": "Performance Tests/Contact Islands",
 		"path": "res://tests/performance/test_perf_contact_islands.tscn",
 	},
+	{
+		"id": "Functional Tests/Solver/Rain on Pin Joint",
+		"path": "res://tests/functional/solver/rain_on_pin_joint.tscn",
+	},
+	{
+		"id": "Functional Tests/Solver/Bodies in Bucket",
+		"path": "res://tests/functional/solver/bodies_in_bucket.tscn",
+	},
 ]
 
 
 func _ready() -> void:
-	var test_menu: OptionMenu = $TestsMenu
+	# UI should stay active during pause.
+	# The rest of the UI will inherit this, except
+	# for frame counter which only counts unpaused frames.
+	process_mode = PROCESS_MODE_ALWAYS
+	_get_default_options()
+
+	var test_menu: OptionMenu = %TestsMenu
 	for test: Dictionary in _tests:
 		test_menu.add_test(test.id, test.path)
+
+	var arguments := { }
+	for arg in OS.get_cmdline_user_args():
+		if arg.contains("="):
+			var key_value := arg.split("=")
+			arguments[key_value[0].trim_prefix("--")] = key_value[1]
+		else:
+			arguments[arg.trim_prefix("--")] = ""
+
+	if arguments.has("ticks_per_second"):
+		Engine.physics_ticks_per_second = int(arguments["ticks_per_second"])
+		%TicksPerSecond.value = Engine.physics_ticks_per_second
+
+	if arguments.has("time_scale"):
+		Engine.time_scale = float(arguments["time_scale"])
+		%TimeScale.value = Engine.time_scale
+
+	if arguments.has("max_steps_per_frame"):
+		Engine.max_physics_steps_per_frame = int(arguments["max_steps_per_frame"])
+		%MaxStepsPerFrame.value = Engine.max_physics_steps_per_frame
+
+	if arguments.has("solver_iterations"):
+		%SolverIterations.value = int(arguments["solver_iterations"])
+		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS, int(arguments["solver_iterations"]))
+
+	if arguments.has("contact_bias"):
+		%ContactBias.value = float(arguments["contact_bias"])
+		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONTACT_DEFAULT_BIAS, float(arguments["contact_bias"]))
+
+	if arguments.has("constraint_bias"):
+		%ConstraintBias.value = float(arguments["constraint_bias"])
+		PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS, float(arguments["constraint_bias"]))
+
+	if arguments.has("physics_interpolation"):
+		var arg: String = arguments["physics_interpolation"].to_lower()
+		get_tree().physics_interpolation = arg == "true" or arg == "on"
+		%PhysicsInterpolation.button_pressed = get_tree().physics_interpolation
+
+	if arguments.has("fullscreen"):
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+
+	if arguments.has("test_scene"):
+		test_menu.start_test_from_scene.call_deferred(arguments["test_scene"])
+
+
+func _on_ticks_per_second_value_changed(value: float) -> void:
+	%TicksPerSecondValue.text = str(roundi(value * Engine.time_scale))
+	Engine.physics_ticks_per_second = roundi(value)
+
+
+func _on_time_scale_value_changed(value: float) -> void:
+	value = maxf(0.1, value)
+	%TimeScaleValue.text = "%.1f×" % value
+	Engine.time_scale = value
+	Engine.physics_ticks_per_second = %TicksPerSecond.value * value
+	%TicksPerSecondValue.text = str(roundi(%TicksPerSecond.value * value))
+
+
+func _on_max_steps_per_frame_value_changed(value: float) -> void:
+	%MaxStepsPerFrameValue.text = str(roundi(value))
+	Engine.max_physics_steps_per_frame = roundi(value)
+
+
+func _on_solver_iterations_value_changed(value: float) -> void:
+	%SolverIterationsValue.text = str(roundi(value))
+	PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS,roundi(value))
+
+
+func _on_contact_bias_value_changed(value: float) -> void:
+	%ContactBiasValue.text = "%.2f" % value
+	PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONTACT_DEFAULT_BIAS, value)
+
+
+func _on_constraint_bias_value_changed(value: float) -> void:
+	%ConstraintBiasValue.text = "%.2f" % value
+	PhysicsServer2D.space_set_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS, value)
+
+
+func _on_physics_interpolation_toggled(toggled_on: bool) -> void:
+	get_tree().physics_interpolation = toggled_on
+
+
+func _get_default_options() -> void:
+	%PhysicsInterpolation.button_pressed = get_tree().physics_interpolation
+	%ConstraintBias.value = PhysicsServer2D.space_get_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS)
+	%ContactBias.value = PhysicsServer2D.space_get_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_CONTACT_DEFAULT_BIAS)
+	%SolverIterations.value = PhysicsServer2D.space_get_param(get_viewport().find_world_2d().space, PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS)
+	%MaxStepsPerFrame.value = Engine.max_physics_steps_per_frame
+	%TicksPerSecond.value = Engine.physics_ticks_per_second
+	%TimeScale.value = Engine.time_scale

--- a/2d/physics_tests/tests.gd
+++ b/2d/physics_tests/tests.gd
@@ -75,7 +75,7 @@ func _ready() -> void:
 	for test: Dictionary in _tests:
 		test_menu.add_test(test.id, test.path)
 
-	var arguments := { }
+	var arguments := {}
 	for arg in OS.get_cmdline_user_args():
 		if arg.contains("="):
 			var key_value := arg.split("=")

--- a/2d/physics_tests/tests/functional/solver/bodies_in_bucket.tscn
+++ b/2d/physics_tests/tests/functional/solver/bodies_in_bucket.tscn
@@ -1,0 +1,80 @@
+[gd_scene format=3 uid="uid://b2425idb2urkl"]
+
+[ext_resource type="Script" uid="uid://bu4llp5vwwdk3" path="res://tests/functional/solver/body_spawner.gd" id="1_60g6e"]
+[ext_resource type="PackedScene" uid="uid://cj5t3sbxdiqss" path="res://tests/functional/solver/test_bodies/concave_polygon.tscn" id="2_eqv8g"]
+[ext_resource type="PackedScene" uid="uid://bwbkdtvokfwr3" path="res://tests/functional/solver/test_bodies/convex_polygon.tscn" id="3_k3wic"]
+[ext_resource type="PackedScene" uid="uid://nqx8bxc67lyq" path="res://tests/functional/solver/test_bodies/circle.tscn" id="4_eqv8g"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_rl7rh"]
+size = Vector2(0, 0)
+
+[sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_0fdrj"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_rp5ok"]
+size = Vector2(500, 30)
+
+[node name="BodiesInBucket" type="Node2D" unique_id=1327340147]
+
+[node name="TimeControl" type="Node2D" parent="." unique_id=296966780]
+
+[node name="CantileveredBeam" type="StaticBody2D" parent="." unique_id=1315170967]
+unique_name_in_owner = true
+position = Vector2(129, 259)
+collision_layer = 0
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CantileveredBeam" unique_id=799502497]
+shape = SubResource("RectangleShape2D_rl7rh")
+
+[node name="BodySpawner" type="Node2D" parent="." unique_id=848283850]
+position = Vector2(597, -65)
+script = ExtResource("1_60g6e")
+body_scenes = Array[PackedScene]([ExtResource("2_eqv8g"), ExtResource("3_k3wic"), ExtResource("4_eqv8g")])
+body_spawn_roll = Array[int]([20, 80, 200])
+
+[node name="SpawnTimer" type="Timer" parent="BodySpawner" unique_id=1206903970]
+wait_time = 0.1
+autostart = true
+
+[node name="StaticBody2D" type="StaticBody2D" parent="." unique_id=1542910147]
+position = Vector2(282, -4)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D" unique_id=109410884]
+position = Vector2(288, 646)
+shape = SubResource("WorldBoundaryShape2D_0fdrj")
+
+[node name="StaticBody2D2" type="StaticBody2D" parent="." unique_id=936930901]
+position = Vector2(501, 589)
+rotation = -1.5707964
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D2" unique_id=780982211]
+position = Vector2(288, 646)
+shape = SubResource("WorldBoundaryShape2D_0fdrj")
+
+[node name="StaticBody2D3" type="StaticBody2D" parent="." unique_id=1458071085]
+position = Vector2(649, -5)
+rotation = 1.5707964
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D3" unique_id=861829250]
+position = Vector2(288, 646)
+shape = SubResource("WorldBoundaryShape2D_0fdrj")
+
+[node name="Bucket" type="Node2D" parent="." unique_id=221439261]
+
+[node name="StaticBody2D" type="StaticBody2D" parent="Bucket" unique_id=2024476473]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Bucket/StaticBody2D" unique_id=760324576]
+position = Vector2(600, 600)
+shape = SubResource("RectangleShape2D_rp5ok")
+
+[node name="CollisionShape2D2" type="CollisionShape2D" parent="Bucket/StaticBody2D" unique_id=873470206]
+position = Vector2(289.99997, 353.99997)
+rotation = -1.8325957
+shape = SubResource("RectangleShape2D_rp5ok")
+
+[node name="CollisionShape2D3" type="CollisionShape2D" parent="Bucket/StaticBody2D" unique_id=1491156732]
+position = Vector2(917, 356)
+rotation = 1.8325957
+shape = SubResource("RectangleShape2D_rp5ok")
+
+[connection signal="timeout" from="BodySpawner/SpawnTimer" to="BodySpawner" method="_on_spawn_timer_timeout"]

--- a/2d/physics_tests/tests/functional/solver/body_spawner.gd
+++ b/2d/physics_tests/tests/functional/solver/body_spawner.gd
@@ -1,13 +1,13 @@
 # Spawn random RigidBody scenes.
 extends Node2D
 
-@export var body_scenes : Array[PackedScene]
-@export var body_spawn_roll : Array[int]
-@export var mass : float = 0.27
+@export var body_scenes: Array[PackedScene]
+@export var body_spawn_roll: Array[int]
+@export var mass: float = 0.27
 
 var _rng := RandomNumberGenerator.new()
-var _total_roll : int = 0
-var _accum_roll : Array[int]
+var _total_roll: int = 0
+var _accum_roll: Array[int]
 
 
 func _sum(accum: int, number: int) -> int:
@@ -23,7 +23,7 @@ func _ready() -> void:
 
 func spawn_body() -> void:
 	var rndi := _rng.randi_range(0, _total_roll)
-	var pick : int = 0
+	var pick: int = 0
 	for i in body_spawn_roll.size():
 		if rndi <= _accum_roll[i]:
 			pick = i

--- a/2d/physics_tests/tests/functional/solver/body_spawner.gd
+++ b/2d/physics_tests/tests/functional/solver/body_spawner.gd
@@ -37,6 +37,7 @@ func spawn_body() -> void:
 	add_child(rb)
 	vn.screen_exited.connect(_on_screen_exited.bind(rb))
 
+
 func _on_screen_exited(rb: RigidBody2D) -> void:
 	rb.queue_free()
 

--- a/2d/physics_tests/tests/functional/solver/body_spawner.gd
+++ b/2d/physics_tests/tests/functional/solver/body_spawner.gd
@@ -1,0 +1,45 @@
+# Spawn random RigidBody scenes.
+extends Node2D
+
+@export var body_scenes : Array[PackedScene]
+@export var body_spawn_roll : Array[int]
+@export var mass : float = 0.27
+
+var _rng := RandomNumberGenerator.new()
+var _total_roll : int = 0
+var _accum_roll : Array[int]
+
+
+func _sum(accum: int, number: int) -> int:
+	return accum + number
+
+
+func _ready() -> void:
+	_rng.seed = 12345
+	for i in body_spawn_roll.size():
+		_total_roll += body_spawn_roll[i]
+		_accum_roll.append(_total_roll)
+
+
+func spawn_body() -> void:
+	var rndi := _rng.randi_range(0, _total_roll)
+	var pick : int = 0
+	for i in body_spawn_roll.size():
+		if rndi <= _accum_roll[i]:
+			pick = i
+			break
+
+	var vn := VisibleOnScreenNotifier2D.new()
+	var rb: RigidBody2D = body_scenes[pick].instantiate()
+	rb.transform.origin.x = _rng.randf_range(-200.0, 200.0)
+
+	rb.add_child(vn)
+	add_child(rb)
+	vn.screen_exited.connect(_on_screen_exited.bind(rb))
+
+func _on_screen_exited(rb: RigidBody2D) -> void:
+	rb.queue_free()
+
+
+func _on_spawn_timer_timeout() -> void:
+	spawn_body()

--- a/2d/physics_tests/tests/functional/solver/body_spawner.gd.uid
+++ b/2d/physics_tests/tests/functional/solver/body_spawner.gd.uid
@@ -1,0 +1,1 @@
+uid://bu4llp5vwwdk3

--- a/2d/physics_tests/tests/functional/solver/rain_on_pin_joint.tscn
+++ b/2d/physics_tests/tests/functional/solver/rain_on_pin_joint.tscn
@@ -1,0 +1,138 @@
+[gd_scene format=3 uid="uid://cwfsgi63o1pod"]
+
+[ext_resource type="Script" uid="uid://bjckrk4dmnguh" path="res://tests/functional/solver/rain_spawner.gd" id="2_w8rqi"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_rl7rh"]
+size = Vector2(0, 0)
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_0fdrj"]
+radius = 20.0
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_foa4q"]
+size = Vector2(300, 20)
+
+[sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_0fdrj"]
+
+[node name="RainOnPinJoint" type="Node2D" unique_id=1327340147]
+
+[node name="CantileveredBeam" type="StaticBody2D" parent="." unique_id=1315170967]
+unique_name_in_owner = true
+position = Vector2(129, 259)
+collision_layer = 0
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CantileveredBeam" unique_id=799502497]
+shape = SubResource("RectangleShape2D_rl7rh")
+
+[node name="RainSpawner" type="Node2D" parent="." unique_id=848283850]
+position = Vector2(300, -65)
+script = ExtResource("2_w8rqi")
+
+[node name="SpawnTimer" type="Timer" parent="RainSpawner" unique_id=1206903970]
+wait_time = 0.5
+autostart = true
+
+[node name="Lever1" type="Node2D" parent="." unique_id=1434451354]
+position = Vector2(300, 300)
+
+[node name="PinJoint2DLever1" type="PinJoint2D" parent="Lever1" unique_id=1370430001]
+unique_name_in_owner = true
+position = Vector2(-20, 0)
+node_a = NodePath("StaticBody2D")
+node_b = NodePath("../RigidBody2D")
+angular_limit_enabled = true
+angular_limit_lower = -0.2617994
+angular_limit_upper = 0.2617994
+
+[node name="StaticBody2D" type="StaticBody2D" parent="Lever1/PinJoint2DLever1" unique_id=1526426481]
+collision_layer = 0
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Lever1/PinJoint2DLever1/StaticBody2D" unique_id=1985752402]
+shape = SubResource("CircleShape2D_0fdrj")
+
+[node name="RigidBody2D" type="RigidBody2D" parent="Lever1" unique_id=1940580592]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Lever1/RigidBody2D" unique_id=1549961216]
+shape = SubResource("RectangleShape2D_foa4q")
+
+[node name="LowerLimit" type="Line2D" parent="Lever1" unique_id=1271109450]
+modulate = Color(1, 0, 0, 1)
+position = Vector2(-20, 0)
+rotation = -0.2617994
+points = PackedVector2Array(-130, 0, 170, 0)
+width = 1.0
+
+[node name="UpperLimit" type="Line2D" parent="Lever1" unique_id=1022594586]
+modulate = Color(1, 0, 0, 1)
+position = Vector2(-20, 0)
+rotation = 0.2617994
+points = PackedVector2Array(-130, 0, 170, 0)
+width = 1.0
+
+[node name="Lever2" type="Node2D" parent="." unique_id=1644240585]
+position = Vector2(800, 300)
+
+[node name="LowerLimit" type="Line2D" parent="Lever2" unique_id=287089944]
+visible = false
+modulate = Color(1, 0, 0, 1)
+position = Vector2(-100, 0)
+rotation = -0.5235988
+points = PackedVector2Array(-50, 0, 250, 0)
+width = 1.0
+
+[node name="UpperLimit" type="Line2D" parent="Lever2" unique_id=586593678]
+visible = false
+modulate = Color(1, 0, 0, 1)
+position = Vector2(-100, 0)
+rotation = 0.5235988
+points = PackedVector2Array(-50, 0, 250, 0)
+width = 1.0
+
+[node name="PinJoint2DLever2" type="PinJoint2D" parent="Lever2" unique_id=647322840]
+unique_name_in_owner = true
+position = Vector2(-100, 0)
+node_a = NodePath("StaticBody2D")
+node_b = NodePath("../RigidBody2D")
+angular_limit_lower = -0.5235988
+angular_limit_upper = 0.5235988
+motor_enabled = true
+motor_target_velocity = -3.1415927
+
+[node name="StaticBody2D" type="StaticBody2D" parent="Lever2/PinJoint2DLever2" unique_id=221424010]
+collision_layer = 0
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Lever2/PinJoint2DLever2/StaticBody2D" unique_id=755175220]
+shape = SubResource("CircleShape2D_0fdrj")
+
+[node name="RigidBody2D" type="RigidBody2D" parent="Lever2" unique_id=2349510]
+continuous_cd = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Lever2/RigidBody2D" unique_id=802327767]
+shape = SubResource("RectangleShape2D_foa4q")
+
+[node name="StaticBody2D" type="StaticBody2D" parent="." unique_id=1542910147]
+position = Vector2(282, -4)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D" unique_id=109410884]
+position = Vector2(288, 646)
+shape = SubResource("WorldBoundaryShape2D_0fdrj")
+
+[node name="StaticBody2D2" type="StaticBody2D" parent="." unique_id=936930901]
+position = Vector2(501, 589)
+rotation = -1.5707964
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D2" unique_id=780982211]
+position = Vector2(288, 646)
+shape = SubResource("WorldBoundaryShape2D_0fdrj")
+
+[node name="StaticBody2D3" type="StaticBody2D" parent="." unique_id=1458071085]
+position = Vector2(649, -5)
+rotation = 1.5707964
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D3" unique_id=861829250]
+position = Vector2(288, 646)
+shape = SubResource("WorldBoundaryShape2D_0fdrj")
+
+[connection signal="timeout" from="RainSpawner/SpawnTimer" to="RainSpawner" method="_on_spawn_timer_timeout"]

--- a/2d/physics_tests/tests/functional/solver/rain_spawner.gd
+++ b/2d/physics_tests/tests/functional/solver/rain_spawner.gd
@@ -2,7 +2,7 @@
 # side by side comparisons.
 extends Node2D
 
-@export var mass : float = 0.27
+@export var mass: float = 0.27
 var rng := RandomNumberGenerator.new()
 
 

--- a/2d/physics_tests/tests/functional/solver/rain_spawner.gd
+++ b/2d/physics_tests/tests/functional/solver/rain_spawner.gd
@@ -1,0 +1,47 @@
+# Spawn RigidBody rain 500px apart to enable
+# side by side comparisons.
+extends Node2D
+
+@export var mass : float = 0.27
+var rng := RandomNumberGenerator.new()
+
+
+func _ready() -> void:
+	rng.seed = 12345
+
+
+func spawn_circle_body() -> void:
+	var rb := RigidBody2D.new()
+	var rb2 := RigidBody2D.new()
+	var cs := CollisionShape2D.new()
+	var cs2 := CollisionShape2D.new()
+	var sp := CircleShape2D.new()
+	var vn := VisibleOnScreenNotifier2D.new()
+	var vn2 := VisibleOnScreenNotifier2D.new()
+	sp.radius = 10.0 * rng.randf_range(0.5, 3.5)
+	cs.shape = sp
+	cs2.shape = sp
+
+	var x := rng.randf_range(-200.0, 200.0)
+	rb.mass = mass * (sp.radius / 20.0) ** 3
+	rb.transform.origin.x = x
+	rb.add_child(cs)
+	rb.add_child(vn)
+	add_child(rb)
+
+	rb2.mass = mass * (sp.radius / 20.0) ** 3
+	rb2.transform.origin.x = x + 500.0
+	rb2.add_child(cs2)
+	rb2.add_child(vn2)
+	add_child(rb2)
+
+	vn.screen_exited.connect(_on_screen_exited.bind(rb))
+	vn2.screen_exited.connect(_on_screen_exited.bind(rb2))
+
+
+func _on_screen_exited(rb: RigidBody2D) -> void:
+	rb.queue_free()
+
+
+func _on_spawn_timer_timeout() -> void:
+	spawn_circle_body()

--- a/2d/physics_tests/tests/functional/solver/rain_spawner.gd.uid
+++ b/2d/physics_tests/tests/functional/solver/rain_spawner.gd.uid
@@ -1,0 +1,1 @@
+uid://bjckrk4dmnguh

--- a/2d/physics_tests/tests/functional/solver/test_bodies/circle.tscn
+++ b/2d/physics_tests/tests/functional/solver/test_bodies/circle.tscn
@@ -1,0 +1,9 @@
+[gd_scene format=3 uid="uid://nqx8bxc67lyq"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_u0p83"]
+radius = 20.0
+
+[node name="Circle" type="RigidBody2D" unique_id=751771242]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=360424507]
+shape = SubResource("CircleShape2D_u0p83")

--- a/2d/physics_tests/tests/functional/solver/test_bodies/concave_polygon.tscn
+++ b/2d/physics_tests/tests/functional/solver/test_bodies/concave_polygon.tscn
@@ -1,0 +1,7 @@
+[gd_scene format=3 uid="uid://cj5t3sbxdiqss"]
+
+[node name="ConcavePolygon" type="RigidBody2D" unique_id=1187710576]
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="." unique_id=882638497]
+scale = Vector2(0.2731092, 0.27310926)
+polygon = PackedVector2Array(-53, -24, -2, -90, 100, -65, 167, 55, 65, 148, 39, 96, 64, 23, -129, 26, -145, -73, -76, -77)

--- a/2d/physics_tests/tests/functional/solver/test_bodies/convex_polygon.tscn
+++ b/2d/physics_tests/tests/functional/solver/test_bodies/convex_polygon.tscn
@@ -1,0 +1,7 @@
+[gd_scene format=3 uid="uid://bwbkdtvokfwr3"]
+
+[node name="ConvexPolygon" type="RigidBody2D" unique_id=1646060318]
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="." unique_id=1692155763]
+scale = Vector2(0.3707627, 0.37076253)
+polygon = PackedVector2Array(-55, -21, -1, -77, 48, -45, 63, 49, 21, 62, -34, 47)

--- a/2d/physics_tests/tests_menu.gd
+++ b/2d/physics_tests/tests_menu.gd
@@ -1,15 +1,14 @@
 extends OptionMenu
 
-
-class TestData:
-	var id: String = ""
-	var scene_path: String = ""
+class TestData :
+	var id : String = ""
+	var scene_path : String = ""
 
 
 var _test_list := []
 
-var _current_test: TestData = null
-var _current_test_scene: Node = null
+var _current_test : TestData = null
+var _current_test_scene : Node = null
 
 
 func _ready() -> void:
@@ -18,6 +17,7 @@ func _ready() -> void:
 
 func _process(_delta: float) -> void:
 	if Input.is_action_just_pressed(&"restart_test"):
+		%LabelFrames.reset()
 		if _current_test:
 			_start_test(_current_test)
 
@@ -31,8 +31,14 @@ func add_test(id: String, scene_path: String) -> void:
 	add_menu_item(id)
 
 
+func start_test_from_scene(scene_path: String) -> void:
+	for test : TestData in _test_list:
+		if test.scene_path == scene_path:
+			_start_test(test)
+
+
 func _on_option_selected(item_path: String) -> void:
-	for test: TestData in _test_list:
+	for test : TestData in _test_list:
 		if test.id == item_path:
 			_start_test(test)
 
@@ -50,5 +56,5 @@ func _start_test(test: TestData) -> void:
 	get_tree().root.add_child(_current_test_scene)
 	get_tree().root.move_child(_current_test_scene, 0)
 
-	var label_test: Label = $"../LabelTest"
+	var label_test : Label = %LabelTest
 	label_test.test_name = test.id

--- a/2d/physics_tests/tests_menu.gd
+++ b/2d/physics_tests/tests_menu.gd
@@ -1,14 +1,14 @@
 extends OptionMenu
 
 class TestData:
-	var id : String = ""
-	var scene_path : String = ""
+	var id: String = ""
+	var scene_path: String = ""
 
 
 var _test_list := []
 
-var _current_test : TestData = null
-var _current_test_scene : Node = null
+var _current_test: TestData = null
+var _current_test_scene: Node = null
 
 
 func _ready() -> void:
@@ -32,13 +32,13 @@ func add_test(id: String, scene_path: String) -> void:
 
 
 func start_test_from_scene(scene_path: String) -> void:
-	for test : TestData in _test_list:
+	for test: TestData in _test_list:
 		if test.scene_path == scene_path:
 			_start_test(test)
 
 
 func _on_option_selected(item_path: String) -> void:
-	for test : TestData in _test_list:
+	for test: TestData in _test_list:
 		if test.id == item_path:
 			_start_test(test)
 
@@ -56,5 +56,5 @@ func _start_test(test: TestData) -> void:
 	get_tree().root.add_child(_current_test_scene)
 	get_tree().root.move_child(_current_test_scene, 0)
 
-	var label_test : Label = %LabelTest
+	var label_test: Label = %LabelTest
 	label_test.test_name = test.id

--- a/2d/physics_tests/tests_menu.gd
+++ b/2d/physics_tests/tests_menu.gd
@@ -1,6 +1,6 @@
 extends OptionMenu
 
-class TestData :
+class TestData:
 	var id : String = ""
 	var scene_path : String = ""
 

--- a/2d/physics_tests/utils/label_frames.gd
+++ b/2d/physics_tests/utils/label_frames.gd
@@ -1,0 +1,20 @@
+extends Label
+
+var _unpaused_frame_count : int = 0
+
+
+func reset() -> void:
+	_unpaused_frame_count = 0
+	text = "%d Frames" % [_unpaused_frame_count]
+
+
+func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_PAUSABLE
+
+
+func _process(_delta: float) -> void:
+	text = "%d Frames" % [_unpaused_frame_count]
+
+
+func _physics_process(_delta: float) -> void:
+	_unpaused_frame_count += 1

--- a/2d/physics_tests/utils/label_frames.gd
+++ b/2d/physics_tests/utils/label_frames.gd
@@ -1,6 +1,6 @@
 extends Label
 
-var _unpaused_frame_count : int = 0
+var _unpaused_frame_count: int = 0
 
 
 func reset() -> void:

--- a/2d/physics_tests/utils/label_frames.gd.uid
+++ b/2d/physics_tests/utils/label_frames.gd.uid
@@ -1,0 +1,1 @@
+uid://bn4y1s3dxwyus

--- a/2d/physics_tests/utils/max_steps_per_frame.gd
+++ b/2d/physics_tests/utils/max_steps_per_frame.gd
@@ -1,6 +1,0 @@
-extends HBoxContainer
-
-
-func _on_h_slider_value_changed(value: float) -> void:
-	$Value.text = str(roundi(value))
-	Engine.max_physics_steps_per_frame = roundi(value)

--- a/2d/physics_tests/utils/max_steps_per_frame.gd.uid
+++ b/2d/physics_tests/utils/max_steps_per_frame.gd.uid
@@ -1,1 +1,0 @@
-uid://cyx64fbvm7bw0

--- a/2d/physics_tests/utils/physics_interpolation.gd
+++ b/2d/physics_tests/utils/physics_interpolation.gd
@@ -1,5 +1,0 @@
-extends CheckButton
-
-
-func _on_check_button_toggled(toggled_on: bool) -> void:
-	get_tree().physics_interpolation = toggled_on

--- a/2d/physics_tests/utils/physics_interpolation.gd.uid
+++ b/2d/physics_tests/utils/physics_interpolation.gd.uid
@@ -1,1 +1,0 @@
-uid://c805rm8ds7mo3

--- a/2d/physics_tests/utils/system.gd
+++ b/2d/physics_tests/utils/system.gd
@@ -5,7 +5,9 @@ enum PhysicsEngine {
 	OTHER,
 }
 
-var _engine: PhysicsEngine = PhysicsEngine.OTHER
+var _engine : PhysicsEngine = PhysicsEngine.OTHER
+var _step_once : bool = false
+
 
 func _enter_tree() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
@@ -14,7 +16,7 @@ func _enter_tree() -> void:
 	# (same as the Debug > Visible Collision Shapes option).
 	get_tree().debug_collisions_hint = true
 
-	var engine_string:= String(ProjectSettings.get_setting("physics/2d/physics_engine"))
+	var engine_string := String(ProjectSettings.get_setting("physics/2d/physics_engine"))
 	match engine_string:
 		"DEFAULT":
 			_engine = PhysicsEngine.GODOT_PHYSICS
@@ -44,6 +46,28 @@ func _process(_delta: float) -> void:
 
 	if Input.is_action_just_pressed(&"exit"):
 		get_tree().quit()
+
+
+func _physics_process(_delta: float) -> void:
+	# Step pause after NOTIFICATION_INTERNAL_PHYSICS_PROCESS
+	# and before engine physics step.
+	if Input.is_action_just_pressed(&"step_once"):
+		if get_tree().paused:
+			_unpause.call_deferred()
+			_step_once = true
+		else:
+			_pause.call_deferred()
+	elif _step_once:
+		_pause.call_deferred()
+		_step_once = false
+
+
+func _pause() -> void:
+	get_tree().paused = true
+
+
+func _unpause() -> void:
+	get_tree().paused = false
 
 
 func get_physics_engine() -> PhysicsEngine:

--- a/2d/physics_tests/utils/ticks_per_second.gd
+++ b/2d/physics_tests/utils/ticks_per_second.gd
@@ -1,6 +1,0 @@
-extends HBoxContainer
-
-
-func _on_h_slider_value_changed(value: float) -> void:
-	$Value.text = str(roundi(value))
-	Engine.physics_ticks_per_second = roundi(value * Engine.time_scale)

--- a/2d/physics_tests/utils/ticks_per_second.gd.uid
+++ b/2d/physics_tests/utils/ticks_per_second.gd.uid
@@ -1,1 +1,0 @@
-uid://cg23ktlqpvfgx

--- a/2d/physics_tests/utils/time_scale.gd
+++ b/2d/physics_tests/utils/time_scale.gd
@@ -1,8 +1,0 @@
-extends HBoxContainer
-
-
-func _on_h_slider_value_changed(value: float) -> void:
-	value = maxf(0.1, value)
-	$Value.text = "%.1f×" % value
-	Engine.time_scale = value
-	Engine.physics_ticks_per_second = $"../TicksPerSecond/HSlider".value * value

--- a/2d/physics_tests/utils/time_scale.gd.uid
+++ b/2d/physics_tests/utils/time_scale.gd.uid
@@ -1,1 +1,0 @@
-uid://d12wj88dgcvd4


### PR DESCRIPTION
Add command line launch options for direct debugging 
2 new demos to aid in solver debugging and review. 'Rain on pin joints' and 'bodies in bucket'
Add ‘pause stepping’ by pressing ‘L’
Add Solver Iteration settings and bias controls
Small fixes and improvements
Lightly refactor UI and code as necessary

This work is all about what I need in order to run useful solver tests from a debugger while working on Godot solver code. I figure other 2D Physics contributors will also value the additions.

This will also give reviewers access to useful tests when reading future discussions and proposals such as this one:

[Change default physics bias to 0.2 (from 0.8) #119887](https://github.com/godotengine/godot/pull/119887)

