### PR TITLE
Squash the Creeps: Update Mob.gd, explicit floats

### DIFF
--- a/3d/squash_the_creeps/Mob.gd
+++ b/3d/squash_the_creeps/Mob.gd
@@ -4,9 +4,9 @@ extends CharacterBody3D
 signal squashed
 
 ## Minimum speed of the mob in meters per second.
-@export var min_speed = 10
+@export var min_speed = 10.0
 ## Maximum speed of the mob in meters per second.
-@export var max_speed = 18
+@export var max_speed = 18.0
 
 
 func _physics_process(_delta):


### PR DESCRIPTION
Explicitly use floats for min and max speed for clarity.

Documentation pr: https://github.com/godotengine/godot-docs/pull/12075