### PR TITLE
Fix the 2D part of the Matrix Transform demo

### DIFF
--- a/misc/matrix_transform/marker/AxisMarker2D.gd
+++ b/misc/matrix_transform/marker/AxisMarker2D.gd
@@ -8,6 +8,12 @@ func _process(_delta: float) -> void:
 	var line: Line2D = get_child(0).get_child(0)
 	var marker_parent: Node = get_parent()
 
-	line.points[1] = transform.origin
+	# Modify a copy of the points array and assign it to the Line2D's `points` property.
+	# Otherwise, we modify a copy of the property which ends up having no effect
+	# (see the `confusable_temporary_modification` GDScript warning).
+	var points: PackedVector2Array = line.points
+	points[1] = transform.origin
+	line.points = points
+
 	if marker_parent as Node2D != null:
 		line.transform = marker_parent.global_transform


### PR DESCRIPTION
The Line2D `points` property was being modified directly, which meant that a copy of the property was modified instead (since it's a PackedVector2Array). To modify it correctly in Godot 4.x, we need to make a copy of the property, modify it and assign the copy to the property's value instead.
