### PR TITLE
Improve 3d/physics_tests for debugging and review

### DIFF
--- a/3d/physics_tests/main.tscn
+++ b/3d/physics_tests/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene format=3 uid="uid://d324ky4w51nwn"]
+[gd_scene format=3 uid="uid://duuq3oa8yi6yi"]
 
 [ext_resource type="Script" uid="uid://d3h23soe03uxu" path="res://utils/label_fps.gd" id="1"]
 [ext_resource type="Script" uid="uid://bcr1liuxpc20g" path="res://utils/label_version.gd" id="2"]
@@ -6,19 +6,17 @@
 [ext_resource type="Script" uid="uid://d130d5qxmy0fv" path="res://tests_menu.gd" id="4"]
 [ext_resource type="Script" uid="uid://bdn4obw5gh82x" path="res://utils/label_test.gd" id="5"]
 [ext_resource type="Script" uid="uid://ccyujlle7bf5f" path="res://utils/label_pause.gd" id="6"]
-[ext_resource type="Script" uid="uid://k33h4xgp375h" path="res://utils/ticks_per_second.gd" id="8_dg77c"]
-[ext_resource type="Script" uid="uid://cxmg0vd1dtcd4" path="res://utils/time_scale.gd" id="9_ycdy4"]
+[ext_resource type="Script" uid="uid://bn4y1s3dxwyus" path="res://utils/label_frames.gd" id="7_w48qg"]
 [ext_resource type="Script" uid="uid://dxbsa1k3uwvg4" path="res://utils/container_log.gd" id="10"]
-[ext_resource type="Script" uid="uid://byodgvu5wtwwl" path="res://utils/max_steps_per_frame.gd" id="10_w48qg"]
 [ext_resource type="Script" uid="uid://7v2gavc8dbne" path="res://utils/scroll_log.gd" id="11"]
-[ext_resource type="Script" uid="uid://c1i4en86nil3i" path="res://utils/physics_interpolation.gd" id="11_ycdy4"]
 [ext_resource type="Script" uid="uid://df6hnvpqqeefg" path="res://tests.gd" id="12"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 bg_color = Color(0, 0, 0, 0.176471)
 
-[node name="Main" type="Control" unique_id=2146859428]
+[node name="Main" type="Control" unique_id=2128203463]
 process_mode = 3
+modulate = Color(1, 1, 1, 0.7058824)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -28,107 +26,96 @@ grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("12")
 
-[node name="TestsMenu" type="MenuButton" parent="." unique_id=1637126499]
+[node name="TestsMenu" type="MenuButton" parent="." unique_id=1051533574]
+unique_name_in_owner = true
 layout_mode = 0
 offset_left = 10.0
 offset_top = 10.0
 offset_right = 125.0
-offset_bottom = 30.0
+offset_bottom = 41.0
 text = "Tests"
 flat = false
 script = ExtResource("4")
 
-[node name="LabelControls" type="Label" parent="." unique_id=1638542395]
+[node name="LabelControls" type="Label" parent="." unique_id=1639582477]
 layout_mode = 0
 offset_left = 157.0
 offset_top = 13.0
-offset_right = 375.0
-offset_bottom = 27.0
+offset_right = 925.0
+offset_bottom = 36.0
 theme_override_constants/outline_size = 4
-text = "P: Toggle Pause  |  R: Restart  |  C: Toggle Collision  |  F: Toggle Fullscreen  |  ESC: Quit"
+text = "P: Toggle Pause  |  L: Step Once  |  R: Restart  |  C: Toggle Collision  |  F: Toggle Fullscreen  |  ESC: Quit"
 
-[node name="LabelFPS" type="Label" parent="." unique_id=906320866]
+[node name="StatsContainer" type="MarginContainer" parent="." unique_id=1189787900]
 layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -36.0
-offset_right = 55.0
-offset_bottom = -13.0
-grow_vertical = 0
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 4
-text = "FPS: 0"
-script = ExtResource("1")
-
-[node name="LabelEngine" type="Label" parent="." unique_id=2068376356]
-self_modulate = Color(1, 1, 1, 0.752941)
-layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -64.0
+offset_top = -141.0
 offset_right = 128.0
-offset_bottom = -41.0
 grow_vertical = 0
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 4
-text = "Physics engine:"
-script = ExtResource("3")
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_bottom = 10
 
-[node name="LabelVersion" type="Label" parent="." unique_id=1274666020]
-self_modulate = Color(1, 1, 1, 0.752941)
-layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -92.0
-offset_right = 125.0
-offset_bottom = -69.0
-grow_vertical = 0
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 4
-text = "Godot version:"
-script = ExtResource("2")
+[node name="Stats" type="VBoxContainer" parent="StatsContainer" unique_id=441593164]
+layout_mode = 2
 
-[node name="LabelTest" type="Label" parent="." unique_id=545916486]
-layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = -120.0
-offset_right = 50.0
-offset_bottom = -97.0
-grow_vertical = 0
+[node name="LabelTest" type="Label" parent="StatsContainer/Stats" unique_id=789147083]
+unique_name_in_owner = true
+layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "Test:"
 script = ExtResource("5")
 
-[node name="LabelPause" type="Label" parent="." unique_id=657441717]
+[node name="LabelVersion" type="Label" parent="StatsContainer/Stats" unique_id=1425389712]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 0.752941)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "Godot version:"
+script = ExtResource("2")
+
+[node name="LabelEngine" type="Label" parent="StatsContainer/Stats" unique_id=285515091]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 0.752941)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "Physics engine:"
+script = ExtResource("3")
+
+[node name="LabelFPS" type="Label" parent="StatsContainer/Stats" unique_id=1221424336]
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "FPS: 0"
+script = ExtResource("1")
+
+[node name="LabelFrames" type="Label" parent="StatsContainer/Stats" unique_id=1888219416]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "Frame:"
+script = ExtResource("7_w48qg")
+
+[node name="LabelPause" type="Label" parent="." unique_id=238168997]
+modulate = Color(1, 1, 0, 1)
 layout_mode = 1
-anchors_preset = 7
+anchors_preset = 5
 anchor_left = 0.5
-anchor_top = 1.0
 anchor_right = 0.5
-anchor_bottom = 1.0
-offset_left = -46.5
-offset_top = -584.0
-offset_right = 46.5
-offset_bottom = -547.0
+offset_left = -62.0
+offset_top = 48.0
+offset_right = 62.0
+offset_bottom = 96.0
 grow_horizontal = 2
-grow_vertical = 0
-theme_override_colors/font_color = Color(1, 1, 0, 1)
 theme_override_constants/outline_size = 6
 theme_override_font_sizes/font_size = 24
 text = "Paused"
 script = ExtResource("6")
 
-[node name="Options" type="VBoxContainer" parent="." unique_id=1579599961]
+[node name="Options" type="VBoxContainer" parent="." unique_id=1461871449]
 layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
@@ -136,26 +123,27 @@ anchor_right = 1.0
 offset_left = -392.0
 offset_top = 56.0
 offset_right = -16.0
-offset_bottom = 174.0
+offset_bottom = 261.0
 grow_horizontal = 0
 theme_override_constants/separation = 6
 
-[node name="TicksPerSecond" type="HBoxContainer" parent="Options" unique_id=807732362]
+[node name="TicksPerSecond" type="HBoxContainer" parent="Options" unique_id=538503540]
+layout_direction = 2
 layout_mode = 2
 tooltip_text = "Higher values make physics more precise at the cost of higher CPU utilization.
 Low values may result in objects phasing through each other (tunneling).
 Physics ticks per second are automatically multiplied by Time Scale in this project."
 theme_override_constants/separation = 10
-script = ExtResource("8_dg77c")
 
-[node name="Label" type="Label" parent="Options/TicksPerSecond" unique_id=381980434]
+[node name="Label" type="Label" parent="Options/TicksPerSecond" unique_id=1576971871]
 custom_minimum_size = Vector2(164, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "Ticks per Second"
 
-[node name="HSlider" type="HSlider" parent="Options/TicksPerSecond" unique_id=1230244940]
+[node name="TicksPerSecond" type="HSlider" parent="Options/TicksPerSecond" unique_id=247607595]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 size_flags_vertical = 4
@@ -164,57 +152,59 @@ max_value = 240.0
 step = 10.0
 value = 60.0
 
-[node name="Value" type="Label" parent="Options/TicksPerSecond" unique_id=685403757]
+[node name="TicksPerSecondValue" type="Label" parent="Options/TicksPerSecond" unique_id=549785606]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "60"
 
-[node name="TimeScale" type="HBoxContainer" parent="Options" unique_id=1787277092]
+[node name="TimeScale" type="HBoxContainer" parent="Options" unique_id=5056712]
 layout_mode = 2
 tooltip_text = "Game speed multiplier. Physics ticks per second are
 automatically multiplied by Time Scale in this project
 to ensure accurate simulation regardless of time scale."
 theme_override_constants/separation = 10
-script = ExtResource("9_ycdy4")
 
-[node name="Label" type="Label" parent="Options/TimeScale" unique_id=288511176]
+[node name="Label" type="Label" parent="Options/TimeScale" unique_id=151694134]
 custom_minimum_size = Vector2(164, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "Time Scale"
 
-[node name="HSlider" type="HSlider" parent="Options/TimeScale" unique_id=472756756]
+[node name="TimeScale" type="HSlider" parent="Options/TimeScale" unique_id=8530608]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 size_flags_vertical = 4
 max_value = 5.0
 step = 0.5
-value = 0.5
+value = 1.0
 
-[node name="Value" type="Label" parent="Options/TimeScale" unique_id=16867900]
+[node name="TimeScaleValue" type="Label" parent="Options/TimeScale" unique_id=1344187457]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "1.0×"
 
-[node name="MaxStepsPerFrame" type="HBoxContainer" parent="Options" unique_id=492098091]
+[node name="MaxStepsPerFrame" type="HBoxContainer" parent="Options" unique_id=1684706066]
 layout_mode = 2
 tooltip_text = "Physics will slow down if more physics steps
 than this value need to be simulated in a
 single rendered frame."
 theme_override_constants/separation = 10
-script = ExtResource("10_w48qg")
 
-[node name="Label" type="Label" parent="Options/MaxStepsPerFrame" unique_id=929284481]
+[node name="Label" type="Label" parent="Options/MaxStepsPerFrame" unique_id=856708187]
 custom_minimum_size = Vector2(164, 0)
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "Max Steps per Frame"
 
-[node name="HSlider" type="HSlider" parent="Options/MaxStepsPerFrame" unique_id=1174090254]
+[node name="MaxStepsPerFrame" type="HSlider" parent="Options/MaxStepsPerFrame" unique_id=1839821832]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 size_flags_vertical = 4
@@ -222,13 +212,72 @@ min_value = 1.0
 max_value = 20.0
 value = 8.0
 
-[node name="Value" type="Label" parent="Options/MaxStepsPerFrame" unique_id=793696671]
+[node name="MaxStepsPerFrameValue" type="Label" parent="Options/MaxStepsPerFrame" unique_id=233340329]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
 text = "8"
 
-[node name="PhysicsInterpolation" type="CheckButton" parent="Options" unique_id=2024524758]
+[node name="SolverIterations" type="HBoxContainer" parent="Options" unique_id=1380786056]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Label" type="Label" parent="Options/SolverIterations" unique_id=1066078852]
+custom_minimum_size = Vector2(164, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "Solver Iterations"
+
+[node name="SolverIterations" type="HSlider" parent="Options/SolverIterations" unique_id=279084094]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(160, 0)
+layout_mode = 2
+size_flags_vertical = 4
+min_value = 1.0
+max_value = 200.0
+value = 16.0
+
+[node name="SolverIterationsValue" type="Label" parent="Options/SolverIterations" unique_id=591474766]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "16"
+
+[node name="ContactBias" type="HBoxContainer" parent="Options" unique_id=1405354295]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Label" type="Label" parent="Options/ContactBias" unique_id=81432287]
+custom_minimum_size = Vector2(164, 0)
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "Contact Bias"
+
+[node name="ContactBias" type="HSlider" parent="Options/ContactBias" unique_id=726514010]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(160, 0)
+layout_mode = 2
+size_flags_vertical = 4
+max_value = 1.0
+step = 0.05
+value = 0.8
+
+[node name="ContactBiasValue" type="Label" parent="Options/ContactBias" unique_id=278195393]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+text = "0.80"
+
+[node name="PhysicsInterpolation2" type="HBoxContainer" parent="Options" unique_id=1044808489]
+layout_mode = 2
+
+[node name="PhysicsInterpolation" type="CheckButton" parent="Options/PhysicsInterpolation2" unique_id=594845751]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(217, 0)
 layout_mode = 2
 size_flags_horizontal = 0
@@ -237,30 +286,29 @@ This is a purely visual effect and has no impact on the physics simulation."
 theme_override_constants/outline_size = 4
 button_pressed = true
 text = "Physics Interpolation"
-script = ExtResource("11_ycdy4")
 
-[node name="PanelLog" type="Panel" parent="." unique_id=1467170025]
+[node name="PanelLog" type="Panel" parent="." unique_id=859449411]
 layout_mode = 1
 anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -629.0
-offset_top = -252.0
+offset_left = -630.0
+offset_top = -251.0
 grow_horizontal = 0
 grow_vertical = 0
 mouse_filter = 1
 theme_override_styles/panel = SubResource("1")
 
-[node name="ButtonClear" type="Button" parent="PanelLog" unique_id=527977230]
+[node name="ButtonClear" type="Button" parent="PanelLog" unique_id=1294766683]
 layout_mode = 1
 anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -64.0
+offset_left = -65.0
 offset_top = -36.0
 offset_right = -5.0
 offset_bottom = -5.0
@@ -269,7 +317,7 @@ grow_vertical = 0
 focus_mode = 0
 text = "Clear"
 
-[node name="CheckBoxScroll" type="CheckButton" parent="PanelLog" unique_id=1225796363]
+[node name="CheckBoxScroll" type="CheckButton" parent="PanelLog" unique_id=377719472]
 layout_mode = 1
 anchors_preset = 3
 anchor_left = 1.0
@@ -286,30 +334,32 @@ focus_mode = 0
 button_pressed = true
 text = "Automatic Scrolling"
 
-[node name="ScrollLog" type="ScrollContainer" parent="PanelLog" unique_id=24950604]
+[node name="ScrollLog" type="ScrollContainer" parent="PanelLog" unique_id=2110387942]
 layout_mode = 0
 offset_left = 10.0
 offset_top = 5.0
-offset_right = 616.0
-offset_bottom = 194.0
+offset_right = 619.0
+offset_bottom = 210.0
 script = ExtResource("11")
 auto_scroll = true
 
-[node name="VBoxLog" type="VBoxContainer" parent="PanelLog/ScrollLog" unique_id=1533802738]
+[node name="VBoxLog" type="VBoxContainer" parent="PanelLog/ScrollLog" unique_id=1138962883]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 alignment = 2
 script = ExtResource("10")
 
-[node name="LabelLog" type="Label" parent="PanelLog/ScrollLog/VBoxLog" unique_id=2015363105]
+[node name="LabelLog" type="Label" parent="PanelLog/ScrollLog/VBoxLog" unique_id=1624492529]
 layout_mode = 2
 text = "Log start"
 max_lines_visible = 5
 
-[connection signal="value_changed" from="Options/TicksPerSecond/HSlider" to="Options/TicksPerSecond" method="_on_h_slider_value_changed"]
-[connection signal="value_changed" from="Options/TimeScale/HSlider" to="Options/TimeScale" method="_on_h_slider_value_changed"]
-[connection signal="value_changed" from="Options/MaxStepsPerFrame/HSlider" to="Options/MaxStepsPerFrame" method="_on_h_slider_value_changed"]
-[connection signal="toggled" from="Options/PhysicsInterpolation" to="Options/PhysicsInterpolation" method="_on_check_button_toggled"]
+[connection signal="value_changed" from="Options/TicksPerSecond/TicksPerSecond" to="." method="_on_ticks_per_second_value_changed"]
+[connection signal="value_changed" from="Options/TimeScale/TimeScale" to="." method="_on_time_scale_value_changed"]
+[connection signal="value_changed" from="Options/MaxStepsPerFrame/MaxStepsPerFrame" to="." method="_on_max_steps_per_frame_value_changed"]
+[connection signal="value_changed" from="Options/SolverIterations/SolverIterations" to="." method="_on_solver_iterations_value_changed"]
+[connection signal="value_changed" from="Options/ContactBias/ContactBias" to="." method="_on_contact_bias_value_changed"]
+[connection signal="toggled" from="Options/PhysicsInterpolation2/PhysicsInterpolation" to="." method="_on_physics_interpolation_toggled"]
 [connection signal="pressed" from="PanelLog/ButtonClear" to="PanelLog/ScrollLog/VBoxLog" method="clear"]
 [connection signal="toggled" from="PanelLog/CheckBoxScroll" to="PanelLog/ScrollLog" method="_on_check_box_scroll_toggled"]

--- a/3d/physics_tests/project.godot
+++ b/3d/physics_tests/project.godot
@@ -100,7 +100,8 @@ step_once={
 
 [physics]
 
-jolt_physics_3d/limits/temporary_memory_buffer_size=256
+3d/physics_engine="Jolt Physics"
+jolt_physics_3d/limits/temporary_memory_buffer_size=448
 jolt_physics_3d/limits/max_bodies=262144
 jolt_physics_3d/limits/max_body_pairs=262144
 jolt_physics_3d/limits/max_contact_constraints=524288

--- a/3d/physics_tests/project.godot
+++ b/3d/physics_tests/project.godot
@@ -92,10 +92,14 @@ character_jump={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 ]
 }
+step_once={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":76,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [physics]
 
-3d/physics_engine="Jolt Physics"
 jolt_physics_3d/limits/temporary_memory_buffer_size=256
 jolt_physics_3d/limits/max_bodies=262144
 jolt_physics_3d/limits/max_body_pairs=262144

--- a/3d/physics_tests/tests.gd
+++ b/3d/physics_tests/tests.gd
@@ -1,6 +1,6 @@
 extends Node
 
-var _tests : Array[Dictionary] = [
+var _tests: Array[Dictionary] = [
 	{
 		"id": "Functional Tests/Shapes",
 		"path": "res://tests/functional/test_shapes.tscn",

--- a/3d/physics_tests/tests.gd
+++ b/3d/physics_tests/tests.gd
@@ -79,36 +79,36 @@ func _ready() -> void:
 		else:
 			arguments[arg.trim_prefix("--")] = ""
 
-	if arguments.has("ticks_per_second"):
-		Engine.physics_ticks_per_second = int(arguments["ticks_per_second"])
+	if arguments.has("ticks-per-second"):
+		Engine.physics_ticks_per_second = int(arguments["ticks-per-second"])
 		%TicksPerSecond.value = Engine.physics_ticks_per_second
 
-	if arguments.has("time_scale"):
-		Engine.time_scale = float(arguments["time_scale"])
+	if arguments.has("time-scale"):
+		Engine.time_scale = float(arguments["time-scale"])
 		%TimeScale.value = Engine.time_scale
 
-	if arguments.has("max_steps_per_frame"):
-		Engine.max_physics_steps_per_frame = int(arguments["max_steps_per_frame"])
+	if arguments.has("max-steps-per-frame"):
+		Engine.max_physics_steps_per_frame = int(arguments["max-steps-per-frame"])
 		%MaxStepsPerFrame.value = Engine.max_physics_steps_per_frame
 
-	if arguments.has("solver_iterations"):
-		%SolverIterations.value = int(arguments["solver_iterations"])
-		PhysicsServer3D.space_set_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_SOLVER_ITERATIONS, int(arguments["solver_iterations"]))
+	if arguments.has("solver-iterations"):
+		%SolverIterations.value = int(arguments["solver-iterations"])
+		PhysicsServer3D.space_set_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_SOLVER_ITERATIONS, int(arguments["solver-iterations"]))
 
-	if arguments.has("contact_bias"):
-		%ContactBias.value = float(arguments["contact_bias"])
-		PhysicsServer3D.space_set_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_CONTACT_DEFAULT_BIAS, float(arguments["contact_bias"]))
+	if arguments.has("contact-bias"):
+		%ContactBias.value = float(arguments["contact-bias"])
+		PhysicsServer3D.space_set_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_CONTACT_DEFAULT_BIAS, float(arguments["contact-bias"]))
 
-	if arguments.has("physics_interpolation"):
-		var arg: String = arguments["physics_interpolation"].to_lower()
+	if arguments.has("physics-interpolation"):
+		var arg: String = arguments["physics-interpolation"].to_lower()
 		get_tree().physics_interpolation = arg == "true" or arg == "on"
 		%PhysicsInterpolation.button_pressed = get_tree().physics_interpolation
 
 	if arguments.has("fullscreen"):
 		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
 
-	if arguments.has("test_scene"):
-		test_menu.start_test_from_scene.call_deferred(arguments["test_scene"])
+	if arguments.has("test-scene"):
+		test_menu.start_test_from_scene.call_deferred(arguments["test-scene"])
 
 
 func _on_ticks_per_second_value_changed(value: float) -> void:

--- a/3d/physics_tests/tests.gd
+++ b/3d/physics_tests/tests.gd
@@ -104,9 +104,6 @@ func _ready() -> void:
 		get_tree().physics_interpolation = arg == "true" or arg == "on"
 		%PhysicsInterpolation.button_pressed = get_tree().physics_interpolation
 
-	if arguments.has("fullscreen"):
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
-
 	if arguments.has("test-scene"):
 		test_menu.start_test_from_scene.call_deferred(arguments["test-scene"])
 

--- a/3d/physics_tests/tests.gd
+++ b/3d/physics_tests/tests.gd
@@ -1,6 +1,6 @@
 extends Node
 
-var _tests: Array[Dictionary] = [
+var _tests : Array[Dictionary] = [
 	{
 		"id": "Functional Tests/Shapes",
 		"path": "res://tests/functional/test_shapes.tscn",
@@ -61,6 +61,92 @@ var _tests: Array[Dictionary] = [
 
 
 func _ready() -> void:
-	var test_menu: OptionMenu = $TestsMenu
-	for test in _tests:
+	# UI should stay active during pause.
+	# The rest of the UI will inherit this, except
+	# for frame counter which only counts unpaused frames.
+	process_mode = PROCESS_MODE_ALWAYS
+	_get_default_options()
+
+	var test_menu: OptionMenu = %TestsMenu
+	for test: Dictionary in _tests:
 		test_menu.add_test(test.id, test.path)
+
+	var arguments := {}
+	for arg in OS.get_cmdline_user_args():
+		if arg.contains("="):
+			var key_value := arg.split("=")
+			arguments[key_value[0].trim_prefix("--")] = key_value[1]
+		else:
+			arguments[arg.trim_prefix("--")] = ""
+
+	if arguments.has("ticks_per_second"):
+		Engine.physics_ticks_per_second = int(arguments["ticks_per_second"])
+		%TicksPerSecond.value = Engine.physics_ticks_per_second
+
+	if arguments.has("time_scale"):
+		Engine.time_scale = float(arguments["time_scale"])
+		%TimeScale.value = Engine.time_scale
+
+	if arguments.has("max_steps_per_frame"):
+		Engine.max_physics_steps_per_frame = int(arguments["max_steps_per_frame"])
+		%MaxStepsPerFrame.value = Engine.max_physics_steps_per_frame
+
+	if arguments.has("solver_iterations"):
+		%SolverIterations.value = int(arguments["solver_iterations"])
+		PhysicsServer3D.space_set_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_SOLVER_ITERATIONS, int(arguments["solver_iterations"]))
+
+	if arguments.has("contact_bias"):
+		%ContactBias.value = float(arguments["contact_bias"])
+		PhysicsServer3D.space_set_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_CONTACT_DEFAULT_BIAS, float(arguments["contact_bias"]))
+
+	if arguments.has("physics_interpolation"):
+		var arg: String = arguments["physics_interpolation"].to_lower()
+		get_tree().physics_interpolation = arg == "true" or arg == "on"
+		%PhysicsInterpolation.button_pressed = get_tree().physics_interpolation
+
+	if arguments.has("fullscreen"):
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+
+	if arguments.has("test_scene"):
+		test_menu.start_test_from_scene.call_deferred(arguments["test_scene"])
+
+
+func _on_ticks_per_second_value_changed(value: float) -> void:
+	%TicksPerSecondValue.text = str(roundi(value * Engine.time_scale))
+	Engine.physics_ticks_per_second = roundi(value)
+
+
+func _on_time_scale_value_changed(value: float) -> void:
+	value = maxf(0.1, value)
+	%TimeScaleValue.text = "%.1f×" % value
+	Engine.time_scale = value
+	Engine.physics_ticks_per_second = %TicksPerSecond.value * value
+	%TicksPerSecondValue.text = str(roundi(%TicksPerSecond.value * value))
+
+
+func _on_max_steps_per_frame_value_changed(value: float) -> void:
+	%MaxStepsPerFrameValue.text = str(roundi(value))
+	Engine.max_physics_steps_per_frame = roundi(value)
+
+
+func _on_solver_iterations_value_changed(value: float) -> void:
+	%SolverIterationsValue.text = str(roundi(value))
+	PhysicsServer3D.space_set_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_SOLVER_ITERATIONS, roundi(value))
+
+
+func _on_contact_bias_value_changed(value: float) -> void:
+	%ContactBiasValue.text = "%.2f" % value
+	PhysicsServer3D.space_set_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_CONTACT_DEFAULT_BIAS, value)
+
+
+func _on_physics_interpolation_toggled(toggled_on: bool) -> void:
+	get_tree().physics_interpolation = toggled_on
+
+
+func _get_default_options() -> void:
+	%PhysicsInterpolation.button_pressed = get_tree().physics_interpolation
+	%ContactBias.value = PhysicsServer3D.space_get_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_CONTACT_DEFAULT_BIAS)
+	%SolverIterations.value = PhysicsServer3D.space_get_param(get_viewport().find_world_3d().space, PhysicsServer3D.SPACE_PARAM_SOLVER_ITERATIONS)
+	%MaxStepsPerFrame.value = Engine.max_physics_steps_per_frame
+	%TicksPerSecond.value = Engine.physics_ticks_per_second
+	%TimeScale.value = Engine.time_scale

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
@@ -77,6 +77,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5.2912, 0)
 
 [node name="RigidBodyBox" type="RigidBody3D" parent="DynamicShapes/Bodies" unique_id=1379548269]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, 0)
+collision_mask = 3
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -90,6 +91,7 @@ debug_color = Color(1, 1, 0, 1)
 
 [node name="RigidBodyCapsule" type="RigidBody3D" parent="DynamicShapes/Bodies" unique_id=1915206978]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 0, 0)
+collision_mask = 3
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -102,6 +104,7 @@ shape = SubResource("6")
 debug_color = Color(1, 1, 0, 1)
 
 [node name="RigidBodyCylinder" type="RigidBody3D" parent="DynamicShapes/Bodies" unique_id=2005440834]
+collision_mask = 3
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -115,6 +118,7 @@ debug_color = Color(1, 1, 0, 1)
 
 [node name="RigidBodyConvex" type="RigidBody3D" parent="DynamicShapes/Bodies" unique_id=1822778113]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0.974548, 0)
+collision_mask = 3
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -128,6 +132,7 @@ debug_color = Color(1, 1, 0, 1)
 
 [node name="RigidBodySphere" type="RigidBody3D" parent="DynamicShapes/Bodies" unique_id=1844358720]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 0, 0)
+collision_mask = 3
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
@@ -145,6 +150,7 @@ debug_color = Color(1, 1, 0, 1)
 
 [node name="ConvexFloor" type="StaticBody3D" parent="Floors/ConvexSmall" unique_id=1472007432]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10)
+collision_layer = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Floors/ConvexSmall/ConvexFloor" unique_id=1993181116]
 visible = false
@@ -156,6 +162,7 @@ debug_color = Color(0, 0.533333, 1, 1)
 
 [node name="ConvexFloor2" type="StaticBody3D" parent="Floors/ConvexSmall" unique_id=1800428810]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10)
+collision_layer = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Floors/ConvexSmall/ConvexFloor2" unique_id=799859905]
 visible = false
@@ -168,6 +175,7 @@ debug_color = Color(0, 0.533333, 1, 1)
 [node name="ConvexBig" type="Node3D" parent="Floors" unique_id=1418615986]
 
 [node name="ConvexFloor" type="StaticBody3D" parent="Floors/ConvexBig" unique_id=487508714]
+collision_layer = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Floors/ConvexBig/ConvexFloor" unique_id=2097525306]
 visible = false
@@ -181,6 +189,7 @@ debug_color = Color(0, 0.533333, 1, 1)
 
 [node name="ConcaveFloor" type="StaticBody3D" parent="Floors/ConcaveSmall" unique_id=1813381175]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10)
+collision_layer = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Floors/ConcaveSmall/ConcaveFloor" unique_id=796318569]
 visible = false
@@ -193,6 +202,7 @@ debug_color = Color(0, 0.533333, 1, 1)
 
 [node name="ConcaveFloor2" type="StaticBody3D" parent="Floors/ConcaveSmall" unique_id=1839323998]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10)
+collision_layer = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Floors/ConcaveSmall/ConcaveFloor2" unique_id=787588586]
 visible = false
@@ -206,6 +216,7 @@ debug_color = Color(0, 0.533333, 1, 1)
 [node name="ConcaveBig" type="Node3D" parent="Floors" unique_id=770187749]
 
 [node name="ConcaveFloor" type="StaticBody3D" parent="Floors/ConcaveBig" unique_id=871381413]
+collision_layer = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Floors/ConcaveBig/ConcaveFloor" unique_id=1988206681]
 visible = false
@@ -219,6 +230,7 @@ debug_color = Color(0, 0.533333, 1, 1)
 
 [node name="BoxFloor" type="StaticBody3D" parent="Floors/BoxSmall" unique_id=1392977531]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10)
+collision_layer = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Floors/BoxSmall/BoxFloor" unique_id=1734126461]
 visible = false
@@ -231,6 +243,7 @@ debug_color = Color(0, 0.533333, 1, 1)
 
 [node name="BoxFloor2" type="StaticBody3D" parent="Floors/BoxSmall" unique_id=1013912033]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 10)
+collision_layer = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Floors/BoxSmall/BoxFloor2" unique_id=711924352]
 visible = false
@@ -244,6 +257,7 @@ debug_color = Color(0, 0.533333, 1, 1)
 [node name="BoxBig" type="Node3D" parent="Floors" unique_id=183483992]
 
 [node name="BoxFloor" type="StaticBody3D" parent="Floors/BoxBig" unique_id=599962589]
+collision_layer = 2
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Floors/BoxBig/BoxFloor" unique_id=243665825]
 visible = false

--- a/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
+++ b/3d/physics_tests/tests/functional/test_rigidbody_ground_check.tscn
@@ -85,7 +85,6 @@ physics_material_override = SubResource("1")
 script = ExtResource("1")
 
 [node name="CollisionShape" type="CollisionShape3D" parent="DynamicShapes/Bodies/RigidBodyBox" unique_id=1382951647]
-transform = Transform3D(0.6, 0, 0, 0, 1, 0, 0, 0, 0.6, 0, 0, 0)
 shape = SubResource("2")
 debug_color = Color(1, 1, 0, 1)
 
@@ -112,7 +111,6 @@ physics_material_override = SubResource("9")
 script = ExtResource("1")
 
 [node name="CollisionShape" type="CollisionShape3D" parent="DynamicShapes/Bodies/RigidBodyCylinder" unique_id=1182016753]
-transform = Transform3D(0.8, 0, 0, 0, 1, 0, 0, 0, 0.8, 0, 0, 0)
 shape = SubResource("10")
 debug_color = Color(1, 1, 0, 1)
 
@@ -126,7 +124,6 @@ physics_material_override = SubResource("13")
 script = ExtResource("1")
 
 [node name="CollisionShape" type="CollisionShape3D" parent="DynamicShapes/Bodies/RigidBodyConvex" unique_id=164744696]
-transform = Transform3D(1.5, 0, 0, 0, 2, 0, 0, 0, 1.5, 0, 0, 0)
 shape = SubResource("14")
 debug_color = Color(1, 1, 0, 1)
 
@@ -196,7 +193,7 @@ visible = false
 mesh = SubResource("23")
 
 [node name="CollisionShape" type="CollisionShape3D" parent="Floors/ConcaveSmall/ConcaveFloor" unique_id=794867424]
-transform = Transform3D(25, 0, 0, 0, 1, 0, 0, 0, 10, 0, 0, 0)
+transform = Transform3D(10, 0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0)
 shape = SubResource("27")
 debug_color = Color(0, 0.533333, 1, 1)
 
@@ -209,7 +206,7 @@ visible = false
 mesh = SubResource("23")
 
 [node name="CollisionShape" type="CollisionShape3D" parent="Floors/ConcaveSmall/ConcaveFloor2" unique_id=2146831954]
-transform = Transform3D(25, 0, 0, 0, 1, 0, 0, 0, 10, 0, 0, 0)
+transform = Transform3D(10, 0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0)
 shape = SubResource("27")
 debug_color = Color(0, 0.533333, 1, 1)
 

--- a/3d/physics_tests/tests_menu.gd
+++ b/3d/physics_tests/tests_menu.gd
@@ -1,14 +1,14 @@
 extends OptionMenu
 
 class TestData:
-	var id : String = ""
-	var scene_path : String = ""
+	var id: String = ""
+	var scene_path: String = ""
 
 
 var _test_list := []
 
-var _current_test : TestData = null
-var _current_test_scene : Node = null
+var _current_test: TestData = null
+var _current_test_scene: Node = null
 
 
 func _ready() -> void:
@@ -32,13 +32,13 @@ func add_test(id: String, scene_path: String) -> void:
 
 
 func start_test_from_scene(scene_path: String) -> void:
-	for test : TestData in _test_list:
+	for test: TestData in _test_list:
 		if test.scene_path == scene_path:
 			_start_test(test)
 
 
 func _on_option_selected(item_path: String) -> void:
-	for test : TestData in _test_list:
+	for test: TestData in _test_list:
 		if test.id == item_path:
 			_start_test(test)
 
@@ -56,5 +56,5 @@ func _start_test(test: TestData) -> void:
 	get_tree().root.add_child(_current_test_scene)
 	get_tree().root.move_child(_current_test_scene, 0)
 
-	var label_test : Label = %LabelTest
+	var label_test: Label = %LabelTest
 	label_test.test_name = test.id

--- a/3d/physics_tests/tests_menu.gd
+++ b/3d/physics_tests/tests_menu.gd
@@ -1,15 +1,14 @@
 extends OptionMenu
 
-
 class TestData:
-	var id: String = ""
-	var scene_path: String = ""
+	var id : String = ""
+	var scene_path : String = ""
 
 
-var _test_list: Array[TestData] = []
+var _test_list := []
 
-var _current_test: TestData = null
-var _current_test_scene: Node = null
+var _current_test : TestData = null
+var _current_test_scene : Node = null
 
 
 func _ready() -> void:
@@ -18,6 +17,7 @@ func _ready() -> void:
 
 func _process(_delta: float) -> void:
 	if Input.is_action_just_pressed(&"restart_test"):
+		%LabelFrames.reset()
 		if _current_test:
 			_start_test(_current_test)
 
@@ -31,8 +31,14 @@ func add_test(id: String, scene_path: String) -> void:
 	add_menu_item(id)
 
 
+func start_test_from_scene(scene_path: String) -> void:
+	for test : TestData in _test_list:
+		if test.scene_path == scene_path:
+			_start_test(test)
+
+
 func _on_option_selected(item_path: String) -> void:
-	for test in _test_list:
+	for test : TestData in _test_list:
 		if test.id == item_path:
 			_start_test(test)
 
@@ -48,6 +54,7 @@ func _start_test(test: TestData) -> void:
 	var scene := load(test.scene_path)
 	_current_test_scene = scene.instantiate()
 	get_tree().root.add_child(_current_test_scene)
+	get_tree().root.move_child(_current_test_scene, 0)
 
-	var label_test: Label = $"../LabelTest"
+	var label_test : Label = %LabelTest
 	label_test.test_name = test.id

--- a/3d/physics_tests/utils/label_frames.gd
+++ b/3d/physics_tests/utils/label_frames.gd
@@ -1,0 +1,20 @@
+extends Label
+
+var _unpaused_frame_count : int = 0
+
+
+func reset() -> void:
+	_unpaused_frame_count = 0
+	text = "%d Frames" % [_unpaused_frame_count]
+
+
+func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_PAUSABLE
+
+
+func _process(_delta: float) -> void:
+	text = "%d Frames" % [_unpaused_frame_count]
+
+
+func _physics_process(_delta: float) -> void:
+	_unpaused_frame_count += 1

--- a/3d/physics_tests/utils/label_frames.gd
+++ b/3d/physics_tests/utils/label_frames.gd
@@ -1,6 +1,6 @@
 extends Label
 
-var _unpaused_frame_count : int = 0
+var _unpaused_frame_count: int = 0
 
 
 func reset() -> void:

--- a/3d/physics_tests/utils/label_frames.gd.uid
+++ b/3d/physics_tests/utils/label_frames.gd.uid
@@ -1,0 +1,1 @@
+uid://bn4y1s3dxwyus

--- a/3d/physics_tests/utils/rigidbody_ground_check.gd
+++ b/3d/physics_tests/utils/rigidbody_ground_check.gd
@@ -9,20 +9,17 @@ var _is_on_floor: bool = false
 
 @onready var _forward := -transform.basis.z
 @onready var _collision_shape := $CollisionShape
-@onready var _material: StandardMaterial3D = $CollisionShape/MeshInstance3D.get_active_material(0)
 
 
 func _ready() -> void:
-	if not _material:
-		_material = StandardMaterial3D.new()
-		$CollisionShape/MeshInstance3D.set_surface_override_material(0, _material)
+	$CollisionShape.debug_color = Color.RED
 
 
 func _process(_delta: float) -> void:
 	if _is_on_floor:
-		_material.albedo_color = Color.WHITE
+		$CollisionShape.debug_color = Color.WHITE
 	else:
-		_material.albedo_color = Color.RED
+		$CollisionShape.debug_color = Color.RED
 
 
 func _integrate_forces(state: PhysicsDirectBodyState3D) -> void:

--- a/3d/physics_tests/utils/rigidbody_ground_check.gd
+++ b/3d/physics_tests/utils/rigidbody_ground_check.gd
@@ -32,13 +32,14 @@ func _integrate_forces(state: PhysicsDirectBodyState3D) -> void:
 	if state.transform.origin.z > _distance:
 		_dir = 1.0
 
-	ground_check()
+	ground_check(delta)
 
 
-func ground_check() -> void:
+func ground_check(delta: float) -> void:
 	var space_state: PhysicsDirectSpaceState3D = get_world_3d().direct_space_state
 	var shape := PhysicsShapeQueryParameters3D.new()
 	shape.transform = _collision_shape.global_transform
+	shape.transform.origin += get_gravity() * delta
 	shape.shape_rid = _collision_shape.shape.get_rid()
 	shape.collision_mask = 2
 	var result := space_state.get_rest_info(shape)

--- a/3d/physics_tests/utils/system.gd
+++ b/3d/physics_tests/utils/system.gd
@@ -8,7 +8,7 @@ enum PhysicsEngine {
 }
 
 var _engine := PhysicsEngine.OTHER
-var _step_once : bool = false
+var _step_once: bool = false
 
 func _enter_tree() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS

--- a/3d/physics_tests/utils/system.gd
+++ b/3d/physics_tests/utils/system.gd
@@ -8,7 +8,7 @@ enum PhysicsEngine {
 }
 
 var _engine := PhysicsEngine.OTHER
-
+var _step_once : bool = false
 
 func _enter_tree() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
@@ -17,7 +17,7 @@ func _enter_tree() -> void:
 	# (same as the Debug > Visible Collision Shapes option).
 	get_tree().debug_collisions_hint = true
 
-	var engine_string: String = ProjectSettings.get_setting("physics/3d/physics_engine")
+	var engine_string := String(ProjectSettings.get_setting("physics/3d/physics_engine"))
 	match engine_string:
 		"DEFAULT":
 			_engine = PhysicsEngine.GODOT_PHYSICS
@@ -49,6 +49,28 @@ func _process(_delta: float) -> void:
 
 	if Input.is_action_just_pressed(&"exit"):
 		get_tree().quit()
+
+
+func _physics_process(_delta: float) -> void:
+	# Step pause after NOTIFICATION_INTERNAL_PHYSICS_PROCESS
+	# and before engine physics step.
+	if Input.is_action_just_pressed(&"step_once"):
+		if get_tree().paused:
+			_unpause.call_deferred()
+			_step_once = true
+		else:
+			_pause.call_deferred()
+	elif _step_once:
+		_pause.call_deferred()
+		_step_once = false
+
+
+func _pause() -> void:
+	get_tree().paused = true
+
+
+func _unpause() -> void:
+	get_tree().paused = false
 
 
 func get_physics_engine() -> PhysicsEngine:


### PR DESCRIPTION
Refer to this similar PR to Improve  2d/physics_tests: [Improve 2d/physics_tests for debugging and review #1326](https://github.com/godotengine/godot-demo-projects/pull/1326)  
This PR copies those changes across to the 3d/physics_tests as verbatim as possible, to keep the functionality in sync.  
The changes are useful for running solver tests from a debugger while working on Godot Engine.

- Add command line launch options for direct debugging
- Add pause stepping by pressing `L`
- Add solver iteration settings and bias controls
- Small fixes and improvements
- Lightly refactor UI and code as necessary