### PR TITLE
Fix indentation in Tween demo that caused a script error

### DIFF
--- a/2d/tween/main.gd
+++ b/2d/tween/main.gd
@@ -74,7 +74,7 @@ func start_animation() -> void:
 				sub_tween = create_tween().set_speed_scale(%SpeedSlider.value).set_trans(Tween.TRANS_SINE)
 				sub_tween.tween_property(icon, ^"position:y", -150.0, 0.5).as_relative().set_ease(Tween.EASE_OUT)
 				sub_tween.tween_property(icon, ^"position:y", 150.0, 0.5).as_relative().set_ease(Tween.EASE_IN)
-			)
+		)
 
 	# Step 5
 


### PR DESCRIPTION
While this doesn't follow the GDScript style guide, this change allows the script to run correctly as of Godot 4.7.

The copy of the demo on the asset library already includes this fix.
